### PR TITLE
Sync coverage IDs between child processes

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
@@ -20,6 +20,7 @@ import com.code_intelligence.jazzer.instrumentor.InstrumentationType
 import com.code_intelligence.jazzer.instrumentor.loadHooks
 import com.code_intelligence.jazzer.runtime.ManifestUtils
 import java.lang.instrument.Instrumentation
+import java.nio.file.Path
 
 val KNOWN_ARGUMENTS = listOf(
     "instrumentation_includes",
@@ -28,6 +29,7 @@ val KNOWN_ARGUMENTS = listOf(
     "custom_hook_excludes",
     "trace",
     "custom_hooks",
+    "id_sync_file",
 )
 
 fun premain(agentArgs: String?, instrumentation: Instrumentation) {
@@ -73,8 +75,13 @@ fun premain(agentArgs: String?, instrumentation: Instrumentation) {
             }
         }
     }.toSet()
+    val idSyncFile = argumentMap["id_sync_file"]?.let {
+        Path.of(it.single()).also { path ->
+            println("INFO: Synchronizing coverage IDs in ${path.toAbsolutePath()}")
+        }
+    }
 
-    val runtimeInstrumentor = RuntimeInstrumentor(classNameGlobber, dependencyClassNameGlobber, instrumentationTypes)
+    val runtimeInstrumentor = RuntimeInstrumentor(classNameGlobber, dependencyClassNameGlobber, instrumentationTypes, idSyncFile)
     instrumentation.apply {
         addTransformer(runtimeInstrumentor)
     }

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/CoverageIdStrategy.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/CoverageIdStrategy.kt
@@ -1,0 +1,57 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.agent
+
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
+/**
+ * Indicates a fatal failure to generate synchronized coverage IDs.
+ */
+internal class CoverageIdException(cause: Throwable? = null) :
+    RuntimeException("Failed to synchronize coverage IDs", cause)
+
+interface CoverageIdStrategy {
+    /**
+     * Obtain the first coverage ID to be used for the class [className].
+     * The caller *must* also call [commitIdCount] once it has instrumented that class, even if instrumentation fails.
+     */
+    @Throws(CoverageIdException::class)
+    fun obtainFirstId(className: String): Int
+
+    /**
+     * Records the number of coverage IDs used to instrument the class specified in a previous call to [obtainFirstId].
+     * If instrumenting the class should fail, this function must still be called. In this case, [idCount] is set to 0.
+     */
+    @Throws(CoverageIdException::class)
+    fun commitIdCount(idCount: Int)
+}
+
+/**
+ * An unsynchronized strategy for coverage ID generation that simply increments a global counter.
+ */
+internal class TrivialCoverageIdStrategy : CoverageIdStrategy {
+    private var nextEdgeId = 0
+
+    override fun obtainFirstId(className: String) = nextEdgeId
+
+    override fun commitIdCount(idCount: Int) {
+        nextEdgeId += idCount
+    }
+}
+

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/CoverageIdStrategy.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/CoverageIdStrategy.kt
@@ -55,3 +55,140 @@ internal class TrivialCoverageIdStrategy : CoverageIdStrategy {
     }
 }
 
