### PR TITLE
Fix cases array construction in switch instrumentation

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
@@ -174,20 +174,19 @@ internal class TraceDataFlowInstrumentor(private val types: Set<InstrumentationT
         // duplicate {lookup,table}switch key for use as first function argument
         add(InsnNode(Opcodes.DUP))
         add(InsnNode(Opcodes.I2L))
-        // Setup array with switch cases.
-        // The format libfuzzer expects is created here directly
-        // i.e. first two values are bit size (always 32) and number of cases
+        // Set up array with switch case values. The format libfuzzer expects is created here directly, i.e., the first
+        // two entries are the number of cases and the bit size of values (always 32).
         add(IntInsnNode(Opcodes.SIPUSH, caseValues.size + 2))
         add(IntInsnNode(Opcodes.NEWARRAY, Opcodes.T_LONG))
-        // Store bit size of keys
-        add(InsnNode(Opcodes.DUP))
-        add(IntInsnNode(Opcodes.SIPUSH, 0))
-        add(LdcInsnNode(32.toLong()))
-        add(InsnNode(Opcodes.LASTORE))
         // Store number of cases
         add(InsnNode(Opcodes.DUP))
-        add(IntInsnNode(Opcodes.SIPUSH, 1))
+        add(IntInsnNode(Opcodes.SIPUSH, 0))
         add(LdcInsnNode(caseValues.size.toLong()))
+        add(InsnNode(Opcodes.LASTORE))
+        // Store bit size of keys
+        add(InsnNode(Opcodes.DUP))
+        add(IntInsnNode(Opcodes.SIPUSH, 1))
+        add(LdcInsnNode(32.toLong()))
         add(InsnNode(Opcodes.LASTORE))
         // Store {lookup,table}switch case values
         for ((i, caseValue) in caseValues.withIndex()) {

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/MockTraceDataFlowCallbacks.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/MockTraceDataFlowCallbacks.java
@@ -80,10 +80,10 @@ public class MockTraceDataFlowCallbacks {
 
   public static void traceSwitch(long switchValue, long[] libfuzzerCaseValues, int pc) {
     if (libfuzzerCaseValues.length < 3
-        // bit size of case values is always 32 (int)
-        || libfuzzerCaseValues[0] != 32
         // number of case values must match length
-        || libfuzzerCaseValues[1] != libfuzzerCaseValues.length - 2) {
+        || libfuzzerCaseValues[0] != libfuzzerCaseValues.length - 2
+        // bit size of case values is always 32 (int)
+        || libfuzzerCaseValues[1] != 32) {
       hookCalls.add("INVALID_SWITCH");
       return;
     }


### PR DESCRIPTION
The switch instrumentation constructed the array of case labels incorrectly, which lead to libFuzzer performing an out-of-bounds read.