### PR TITLE
Fix order of frames in StackOverflowError trace

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/ExceptionUtils.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/ExceptionUtils.kt
@@ -73,11 +73,11 @@ fun preprocessThrowable(throwable: Throwable): Throwable = when (throwable) {
         // stopping at the first repetition of a frame. The original error is returned as the cause
         // unchanged.
         val observedFrames = mutableSetOf<StackTraceElement>()
-        val bottomToTopFramesWithoutRepetition = throwable.stackTrace.takeLastWhile { frame ->
+        val bottomFramesWithoutRepetition = throwable.stackTrace.takeLastWhile { frame ->
             (frame !in observedFrames).also { observedFrames.add(frame) }
         }
         FuzzerSecurityIssueLow("Stack overflow (truncated to likely cause)", throwable).apply {
-            stackTrace = bottomToTopFramesWithoutRepetition.reversed().toTypedArray()
+            stackTrace = bottomFramesWithoutRepetition.toTypedArray()
         }
     }
     // Includes OutOfMemoryError


### PR DESCRIPTION
`takeLastWhile` preserves the order of frames and thus `reversed()` should not be applied to the result.