+/**
+ * Reads the [FileChannel] to the end as a UTF-8 string.
+ */
+private fun FileChannel.readFully(): String {
+    check(size() <= Int.MAX_VALUE)
+    val buffer = ByteBuffer.allocate(size().toInt())
+    while (buffer.hasRemaining()) {
+        when (read(buffer)) {
+            0 -> throw IllegalStateException("No bytes read")
+            -1 -> break
+        }
+    }
+    return String(buffer.array())
+}
+
+/**
+ * Appends [string] to the end of the [FileChannel].
+ */
+private fun FileChannel.append(string: String) {
+    position(size())
+    write(ByteBuffer.wrap(string.toByteArray()))
+}
+
+/**
+ * A strategy for coverage ID generation that synchronizes the IDs assigned to a class with other processes via the
+ * specified [idSyncFile].
+ * This class takes care of synchronizing the access to the file between multiple processes as long as the general
+ * contract of [CoverageIdStrategy] is followed.
+ *
+ * Rationale: Coverage (i.e., edge) IDs differ from other kinds of IDs, such as those generated for call sites or cmp
+ * instructions, in that they should be consecutive, collision-free, and lie in a known, small range. This precludes us
+ * from generating them simply as hashes of class names and explains why go through the arduous process of synchronizing
+ * them across multiple agents.
+ */
+internal class SynchronizedCoverageIdStrategy(private val idSyncFile: Path) : CoverageIdStrategy {
+    var idFileLock: FileLock? = null
+
+    var cachedFirstId: Int? = null
+    var cachedClassName: String? = null
+    var cachedIdCount: Int? = null
+
+    /**
+     * Obtains a coverage ID for [className] such that all cooperating agent processes will obtain the same ID.
+     * There are two cases to consider:
+     * - This agent process is the first to encounter [className], i.e., it does not find a record for that class in
+     *   [idSyncFile]. In this case, a lock on the file is held until the class has been instrumented and a record with
+     *   the required number of coverage IDs has been added.
+     * - Another agent process has already encountered [className], i.e., there is a record that class in [idSyncFile].
+     *   In this case, the lock on the file is returned immediately and the extracted first coverage ID is returned to
+     *   the caller. The caller is still expected to call [commitIdCount] so that desynchronization can be detected.
+     */
+    override fun obtainFirstId(className: String): Int {
+        try {
+            check(idFileLock == null) { "Already holding a lock on the ID file" }
+            val localIdFile = FileChannel.open(
+                idSyncFile,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.READ
+            )
+            // Wait until we have obtained the lock on the sync file. We hold the lock from this point until we have
+            // finished reading and writing (if necessary) to the file.
+            val localIdFileLock = localIdFile.lock()
+            // Parse the sync file, which consists of lines of the form
+            // <class name>:<first ID>:<num IDs>
+            val idInfo = localIdFileLock.channel().readFully()
+                .lineSequence()
+                .filterNot { it.isBlank() }
+                .map { line ->
+                    val parts = line.split(':')
+                    check(parts.size == 3) { "Expected ID file line to be of the form  '<class name>:<first ID>:<num IDs>', got '$line'" }
+                    val lineClassName = parts[0]
+                    val lineFirstId = parts[1].toInt()
+                    check(lineFirstId >= 0) { "Negative first ID in line: $line" }
+                    val lineIdCount = parts[2].toInt()
+                    check(lineIdCount >= 0) { "Negative ID count in line: $line" }
+                    Triple(lineClassName, lineFirstId, lineIdCount)
+                }.toList()
+            cachedClassName = className
+            val idInfoForClass = idInfo.filter { it.first == className }
+            return when (idInfoForClass.size) {
+                0 -> {
+                    // We are the first to encounter this class and thus need to hold the lock until the class has been
+                    // instrumented and we know the required number of coverage IDs.
+                    idFileLock = localIdFileLock
+                    // Compute the next free ID as the maximum over the sums of first ID and ID count, starting at 0 if
+                    // this is the first ID to be assigned. In fact, since this is the only way new lines are added to
+                    // the file, the maximum is always attained by the last line.
+                    val nextFreeId = idInfo.asSequence().map { it.second + it.third }.lastOrNull() ?: 0
+                    cachedFirstId = nextFreeId
+                    nextFreeId
+                }
+                1 -> {
+                    // This class has already been instrumented elsewhere, so we just return the first ID and ID count
+                    // reported from there and release the lock right away. The caller is still expected to call
+                    // commitIdCount.
+                    localIdFileLock.release()
+                    cachedIdCount = idInfoForClass.single().third
+                    idInfoForClass.single().second
+                }
+                else -> {
+                    localIdFileLock.release()
+                    throw IllegalStateException("Multiple entries for $className in ID file")
+                }
+            }
+        } catch (e: Exception) {
+            throw CoverageIdException(e)
+        }
+    }
+
+    override fun commitIdCount(idCount: Int) {
+        val localIdFileLock = idFileLock
+        try {
+            check(cachedClassName != null)
+            if (localIdFileLock == null) {
+                // We released the lock already in obtainFirstId since the class had already been instrumented
+                // elsewhere. As we know the expected number of IDs for the current class in this case, check for
+                // deviations.
+                check(cachedIdCount != null)
+                check(idCount == cachedIdCount) {
+                    "$cachedClassName has $idCount edges, but $cachedIdCount edges reserved in ID file"
+                }
+            } else {
+                // We are the first to instrument this class and should record the number of IDs in the sync file.
+                check(cachedFirstId != null)
+                localIdFileLock.channel().append("$cachedClassName:$cachedFirstId:$idCount\n")
+            }
+            idFileLock = null
+            cachedFirstId = null
+            cachedIdCount = null
+            cachedClassName = null
+        } catch (e: Exception) {
+            throw CoverageIdException(e)
+        } finally {
+            localIdFileLock?.release()
+        }
+    }
+}

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -65,10 +65,14 @@ internal class ClassNameGlobber(includes: List<String>, excludes: List<String>) 
 internal class RuntimeInstrumentor(
     private val classesToInstrument: ClassNameGlobber,
     private val dependencyClassesToInstrument: ClassNameGlobber,
-    private val instrumentationTypes: Set<InstrumentationType>
+    private val instrumentationTypes: Set<InstrumentationType>,
+    idSyncFile: Path?,
 ) : ClassFileTransformer {
 
-    private val coverageIdSynchronizer = TrivialCoverageIdStrategy()
+    private val coverageIdSynchronizer = if (idSyncFile != null)
+        SynchronizedCoverageIdStrategy(idSyncFile)
+    else
+        TrivialCoverageIdStrategy()
 
     private val includedHooks = instrumentationTypes
         .mapNotNull { type ->

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/ClassInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/ClassInstrumentor.kt
@@ -23,8 +23,10 @@ class ClassInstrumentor constructor(bytecode: ByteArray) {
     var instrumentedBytecode = bytecode
         private set
 
-    fun coverage() {
-        instrumentedBytecode = EdgeCoverageInstrumentor.instrument(instrumentedBytecode)
+    fun coverage(initialEdgeId: Int): Int {
+        val edgeCoverageInstrumentor = EdgeCoverageInstrumentor(initialEdgeId)
+        instrumentedBytecode = edgeCoverageInstrumentor.instrument(instrumentedBytecode)
+        return edgeCoverageInstrumentor.numEdges
     }
 
     fun traceDataFlow(instrumentations: Set<InstrumentationType>) {

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/EdgeCoverageInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/EdgeCoverageInstrumentor.kt
@@ -30,217 +30,206 @@ import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 import kotlin.math.max
 
-object EdgeCoverageInstrumentor : Instrumentor {
+class EdgeCoverageInstrumentor(
+    private val initialEdgeId: Int,
+    private val coverageMapClass: Class<*> = CoverageMap::class.java
+) : Instrumentor {
+    private var nextEdgeId = initialEdgeId
+    private val coverageMapInternalClassName = coverageMapClass.name.replace('.', '/')
+
     override fun instrument(bytecode: ByteArray): ByteArray {
         val reader = InstrSupport.classReaderFor(bytecode)
         val writer = ClassWriter(reader, 0)
-        val strategy = EdgeCoverageProbeArrayStrategy()
         val version = InstrSupport.getMajorVersion(reader)
         val visitor = EdgeCoverageClassProbesAdapter(
-            ClassInstrumenter(strategy, EdgeCoverageProbeInserterFactory, writer),
+            ClassInstrumenter(edgeCoverageProbeArrayStrategy, edgeCoverageProbeInserterFactory, writer),
             InstrSupport.needsFrames(version)
         )
         reader.accept(visitor, ClassReader.EXPAND_FRAMES)
         return writer.toByteArray()
     }
 
-    var coverageMapClass: Class<*> = CoverageMap::class.java
-        private set
-    val coverageMapInternalClassName
-        get() = coverageMapClass.name.replace('.', '/')
+    val numEdges
+        get() = nextEdgeId - initialEdgeId
 
-    fun setCoverageMapClassForTestingOnly(coverageMap: Class<*>) {
-        coverageMapClass = coverageMap
-    }
-    val isTesting
+    private val isTesting
         get() = coverageMapClass != CoverageMap::class.java
 
-    fun resetNextGlobalEdgeIdForTestingOnly() {
-        nextGlobalEdgeId = 0
+    private fun nextEdgeId(): Int {
+        if (nextEdgeId >= CoverageMap.mem.capacity()) {
+            if (!isTesting) {
+                CoverageMap.enlargeCoverageMap()
+            }
+        }
+        return nextEdgeId++
     }
-}
 
-private var nextGlobalEdgeId = 0
+    /**
+     * The maximal number of stack elements used by [loadCoverageMap].
+     */
+    private val loadCoverageMapStackSize = 1
 
-private fun nextEdgeId(): Int {
-    if (nextGlobalEdgeId >= CoverageMap.mem.capacity()) {
-        if (!EdgeCoverageInstrumentor.isTesting) {
-            CoverageMap.enlargeCoverageMap()
+    /**
+     * Inject bytecode that loads the coverage map into local variable [variable].
+     */
+    private fun loadCoverageMap(mv: MethodVisitor, variable: Int) {
+        mv.apply {
+            visitFieldInsn(
+                Opcodes.GETSTATIC,
+                coverageMapInternalClassName,
+                "mem",
+                "Ljava/nio/ByteBuffer;"
+            )
+            // Stack: mem (maxStack: 1)
+            visitVarInsn(Opcodes.ASTORE, variable)
         }
     }
-    return nextGlobalEdgeId++
-}
 
-/**
- * The maximal number of stack elements used by [loadCoverageMap].
- */
-private const val LOAD_COVERAGE_MAP_STACK_SIZE = 1
+    /**
+     * The maximal number of stack elements used by [instrumentControlFlowEdge].
+     */
+    private val instrumentControlFlowEdgeStackSize = 5
 
-/**
- * Inject bytecode that loads the coverage map into local variable [variable].
- */
-private fun loadCoverageMap(mv: MethodVisitor, variable: Int) {
-    mv.apply {
-        visitFieldInsn(
-            Opcodes.GETSTATIC,
-            EdgeCoverageInstrumentor.coverageMapInternalClassName,
-            "mem",
-            "Ljava/nio/ByteBuffer;"
-        )
-        // Stack: mem (maxStack: 1)
-        visitVarInsn(Opcodes.ASTORE, variable)
-    }
-}
-
-/**
- * The maximal number of stack elements used by [instrumentControlFlowEdge].
- */
-private const val INSTRUMENT_CONTROL_FLOW_EDGE_STACK_SIZE = 5
-
-/**
- * Inject bytecode instrumentation on a control flow edge with ID [edgeId]. The coverage map can be loaded from local
- * variable [variable].
- */
-private fun instrumentControlFlowEdge(mv: MethodVisitor, edgeId: Int, variable: Int) {
-    mv.apply {
-        visitVarInsn(Opcodes.ALOAD, variable)
-        // Stack: mem
-        push(edgeId)
-        // Stack: mem | edgeId
-        visitInsn(Opcodes.DUP2)
-        // Stack: mem | edgeId | mem | edgeId
-        visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/nio/ByteBuffer", "get", "(I)B", false)
-        // Increment the counter, but ensure that it never stays at 0 after an overflow by incrementing it again in that
-        // case.
-        // This approach performs better than saturating the counter at 255 (see Section 3.3 of
-        // https://www.usenix.org/system/files/woot20-paper-fioraldi.pdf)
-        // Stack: mem | edgeId | counter (sign-extended to int)
-        push(0xff)
-        // Stack: mem | edgeId | counter (sign-extended to int) | 0x000000ff
-        visitInsn(Opcodes.IAND)
-        // Stack: mem | edgeId | counter (zero-extended to int)
-        push(1)
-        // Stack: mem | edgeId | counter | 1
-        visitInsn(Opcodes.IADD)
-        // Stack: mem | edgeId | counter + 1
-        visitInsn(Opcodes.DUP)
-        // Stack: mem | edgeId | counter + 1 | counter + 1
-        push(8)
-        // Stack: mem | edgeId | counter + 1 | counter + 1 | 8 (maxStack: +5)
-        visitInsn(Opcodes.ISHR)
-        // Stack: mem | edgeId | counter + 1 | 1 if the increment overflowed to 0, 0 otherwise
-        visitInsn(Opcodes.IADD)
-        // Stack: mem | edgeId | counter + 2 if the increment overflowed, counter + 1 otherwise
-        visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/nio/ByteBuffer", "put", "(IB)Ljava/nio/ByteBuffer;", false)
-        // Stack: mem
-        visitInsn(Opcodes.POP)
-        if (EdgeCoverageInstrumentor.isTesting) {
-            visitMethodInsn(Opcodes.INVOKESTATIC, EdgeCoverageInstrumentor.coverageMapInternalClassName, "updated", "()V", false)
+    /**
+     * Inject bytecode instrumentation on a control flow edge with ID [edgeId]. The coverage map can be loaded from
+     * local variable [variable].
+     */
+    private fun instrumentControlFlowEdge(mv: MethodVisitor, edgeId: Int, variable: Int) {
+        mv.apply {
+            visitVarInsn(Opcodes.ALOAD, variable)
+            // Stack: mem
+            push(edgeId)
+            // Stack: mem | edgeId
+            visitInsn(Opcodes.DUP2)
+            // Stack: mem | edgeId | mem | edgeId
+            visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/nio/ByteBuffer", "get", "(I)B", false)
+            // Increment the counter, but ensure that it never stays at 0 after an overflow by incrementing it again in
+            // that case.
+            // This approach performs better than saturating the counter at 255 (see Section 3.3 of
+            // https://www.usenix.org/system/files/woot20-paper-fioraldi.pdf)
+            // Stack: mem | edgeId | counter (sign-extended to int)
+            push(0xff)
+            // Stack: mem | edgeId | counter (sign-extended to int) | 0x000000ff
+            visitInsn(Opcodes.IAND)
+            // Stack: mem | edgeId | counter (zero-extended to int)
+            push(1)
+            // Stack: mem | edgeId | counter | 1
+            visitInsn(Opcodes.IADD)
+            // Stack: mem | edgeId | counter + 1
+            visitInsn(Opcodes.DUP)
+            // Stack: mem | edgeId | counter + 1 | counter + 1
+            push(8)
+            // Stack: mem | edgeId | counter + 1 | counter + 1 | 8 (maxStack: +5)
+            visitInsn(Opcodes.ISHR)
+            // Stack: mem | edgeId | counter + 1 | 1 if the increment overflowed to 0, 0 otherwise
+            visitInsn(Opcodes.IADD)
+            // Stack: mem | edgeId | counter + 2 if the increment overflowed, counter + 1 otherwise
+            visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/nio/ByteBuffer", "put", "(IB)Ljava/nio/ByteBuffer;", false)
+            // Stack: mem
+            visitInsn(Opcodes.POP)
+            if (isTesting) {
+                visitMethodInsn(Opcodes.INVOKESTATIC, coverageMapInternalClassName, "updated", "()V", false)
+            }
         }
     }
-}
 
-/**
- * The maximal number of stack elements used by [instrumentMethodEdge].
- */
-private const val INSTRUMENT_METHOD_EDGE_STACK_SIZE = INSTRUMENT_CONTROL_FLOW_EDGE_STACK_SIZE
+    /**
+     * The maximal number of stack elements used by [instrumentMethodEdge].
+     */
+    private val instrumentMethodEdgeStackSize = instrumentControlFlowEdgeStackSize
 
-/**
- * Inject bytecode instrumentation right before a method invocation (if needed). The coverage map can be loaded from
- * local variable [variable].
- *
- * Note: Since not every method invocation might need instrumentation, an edge ID should only be generated if needed
- * by calling [nextEdgeId].
- */
-private fun instrumentMethodEdge(
-    mv: MethodVisitor,
-    variable: Int,
-    internalClassName: String,
-    methodName: String,
-    descriptor: String
-) {
-    if (internalClassName.startsWith("com/code_intelligence/jazzer/") && !EdgeCoverageInstrumentor.isTesting)
-        return
-    if (isNoThrowMethod(internalClassName, methodName, descriptor))
-        return
-    instrumentControlFlowEdge(mv, nextEdgeId(), variable)
-}
+    /**
+     * Inject bytecode instrumentation right before a method invocation (if needed). The coverage map can be loaded from
+     * local variable [variable].
+     *
+     * Note: Since not every method invocation might need instrumentation, an edge ID should only be generated if needed
+     * by calling [nextEdgeId].
+     */
+    private fun instrumentMethodEdge(
+        mv: MethodVisitor,
+        variable: Int,
+        internalClassName: String,
+        methodName: String,
+        descriptor: String
+    ) {
+        if (internalClassName.startsWith("com/code_intelligence/jazzer/") && !isTesting)
+            return
+        if (isNoThrowMethod(internalClassName, methodName, descriptor))
+            return
+        instrumentControlFlowEdge(mv, nextEdgeId(), variable)
+    }
 
-/**
- * Checks whether a method is in a list of function known not to throw any exceptions (including subclasses of
- * [java.lang.RuntimeException]).
- *
- * If a method is known not to throw any exceptions, calls to it do not need to be instrumented for coverage as it will
- * always return to the same basic block.
- *
- * Note: According to the JVM specification, a [java.lang.VirtualMachineError] can always be thrown. As it is fatal for
- * all practical purposes, we can ignore errors of this kind for coverage instrumentation.
- */
-private fun isNoThrowMethod(internalClassName: String, methodName: String, descriptor: String): Boolean {
-    // We only collect no throw information for the Java standard library.
-    if (!internalClassName.startsWith("java/"))
-        return false
-    val key = "$internalClassName#$methodName#$descriptor"
-    return key in JAVA_NO_THROW_METHODS
-}
+    /**
+     * Checks whether a method is in a list of function known not to throw any exceptions (including subclasses of
+     * [java.lang.RuntimeException]).
+     *
+     * If a method is known not to throw any exceptions, calls to it do not need to be instrumented for coverage as it
+     * will always return to the same basic block.
+     *
+     * Note: According to the JVM specification, a [java.lang.VirtualMachineError] can always be thrown. As it is fatal
+     * for all practical purposes, we can ignore errors of this kind for coverage instrumentation.
+     */
+    private fun isNoThrowMethod(internalClassName: String, methodName: String, descriptor: String): Boolean {
+        // We only collect no throw information for the Java standard library.
+        if (!internalClassName.startsWith("java/"))
+            return false
+        val key = "$internalClassName#$methodName#$descriptor"
+        return key in JAVA_NO_THROW_METHODS
+    }
 
 // The remainder of this file interfaces with classes in org.jacoco.core.internal. Changes to this part should not be
 // necessary unless JaCoCo is updated or the way we instrument for coverage changes fundamentally.
 
-private class EdgeCoverageProbeInserter(
-    access: Int,
-    name: String,
-    desc: String,
-    mv: MethodVisitor,
-    arrayStrategy: IProbeArrayStrategy,
-) : ProbeInserter(access, name, desc, mv, arrayStrategy) {
-    override fun insertProbe(id: Int) {
-        instrumentControlFlowEdge(mv, id, variable)
-    }
-
-    override fun visitMaxs(maxStack: Int, maxLocals: Int) {
-        val maxStackIncrease = max(INSTRUMENT_CONTROL_FLOW_EDGE_STACK_SIZE, INSTRUMENT_METHOD_EDGE_STACK_SIZE)
-        val newMaxStack = max(maxStack + maxStackIncrease, LOAD_COVERAGE_MAP_STACK_SIZE)
-        val newMaxLocals = maxLocals + 1
-        mv.visitMaxs(newMaxStack, newMaxLocals)
-    }
-
-    override fun visitMethodInsn(
-        opcode: Int,
-        owner: String,
-        name: String,
-        descriptor: String,
-        isInterface: Boolean
-    ) {
-        instrumentMethodEdge(mv, variable, owner, name, descriptor)
-        mv.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
-    }
-}
-
-private object EdgeCoverageProbeInserterFactory : IProbeInserterFactory {
-    override fun makeProbeInserter(
+    private inner class EdgeCoverageProbeInserter(
         access: Int,
         name: String,
         desc: String,
         mv: MethodVisitor,
         arrayStrategy: IProbeArrayStrategy,
-    ) = EdgeCoverageProbeInserter(access, name, desc, mv, arrayStrategy)
-}
+    ) : ProbeInserter(access, name, desc, mv, arrayStrategy) {
+        override fun insertProbe(id: Int) {
+            instrumentControlFlowEdge(mv, id, variable)
+        }
 
-private class EdgeCoverageClassProbesAdapter(cv: ClassProbesVisitor, trackFrames: Boolean) :
-    ClassProbesAdapter(cv, trackFrames) {
-    override fun nextId(): Int = nextEdgeId()
-}
+        override fun visitMaxs(maxStack: Int, maxLocals: Int) {
+            val maxStackIncrease = max(instrumentControlFlowEdgeStackSize, instrumentMethodEdgeStackSize)
+            val newMaxStack = max(maxStack + maxStackIncrease, loadCoverageMapStackSize)
+            val newMaxLocals = maxLocals + 1
+            mv.visitMaxs(newMaxStack, newMaxLocals)
+        }
 
-private class EdgeCoverageProbeArrayStrategy : IProbeArrayStrategy {
-    override fun storeInstance(mv: MethodVisitor, clinit: Boolean, variable: Int): Int {
-        loadCoverageMap(mv, variable)
-        return LOAD_COVERAGE_MAP_STACK_SIZE
+        override fun visitMethodInsn(
+            opcode: Int,
+            owner: String,
+            name: String,
+            descriptor: String,
+            isInterface: Boolean
+        ) {
+            instrumentMethodEdge(mv, variable, owner, name, descriptor)
+            mv.visitMethodInsn(opcode, owner, name, descriptor, isInterface)
+        }
     }
 
-    override fun addMembers(cv: ClassVisitor, probeCount: Int) {}
-}
+    private val edgeCoverageProbeInserterFactory =
+        IProbeInserterFactory { access, name, desc, mv, arrayStrategy ->
+            EdgeCoverageProbeInserter(access, name, desc, mv, arrayStrategy)
+        }
 
-private fun MethodVisitor.push(value: Int) {
-    InstrSupport.push(this, value)
+    private inner class EdgeCoverageClassProbesAdapter(cv: ClassProbesVisitor, trackFrames: Boolean) :
+        ClassProbesAdapter(cv, trackFrames) {
+        override fun nextId(): Int = nextEdgeId()
+    }
+
+    private val edgeCoverageProbeArrayStrategy = object : IProbeArrayStrategy {
+        override fun storeInstance(mv: MethodVisitor, clinit: Boolean, variable: Int): Int {
+            loadCoverageMap(mv, variable)
+            return loadCoverageMapStackSize
+        }
+
+        override fun addMembers(cv: ClassVisitor, probeCount: Int) {}
+    }
+
+    private fun MethodVisitor.push(value: Int) {
+        InstrSupport.push(this, value)
+    }
 }

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/CoverageInstrumentationTest.kt
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/CoverageInstrumentationTest.kt
@@ -19,9 +19,7 @@ import java.io.File
 import kotlin.test.assertEquals
 
 private fun applyInstrumentation(bytecode: ByteArray): ByteArray {
-    EdgeCoverageInstrumentor.resetNextGlobalEdgeIdForTestingOnly()
-    EdgeCoverageInstrumentor.setCoverageMapClassForTestingOnly(MockCoverageMap::class.java)
-    return EdgeCoverageInstrumentor.instrument(bytecode)
+    return EdgeCoverageInstrumentor(0, MockCoverageMap::class.java).instrument(bytecode)
 }
 
 private fun getOriginalInstrumentationTargetInstance(): DynamicTestContract {

--- a/driver/jvm_tooling.cpp
+++ b/driver/jvm_tooling.cpp
@@ -61,6 +61,11 @@ DEFINE_string(
     "list of instrumentation to perform separated by colon \":\". "
     "Available options are cov, cmp, div, gep, all. These options "
     "correspond to the \"-fsanitize-coverage=trace-*\" flags in clang.");
+DEFINE_string(
+    id_sync_file, "",
+    "path to a file that should be used to synchronize coverage IDs "
+    "between parallel fuzzing processes. Defaults to a temporary file "
+    "created for this purpose if running in parallel.");
 
 DECLARE_bool(hooks);
 
@@ -124,6 +129,7 @@ std::string agentArgsFromFlags() {
            {"custom_hook_includes", FLAGS_custom_hook_includes},
            {"custom_hook_excludes", FLAGS_custom_hook_excludes},
            {"trace", FLAGS_trace},
+           {"id_sync_file", FLAGS_id_sync_file},
        }) {
     if (!flag_pair.second.empty()) {
       args.push_back(flag_pair.first + "=" + flag_pair.second);

--- a/driver/libfuzzer_driver.h
+++ b/driver/libfuzzer_driver.h
@@ -31,7 +31,7 @@ namespace jazzer {
 
 class AbstractLibfuzzerDriver {
  public:
-  AbstractLibfuzzerDriver(int argc, char **argv,
+  AbstractLibfuzzerDriver(int *argc, char ***argv,
                           const std::string &usage_string);
 
   virtual ~AbstractLibfuzzerDriver() = default;
@@ -61,7 +61,7 @@ class AbstractLibfuzzerDriver {
 
 class LibfuzzerDriver : public AbstractLibfuzzerDriver {
  public:
-  LibfuzzerDriver(int argc, char **argv);
+  LibfuzzerDriver(int *argc, char ***argv);
 
   virtual RunResult TestOneInput(const uint8_t *data, std::size_t size);
 

--- a/driver/libfuzzer_fuzz_target.cpp
+++ b/driver/libfuzzer_fuzz_target.cpp
@@ -43,13 +43,13 @@ extern "C" void driver_cleanup() {
 
 // Entry point called by libfuzzer before any LLVMFuzzerTestOneInput(...)
 // invocations.
-extern "C" int LLVMFuzzerInitialize(const int *argc, char ***argv) {
+extern "C" int LLVMFuzzerInitialize(int *argc, char ***argv) {
   if (is_asan_active) {
     std::cerr << "WARN: Jazzer is not compatible with LeakSanitizer yet. Leaks "
                  "are not reported."
               << std::endl;
   }
-  gLibfuzzerDriver = std::make_unique<Driver>(*argc, *argv);
+  gLibfuzzerDriver = std::make_unique<Driver>(argc, argv);
   // Run even if we use std::quick_exit to prevent libFuzzer stack trace
   // printing.
   std::atexit(&driver_cleanup);

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -39,6 +39,7 @@ java_fuzz_target_test(
     srcs = [
         "src/main/java/com/example/JpegImageParserFuzzer.java",
     ],
+    fuzzer_args = ["-fork=5"],
     target_class = "com.example.JpegImageParserFuzzer",
     deps = [
         "@maven//:org_apache_commons_commons_imaging",


### PR DESCRIPTION
When run with e.g. the -fork flag, libFuzzer delegates the fuzzing to multiple child processes running concurrently. As each of these processes runs its own JVM with its own instance of the Jazzer agent, different ranges of coverage IDs may be assigned to the same class depending on when it is discovered by that fuzzer process. Since libFuzzer collates the coverage counter buffers, this leads to misreported coverage and unnecessarily large corpora.

This PR adds a coverage ID generation strategy that uses a lockable temporary file as a means to synchronize the IDs between multiple processes.