### PR TITLE
Temporarily disable the Bazel cache

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -20,12 +20,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      
-      - name: Mount bazel cache
-        uses: actions/cache@v2
-        with:
-          path: "/home/runner/.cache/bazel"
-          key: bazel
+
+#      Disabled due to issues with missing dependency declarations on system headers.
+#      - name: Mount bazel cache
+#        uses: actions/cache@v2
+#        with:
+#          path: "/home/runner/.cache/bazel"
+#          key: bazel
 
       - name: Build
         run: ./bazelisk-linux-amd64 build -c opt //...


### PR DESCRIPTION
Incremental builds fail with supposedly undeclared dependencies on
system headers. This might be caused by changes to the underlying
GitHub virtual environment.