### PR TITLE
Enable assertions and severity markup for fuzz targets

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueCritical.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueCritical.java
@@ -1,24 +1,39 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.code_intelligence.jazzer.api;
 
 /**
- * Thrown to indicate that a fuzz target has detected a critical severity security issue rather than a normal bug.
+ * Thrown to indicate that a fuzz target has detected a critical severity security issue rather than
+ * a normal bug.
  *
  * There is only a semantical but no functional difference between throwing exceptions of this type
  * or any other. However, automated fuzzing platforms can use the extra information to handle the
  * detected issues appropriately.
  */
 public class FuzzerSecurityIssueCritical extends RuntimeException {
-    public FuzzerSecurityIssueCritical() {}
+  public FuzzerSecurityIssueCritical() {}
 
-    public FuzzerSecurityIssueCritical(String message) {
-        super(message);
-    }
+  public FuzzerSecurityIssueCritical(String message) {
+    super(message);
+  }
 
-    public FuzzerSecurityIssueCritical(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public FuzzerSecurityIssueCritical(String message, Throwable cause) {
+    super(message, cause);
+  }
 
-    public FuzzerSecurityIssueCritical(Throwable cause) {
-        super(cause);
-    }
+  public FuzzerSecurityIssueCritical(Throwable cause) {
+    super(cause);
+  }
 }

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueCritical.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueCritical.java
@@ -1,0 +1,24 @@
+package com.code_intelligence.jazzer.api;
+
+/**
+ * Thrown to indicate that a fuzz target has detected a critical severity security issue rather than a normal bug.
+ *
+ * There is only a semantical but no functional difference between throwing exceptions of this type
+ * or any other. However, automated fuzzing platforms can use the extra information to handle the
+ * detected issues appropriately.
+ */
+public class FuzzerSecurityIssueCritical extends RuntimeException {
+    public FuzzerSecurityIssueCritical() {}
+
+    public FuzzerSecurityIssueCritical(String message) {
+        super(message);
+    }
+
+    public FuzzerSecurityIssueCritical(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FuzzerSecurityIssueCritical(Throwable cause) {
+        super(cause);
+    }
+}

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueHigh.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueHigh.java
@@ -1,0 +1,24 @@
+package com.code_intelligence.jazzer.api;
+
+/**
+ * Thrown to indicate that a fuzz target has detected a high severity security issue rather than a normal bug.
+ *
+ * There is only a semantical but no functional difference between throwing exceptions of this type
+ * or any other. However, automated fuzzing platforms can use the extra information to handle the
+ * detected issues appropriately.
+ */
+public class FuzzerSecurityIssueHigh extends RuntimeException {
+    public FuzzerSecurityIssueHigh() {}
+
+    public FuzzerSecurityIssueHigh(String message) {
+        super(message);
+    }
+
+    public FuzzerSecurityIssueHigh(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FuzzerSecurityIssueHigh(Throwable cause) {
+        super(cause);
+    }
+}

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueHigh.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueHigh.java
@@ -1,24 +1,39 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.code_intelligence.jazzer.api;
 
 /**
- * Thrown to indicate that a fuzz target has detected a high severity security issue rather than a normal bug.
+ * Thrown to indicate that a fuzz target has detected a high severity security issue rather than a
+ * normal bug.
  *
  * There is only a semantical but no functional difference between throwing exceptions of this type
  * or any other. However, automated fuzzing platforms can use the extra information to handle the
  * detected issues appropriately.
  */
 public class FuzzerSecurityIssueHigh extends RuntimeException {
-    public FuzzerSecurityIssueHigh() {}
+  public FuzzerSecurityIssueHigh() {}
 
-    public FuzzerSecurityIssueHigh(String message) {
-        super(message);
-    }
+  public FuzzerSecurityIssueHigh(String message) {
+    super(message);
+  }
 
-    public FuzzerSecurityIssueHigh(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public FuzzerSecurityIssueHigh(String message, Throwable cause) {
+    super(message, cause);
+  }
 
-    public FuzzerSecurityIssueHigh(Throwable cause) {
-        super(cause);
-    }
+  public FuzzerSecurityIssueHigh(Throwable cause) {
+    super(cause);
+  }
 }

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueLow.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueLow.java
@@ -1,0 +1,24 @@
+package com.code_intelligence.jazzer.api;
+
+/**
+ * Thrown to indicate that a fuzz target has detected a low severity security issue rather than a normal bug.
+ *
+ * There is only a semantical but no functional difference between throwing exceptions of this type
+ * or any other. However, automated fuzzing platforms can use the extra information to handle the
+ * detected issues appropriately.
+ */
+public class FuzzerSecurityIssueLow extends RuntimeException {
+    public FuzzerSecurityIssueLow() {}
+
+    public FuzzerSecurityIssueLow(String message) {
+        super(message);
+    }
+
+    public FuzzerSecurityIssueLow(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FuzzerSecurityIssueLow(Throwable cause) {
+        super(cause);
+    }
+}

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueLow.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueLow.java
@@ -1,24 +1,39 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.code_intelligence.jazzer.api;
 
 /**
- * Thrown to indicate that a fuzz target has detected a low severity security issue rather than a normal bug.
+ * Thrown to indicate that a fuzz target has detected a low severity security issue rather than a
+ * normal bug.
  *
  * There is only a semantical but no functional difference between throwing exceptions of this type
  * or any other. However, automated fuzzing platforms can use the extra information to handle the
  * detected issues appropriately.
  */
 public class FuzzerSecurityIssueLow extends RuntimeException {
-    public FuzzerSecurityIssueLow() {}
+  public FuzzerSecurityIssueLow() {}
 
-    public FuzzerSecurityIssueLow(String message) {
-        super(message);
-    }
+  public FuzzerSecurityIssueLow(String message) {
+    super(message);
+  }
 
-    public FuzzerSecurityIssueLow(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public FuzzerSecurityIssueLow(String message, Throwable cause) {
+    super(message, cause);
+  }
 
-    public FuzzerSecurityIssueLow(Throwable cause) {
-        super(cause);
-    }
+  public FuzzerSecurityIssueLow(Throwable cause) {
+    super(cause);
+  }
 }

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueMedium.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueMedium.java
@@ -1,24 +1,39 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.code_intelligence.jazzer.api;
 
 /**
- * Thrown to indicate that a fuzz target has detected a medium severity security issue rather than a normal bug.
+ * Thrown to indicate that a fuzz target has detected a medium severity security issue rather than a
+ * normal bug.
  *
  * There is only a semantical but no functional difference between throwing exceptions of this type
  * or any other. However, automated fuzzing platforms can use the extra information to handle the
  * detected issues appropriately.
  */
 public class FuzzerSecurityIssueMedium extends RuntimeException {
-    public FuzzerSecurityIssueMedium() {}
+  public FuzzerSecurityIssueMedium() {}
 
-    public FuzzerSecurityIssueMedium(String message) {
-        super(message);
-    }
+  public FuzzerSecurityIssueMedium(String message) {
+    super(message);
+  }
 
-    public FuzzerSecurityIssueMedium(String message, Throwable cause) {
-        super(message, cause);
-    }
+  public FuzzerSecurityIssueMedium(String message, Throwable cause) {
+    super(message, cause);
+  }
 
-    public FuzzerSecurityIssueMedium(Throwable cause) {
-        super(cause);
-    }
+  public FuzzerSecurityIssueMedium(Throwable cause) {
+    super(cause);
+  }
 }

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueMedium.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/FuzzerSecurityIssueMedium.java
@@ -1,0 +1,24 @@
+package com.code_intelligence.jazzer.api;
+
+/**
+ * Thrown to indicate that a fuzz target has detected a medium severity security issue rather than a normal bug.
+ *
+ * There is only a semantical but no functional difference between throwing exceptions of this type
+ * or any other. However, automated fuzzing platforms can use the extra information to handle the
+ * detected issues appropriately.
+ */
+public class FuzzerSecurityIssueMedium extends RuntimeException {
+    public FuzzerSecurityIssueMedium() {}
+
+    public FuzzerSecurityIssueMedium(String message) {
+        super(message);
+    }
+
+    public FuzzerSecurityIssueMedium(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public FuzzerSecurityIssueMedium(Throwable cause) {
+        super(cause);
+    }
+}

--- a/driver/java_reproducer_templates.h
+++ b/driver/java_reproducer_templates.h
@@ -26,6 +26,7 @@ public class Crash_$0 {
     static final String base64Bytes = "$1";
 
     public static void main(String[] args) {
+        ClassLoader.getSystemClassLoader().setDefaultAssertionStatus(true);
         try {
             Method fuzzerInitialize = $2.class.getDeclaredMethod("fuzzerInitialize");
             if (fuzzerInitialize.getParameterTypes().length == 0) {

--- a/driver/jvm_tooling.cpp
+++ b/driver/jvm_tooling.cpp
@@ -155,6 +155,7 @@ JVM::JVM(const std::string &executable_path) {
       JavaVMOption{.optionString = const_cast<char *>(class_path.c_str())});
   // set the maximum heap size
   options.push_back(JavaVMOption{.optionString = (char *)"-Xmx4096m"});
+  options.push_back(JavaVMOption{.optionString = (char *)"-enableassertions"});
 
   // add additional jvm options set through command line flags
   std::vector<std::string> jvm_args;

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -70,11 +70,44 @@ java_fuzz_target_test(
 )
 
 java_fuzz_target_test(
-    name = "JsonSanitizerFuzzer",
+    name = "JsonSanitizerCrashFuzzer",
     srcs = [
-        "src/main/java/com/example/JsonSanitizerFuzzer.java",
+        "src/main/java/com/example/JsonSanitizerCrashFuzzer.java",
     ],
-    target_class = "com.example.JsonSanitizerFuzzer",
+    target_class = "com.example.JsonSanitizerCrashFuzzer",
+    deps = [
+        "@maven//:com_mikesamuel_json_sanitizer",
+    ],
+)
+
+java_fuzz_target_test(
+    name = "JsonSanitizerDenylistFuzzer",
+    srcs = [
+        "src/main/java/com/example/JsonSanitizerDenylistFuzzer.java",
+    ],
+    target_class = "com.example.JsonSanitizerDenylistFuzzer",
+    deps = [
+        "@maven//:com_mikesamuel_json_sanitizer",
+    ],
+)
+
+java_fuzz_target_test(
+    name = "JsonSanitizerIdempotenceFuzzer",
+    srcs = [
+        "src/main/java/com/example/JsonSanitizerIdempotenceFuzzer.java",
+    ],
+    target_class = "com.example.JsonSanitizerIdempotenceFuzzer",
+    deps = [
+        "@maven//:com_mikesamuel_json_sanitizer",
+    ],
+)
+
+java_fuzz_target_test(
+    name = "JsonSanitizerValidJsonFuzzer",
+    srcs = [
+        "src/main/java/com/example/JsonSanitizerValidJsonFuzzer.java",
+    ],
+    target_class = "com.example.JsonSanitizerValidJsonFuzzer",
     deps = [
         "@maven//:com_google_code_gson_gson",
         "@maven//:com_mikesamuel_json_sanitizer",
@@ -131,11 +164,9 @@ java_binary(
         ":ExampleFuzzer_target_deploy.jar",
         ":ExampleValueProfileFuzzer_target_deploy.jar",
         ":FastJsonFuzzer_target_deploy.jar",
-        ":GifImageParserFuzzer_target_deploy.jar",
         ":JacksonCborFuzzer_target_deploy.jar",
         ":JpegImageParserFuzzer_target_deploy.jar",
-        ":JsonSanitizerFuzzer_target_deploy.jar",
-        ":TiffImageParserFuzzer_target_deploy.jar",
+        ":JsonSanitizerDenylistFuzzer_target_deploy.jar",
     ],
     visibility = ["//visibility:public"],
 )

--- a/examples/src/main/java/com/example/ExampleValueProfileFuzzer.java
+++ b/examples/src/main/java/com/example/ExampleValueProfileFuzzer.java
@@ -15,6 +15,7 @@
 package com.example;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueLow;
 import java.util.Base64;
 
 public class ExampleValueProfileFuzzer {
@@ -47,6 +48,6 @@ public class ExampleValueProfileFuzzer {
   }
 
   private static void mustNeverBeCalled() {
-    throw new IllegalStateException("mustNeverBeCalled has been called");
+    throw new FuzzerSecurityIssueLow("mustNeverBeCalled has been called");
   }
 }

--- a/examples/src/main/java/com/example/JsonSanitizerCrashFuzzer.java
+++ b/examples/src/main/java/com/example/JsonSanitizerCrashFuzzer.java
@@ -15,27 +15,16 @@
 package com.example;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import com.google.json.JsonSanitizer;
 
-public class JsonSanitizerFuzzer {
+public class JsonSanitizerCrashFuzzer {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String input = data.consumeRemainingAsString();
-    String validJson;
     try {
-      validJson = JsonSanitizer.sanitize(input, 60);
-    } catch (ArrayIndexOutOfBoundsException e) {
+      JsonSanitizer.sanitize(input, 10);
+    } catch (ArrayIndexOutOfBoundsException ignored) {
       // ArrayIndexOutOfBoundsException is expected if nesting depth is
       // exceeded.
-      return;
-    }
-    Gson gson = new Gson();
-    gson.fromJson(validJson, JsonElement.class);
-    if (validJson.contains("</script>") || validJson.contains("<script")
-        || validJson.contains("<!--") || validJson.contains("]]>")) {
-      System.out.println(validJson);
-      throw new IllegalStateException("Output contains forbidden substring");
     }
   }
 }

--- a/examples/src/main/java/com/example/JsonSanitizerDenylistFuzzer.java
+++ b/examples/src/main/java/com/example/JsonSanitizerDenylistFuzzer.java
@@ -1,0 +1,45 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueHigh;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.google.json.JsonSanitizer;
+
+public class JsonSanitizerDenylistFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    String input = data.consumeRemainingAsString();
+    String validJson;
+    try {
+      validJson = JsonSanitizer.sanitize(input, 10);
+    } catch (Exception e) {
+      return;
+    }
+
+    // Check for forbidden substrings. As these would enable Cross-Site Scripting, treat every
+    // finding as a high severity vulnerability.
+    assert !validJson.contains("</script")
+        : new FuzzerSecurityIssueHigh("Output contains </script");
+    assert !validJson.contains("]]>") : new FuzzerSecurityIssueHigh("Output contains ]]>");
+
+    // Check for more forbidden substrings. As these would not directly enable Cross-Site Scripting
+    // in general, but may impact script execution on the embedding page, treat each finding as a
+    // medium severity vulnerability.
+    assert !validJson.contains("<script")
+        : new FuzzerSecurityIssueMedium("Output contains <script");
+    assert !validJson.contains("<!--") : new FuzzerSecurityIssueMedium("Output contains <!--");
+  }
+}


### PR DESCRIPTION
Allows using `assert` in fuzz targets combined with a custom exception type for security bugs (with an optionally specified severity). 