### PR TITLE
Remove Google Maven repo

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -49,7 +49,6 @@ maven_install(
     artifacts = MAVEN_ARTIFACTS,
     maven_install_json = "//:maven_install.json",
     repositories = [
-        "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
 )

--- a/maven_install.json
+++ b/maven_install.json
@@ -9,7 +9,6 @@
                 "directDependencies": [],
                 "file": "v1/https/repo1.maven.org/maven2/com/alibaba/fastjson/1.2.75/fastjson-1.2.75.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/com/alibaba/fastjson/1.2.75/fastjson-1.2.75.jar",
                     "https://repo1.maven.org/maven2/com/alibaba/fastjson/1.2.75/fastjson-1.2.75.jar"
                 ],
                 "sha256": "9ba58edc4473ee813eca9b8dd4a066378023b7b7e2e605823c07a16abfade189",
@@ -21,7 +20,6 @@
                 "directDependencies": [],
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.12.1/jackson-annotations-2.12.1.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/com/fasterxml/jackson/core/jackson-annotations/2.12.1/jackson-annotations-2.12.1.jar",
                     "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.12.1/jackson-annotations-2.12.1.jar"
                 ],
                 "sha256": "203cefdfa6c81e6aa84e11f292f29ca97344a3c3bc0293abea065cd837592873",
@@ -33,7 +31,6 @@
                 "directDependencies": [],
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.1/jackson-core-2.12.1.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/com/fasterxml/jackson/core/jackson-core/2.12.1/jackson-core-2.12.1.jar",
                     "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.12.1/jackson-core-2.12.1.jar"
                 ],
                 "sha256": "cc899cb6eae0c80b87d590eea86528797369cc4feb7b79463207d6bb18f0c257",
@@ -51,7 +48,6 @@
                 ],
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.1/jackson-databind-2.12.1.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/com/fasterxml/jackson/core/jackson-databind/2.12.1/jackson-databind-2.12.1.jar",
                     "https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.12.1/jackson-databind-2.12.1.jar"
                 ],
                 "sha256": "f2ca3c28ebded59c98447d51afe945323df961540af66a063c015597af936aa0",
@@ -70,7 +66,6 @@
                 ],
                 "file": "v1/https/repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.12.1/jackson-dataformat-cbor-2.12.1.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.12.1/jackson-dataformat-cbor-2.12.1.jar",
                     "https://repo1.maven.org/maven2/com/fasterxml/jackson/dataformat/jackson-dataformat-cbor/2.12.1/jackson-dataformat-cbor-2.12.1.jar"
                 ],
                 "sha256": "e76779aea9427ca73d7f407e5fa808a0405578ec056653a865c26e4c6f01d428",
@@ -82,7 +77,6 @@
                 "directDependencies": [],
                 "file": "v1/https/repo1.maven.org/maven2/com/google/code/gson/gson/2.8.6/gson-2.8.6.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/com/google/code/gson/gson/2.8.6/gson-2.8.6.jar",
                     "https://repo1.maven.org/maven2/com/google/code/gson/gson/2.8.6/gson-2.8.6.jar"
                 ],
                 "sha256": "c8fb4839054d280b3033f800d1f5a97de2f028eb8ba2eb458ad287e536f3f25f",
@@ -94,7 +88,6 @@
                 "directDependencies": [],
                 "file": "v1/https/repo1.maven.org/maven2/com/mikesamuel/json-sanitizer/1.2.1/json-sanitizer-1.2.1.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/com/mikesamuel/json-sanitizer/1.2.1/json-sanitizer-1.2.1.jar",
                     "https://repo1.maven.org/maven2/com/mikesamuel/json-sanitizer/1.2.1/json-sanitizer-1.2.1.jar"
                 ],
                 "sha256": "0f7d702ba2cdfebac1d4f1154d4b107f508d5920c268263087a5f4b80ddb7446",
@@ -110,7 +103,6 @@
                 ],
                 "file": "v1/https/repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/junit/junit/4.12/junit-4.12.jar",
                     "https://repo1.maven.org/maven2/junit/junit/4.12/junit-4.12.jar"
                 ],
                 "sha256": "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
@@ -122,7 +114,6 @@
                 "directDependencies": [],
                 "file": "v1/https/repo1.maven.org/maven2/org/apache/commons/commons-imaging/1.0-alpha2/commons-imaging-1.0-alpha2.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/org/apache/commons/commons-imaging/1.0-alpha2/commons-imaging-1.0-alpha2.jar",
                     "https://repo1.maven.org/maven2/org/apache/commons/commons-imaging/1.0-alpha2/commons-imaging-1.0-alpha2.jar"
                 ],
                 "sha256": "64d649007364d70dcab24a1f895646e6976f5e2b339ba73a4af20642d041666a",
@@ -134,7 +125,6 @@
                 "directDependencies": [],
                 "file": "v1/https/repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
                     "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar"
                 ],
                 "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
@@ -151,7 +141,6 @@
                 ],
                 "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-analysis/9.0/asm-analysis-9.0.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/org/ow2/asm/asm-analysis/9.0/asm-analysis-9.0.jar",
                     "https://repo1.maven.org/maven2/org/ow2/asm/asm-analysis/9.0/asm-analysis-9.0.jar"
                 ],
                 "sha256": "2d46de6df856a4daac9aa534459ab7287eb80584e9109850405e5b302dc9c2a6",
@@ -171,7 +160,6 @@
                 ],
                 "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-commons/9.0/asm-commons-9.0.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/org/ow2/asm/asm-commons/9.0/asm-commons-9.0.jar",
                     "https://repo1.maven.org/maven2/org/ow2/asm/asm-commons/9.0/asm-commons-9.0.jar"
                 ],
                 "sha256": "1b9090acb7e67bd4ed2f2cfb002063316d79cecace237bd07cc4f7f1b302092f",
@@ -187,7 +175,6 @@
                 ],
                 "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm-tree/9.0/asm-tree-9.0.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/org/ow2/asm/asm-tree/9.0/asm-tree-9.0.jar",
                     "https://repo1.maven.org/maven2/org/ow2/asm/asm-tree/9.0/asm-tree-9.0.jar"
                 ],
                 "sha256": "e2c25f332eb95861883a8568e45aac5e77d140d0fe961ae8eb9a474ec876e00d",
@@ -199,7 +186,6 @@
                 "directDependencies": [],
                 "file": "v1/https/repo1.maven.org/maven2/org/ow2/asm/asm/9.0/asm-9.0.jar",
                 "mirror_urls": [
-                    "https://maven.google.com/org/ow2/asm/asm/9.0/asm-9.0.jar",
                     "https://repo1.maven.org/maven2/org/ow2/asm/asm/9.0/asm-9.0.jar"
                 ],
                 "sha256": "0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0",


### PR DESCRIPTION
Google's Maven repository does not offer most of our dependencies, which
makes Bazel print quite a few warnings while downloading.