### PR TITLE
Fix Bazel rules for Maven publishing

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -56,12 +56,13 @@ sh_binary(
     ],
 )
 
+exports_files([
+    "jazzer-api.pom",
+])
+
 # To publish a new release to Maven, run:
-# bazel run --config=maven --define "maven_user=..." --define "maven_password=..." --define gpg_sign=true //:jazzer_api_export.publish
-java_export(
-    name = "jazzer_api_export",
-    maven_coordinates = "com.code-intelligence:jazzer-api:0.9.0",
-    runtime_deps = [
-        "//agent:jazzer_api",
-    ],
+# bazel run --config=maven --define "maven_user=..." --define "maven_password=..." --define gpg_sign=true //:jazzer-api.publish
+alias(
+    name = "jazzer-api.publish",
+    actual = "//agent/src/main/java/com/code_intelligence/jazzer/api:api_export.publish",
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -42,8 +42,16 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_COMMIT,
 )
 
+load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
+
+rules_jvm_external_deps()
+
+load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
+
+rules_jvm_external_setup()
+
 load("@rules_jvm_external//:defs.bzl", "maven_install")
-load("//:maven_artifacts.bzl", "MAVEN_ARTIFACTS")
+load("//:maven.bzl", "MAVEN_ARTIFACTS")
 
 maven_install(
     artifacts = MAVEN_ARTIFACTS,
@@ -57,14 +65,6 @@ maven_install(
 load("@maven//:defs.bzl", "pinned_maven_install")
 
 pinned_maven_install()
-
-load("@rules_jvm_external//:repositories.bzl", "rules_jvm_external_deps")
-
-rules_jvm_external_deps()
-
-load("@rules_jvm_external//:setup.bzl", "rules_jvm_external_setup")
-
-rules_jvm_external_setup()
 
 # bazelbuild/rules_kotlin
 rules_kotlin_version = "v1.5.0-alpha-3"

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@rules_java//java:defs.bzl", "java_library")
 load("@bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")
+load("@rules_jvm_external//:defs.bzl", "java_export")
+load("//:maven.bzl", "JAZZER_API_COORDINATES")
 
 java_library(
     name = "api",
@@ -10,4 +12,12 @@ java_library(
 javadoc_library(
     name = "api_javadoc",
     srcs = glob(["*.java"]),
+)
+
+java_export(
+    name = "api_export",
+    srcs = glob(["*.java"]),
+    maven_coordinates = JAZZER_API_COORDINATES,
+    pom_template = "//:jazzer-api.pom",
+    visibility = ["//visibility:public"],
 )

--- a/jazzer-api.pom
+++ b/jazzer-api.pom
@@ -1,0 +1,38 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>{groupId}</groupId>
+  <artifactId>{artifactId}</artifactId>
+  <version>{version}</version>
+  <packaging>jar</packaging>
+  {dependencies}
+
+  <name>Jazzer API</name>
+  <description>Helper functions and annotations for Jazzer fuzz targets</description>
+  <url>https://github.com/CodeIntelligenceTesting/jazzer</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <organization>
+    <name>Code Intelligence GmbH</name>
+    <url>https://code-intelligence.com</url>
+  </organization>
+
+  <developers>
+    <developer>
+      <id>fmeum</id>
+      <name>Fabian Meumertzheim</name>
+      <email>meumertzheim@code-intelligence.com</email>
+      <organization>Code Intelligence GmbH</organization>
+    </developer>
+  </developers>
+
+  <scm>
+    <url>https://github.com/CodeIntelligenceTesting/jazzer</url>
+  </scm>
+</project>

--- a/maven.bzl
+++ b/maven.bzl
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+JAZZER_API_VERSION = "0.9.0"
+JAZZER_API_COORDINATES = "com.code-intelligence:jazzer-api:%s" % JAZZER_API_VERSION
+
 MAVEN_ARTIFACTS = [
     "org.ow2.asm:asm:9.1",
     "org.ow2.asm:asm-commons:9.1",


### PR DESCRIPTION
The uploaded jar previously did not contain any class files and lacked
required POM fields.