### PR TITLE
Optionally read fuzz target class from JAR manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ A toy example can be run as follows:
 # Using Bazelisk:
 ./bazelisk-linux-amd64 run //examples:ExampleFuzzer
 # Using the binary release and examples_deploy.jar:
-./jazzer --cp=examples_deploy.jar --target_class=com.example.ExampleFuzzer --custom_hooks=com.example.ExampleFuzzerHooks
+./jazzer --cp=examples_deploy.jar
 ```
 
 This should produce output similar to the following:
@@ -166,8 +166,13 @@ invoking Jazzer with the following arguments:
 --cp=fuzz_target.jar:lib1.jar:lib2.jar --target_class=com.example.MyFirstFuzzTarget <optional_corpus_dir>
 ```
 
-Bazel produces the correct type of `.jar` from a `java_binary` target with `create_executable = False` by adding
-the suffix `_deploy.jar` to the target name.
+The fuzz target class can optionally be specified by adding it as the value of the `Jazzer-Fuzz-Target-Class` attribute
+in the JAR's manifest. If there is only a single such attribute among all manifests of JARs on the classpath, Jazzer will
+use its value as the fuzz target class.
+
+Bazel produces the correct type of `.jar` from a `java_binary` target with `create_executable = False` and
+`deploy_manifest_lines = ["Jazzer-Fuzz-Target-Class: com.example.MyFirstFuzzTarget"]` by adding the suffix `_deploy.jar`
+to the target name.
 
 ### Fuzzed Data Provider
 
@@ -304,6 +309,8 @@ for more details.
 
 To use the compiled method hooks they have to be available on the classpath provided by `--cp` and can then be loaded by providing the
 flag `--custom_hooks`, which takes a colon-separated list of names of classes to load hooks from.
+This list of custom hooks can alternatively be specified via the `Jazzer-Hook-Classes` attribute in the fuzz target
+JAR's manifest.
 
 ### Suppressing stack traces
 

--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/ManifestUtils.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/ManifestUtils.kt
@@ -1,0 +1,54 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.runtime
+
+import java.util.jar.Manifest
+
+object ManifestUtils {
+
+    val FUZZ_TARGET_CLASS = "Jazzer-Fuzz-Target-Class"
+    val HOOK_CLASSES = "Jazzer-Hook-Classes"
+
+    fun combineManifestValues(attribute: String): List<String> {
+        val manifests = ManifestUtils::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
+        return manifests.asSequence().mapNotNull { url ->
+            url.openStream().use { inputStream ->
+                val manifest = Manifest(inputStream)
+                manifest.mainAttributes.getValue(attribute)
+            }
+        }.toList()
+    }
+
+    /**
+     * Returns the value of the `Fuzz-Target-Class` manifest attribute if there is a unique one among all manifest
+     * files in the classpath.
+     */
+    @JvmStatic
+    fun detectFuzzTargetClass(): String? {
+        val fuzzTargets = combineManifestValues(FUZZ_TARGET_CLASS)
+        return when (fuzzTargets.size) {
+            0 -> null
+            1 -> fuzzTargets.first()
+            else -> {
+                println(
+                    """
+                    |WARN: More than one Jazzer-Fuzz-Target-Class manifest entry detected on the
+                    |classpath.""".trimMargin()
+                )
+                null
+            }
+        }
+    }
+}

--- a/driver/fuzz_target_runner.cpp
+++ b/driver/fuzz_target_runner.cpp
@@ -52,6 +52,9 @@ DEFINE_string(reproducer_path, ".",
               "Path at which fuzzing reproducers are stored. Defaults to the "
               "current directory.");
 
+constexpr auto kManifestUtilsClass =
+    "com/code_intelligence/jazzer/runtime/ManifestUtils";
+
 namespace jazzer {
 // split a string on unescaped spaces
 std::vector<std::string> splitOnSpace(const std::string &s) {
@@ -78,9 +81,13 @@ FuzzTargetRunner::FuzzTargetRunner(
     JVM &jvm, const std::vector<std::string> &additional_target_args)
     : ExceptionPrinter(jvm), jvm_(jvm), ignore_tokens_() {
   auto &env = jvm.GetEnv();
-  // the first positional argument should be the fuzz target class
   if (FLAGS_target_class.empty()) {
-    std::cerr << "Missing argument --target_class <fuzz_target_class>"
+    FLAGS_target_class = DetectFuzzTargetClass();
+  }
+  // If automatically detecting the fuzz target class failed, we expect it as
+  // the value of the --target_class argument.
+  if (FLAGS_target_class.empty()) {
+    std::cerr << "Missing argument --target_class=<fuzz_target_class>"
               << std::endl;
     exit(1);
   }
@@ -252,5 +259,22 @@ void FuzzTargetRunner::DumpReproducer(const uint8_t *data, std::size_t size) {
                    "reproducer_path='%s'; Java reproducer written to %s",
                    FLAGS_reproducer_path, reproducer_full_path)
             << std::endl;
+}
+
+std::string FuzzTargetRunner::DetectFuzzTargetClass() const {
+  jclass manifest_utils = jvm_.FindClass(kManifestUtilsClass);
+  jmethodID detect_fuzz_target_class = jvm_.GetStaticMethodID(
+      manifest_utils, "detectFuzzTargetClass", "()Ljava/lang/String;", true);
+  auto &env = jvm_.GetEnv();
+  auto jni_fuzz_target_class = (jstring)(
+      env.CallStaticObjectMethod(manifest_utils, detect_fuzz_target_class));
+  if (jni_fuzz_target_class == nullptr) return "";
+
+  const char *fuzz_target_class_cstr =
+      env.GetStringUTFChars(jni_fuzz_target_class, nullptr);
+  std::string fuzz_target_class = std::string(fuzz_target_class_cstr);
+  env.ReleaseStringUTFChars(jni_fuzz_target_class, fuzz_target_class_cstr);
+
+  return fuzz_target_class;
 }
 }  // namespace jazzer

--- a/driver/fuzz_target_runner.h
+++ b/driver/fuzz_target_runner.h
@@ -53,6 +53,8 @@ class FuzzTargetRunner : public ExceptionPrinter {
   jmethodID fuzzer_tear_down_;
   std::vector<jlong> ignore_tokens_;
 
+  std::string DetectFuzzTargetClass() const;
+
  public:
   // Initializes the java fuzz target by calling `void fuzzerInitialize(...)`.
   explicit FuzzTargetRunner(


### PR DESCRIPTION
By reading the fuzz target class from a JAR manifest entry rather than
a command-line argument, fuzz targets can be fully self-contained.

This commit adds a Java function that looks for a unique
`Fuzz-Target-Class` attribute in all manifests on the classpath and
returns it to the driver if found. If no such entry is found, it
falls back to the `--target_class` commandline parameter.