### PR TITLE
Shade external dependencies

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -213,3 +213,20 @@ http_archive(
     strip_prefix = "llvm-project-llvmorg-12.0.0-rc3",
     url = "https://github.com/llvm/llvm-project/archive/llvmorg-12.0.0-rc3.tar.gz",
 )
+
+# bazel_jar_jar
+
+bazel_jar_jar_commit = "171f268569384c57c19474b04aebe574d85fde0d"
+
+bazel_jar_jar_sha = "97c5f862482a05f385bd8f9d28a9bbf684b0cf3fae93112ee96f3fb04d34b193"
+
+http_archive(
+    name = "com_github_johnynek_bazel_jar_jar",
+    sha256 = bazel_jar_jar_sha,
+    strip_prefix = "bazel_jar_jar-%s" % bazel_jar_jar_commit,
+    url = "https://github.com/johnynek/bazel_jar_jar/archive/%s.tar.gz" % bazel_jar_jar_commit,
+)
+
+load("@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl", "jar_jar_repositories")
+
+jar_jar_repositories()

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -41,7 +41,6 @@ private val BASE_EXCLUDED_CLASS_NAME_GLOBS = listOf(
     "java.**",
     "jdk.**",
     "kotlin.**",
-    "org.objectweb.asm.**", // dependency used for bytecode manipulation
     "sun.**",
 )
 

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+load("@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl", "jar_jar")
 
 kt_jvm_library(
     name = "instrumentor",
@@ -10,10 +11,24 @@ kt_jvm_library(
         "//agent/src/test/java/com/code_intelligence/jazzer/instrumentor:__pkg__",
     ],
     deps = [
+        ":shaded_deps",
         "//agent/src/main/java/com/code_intelligence/jazzer/generated:JavaNoThrowMethods",
         "//agent/src/main/java/com/code_intelligence/jazzer/runtime",
         "//agent/src/main/java/com/code_intelligence/jazzer/utils",
         "@com_github_jetbrains_kotlin//:kotlin-reflect",
+    ],
+)
+
+jar_jar(
+    name = "shaded_deps",
+    input_jar = "unshaded_deps_deploy.jar",
+    rules = "shade_rules",
+)
+
+java_binary(
+    name = "unshaded_deps",
+    create_executable = False,
+    runtime_deps = [
         "@jacoco_internal",
         "@maven//:org_ow2_asm_asm",
         "@maven//:org_ow2_asm_asm_commons",

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/EdgeCoverageInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/EdgeCoverageInstrumentor.kt
@@ -16,18 +16,18 @@ package com.code_intelligence.jazzer.instrumentor
 
 import com.code_intelligence.jazzer.generated.JAVA_NO_THROW_METHODS
 import com.code_intelligence.jazzer.runtime.CoverageMap
-import org.jacoco.core.internal.flow.ClassProbesAdapter
-import org.jacoco.core.internal.flow.ClassProbesVisitor
-import org.jacoco.core.internal.instr.ClassInstrumenter
-import org.jacoco.core.internal.instr.IProbeArrayStrategy
-import org.jacoco.core.internal.instr.IProbeInserterFactory
-import org.jacoco.core.internal.instr.InstrSupport
-import org.jacoco.core.internal.instr.ProbeInserter
-import org.objectweb.asm.ClassReader
-import org.objectweb.asm.ClassVisitor
-import org.objectweb.asm.ClassWriter
-import org.objectweb.asm.MethodVisitor
-import org.objectweb.asm.Opcodes
+import com.code_intelligence.jazzer.third_party.jacoco.core.internal.flow.ClassProbesAdapter
+import com.code_intelligence.jazzer.third_party.jacoco.core.internal.flow.ClassProbesVisitor
+import com.code_intelligence.jazzer.third_party.jacoco.core.internal.instr.ClassInstrumenter
+import com.code_intelligence.jazzer.third_party.jacoco.core.internal.instr.IProbeArrayStrategy
+import com.code_intelligence.jazzer.third_party.jacoco.core.internal.instr.IProbeInserterFactory
+import com.code_intelligence.jazzer.third_party.jacoco.core.internal.instr.InstrSupport
+import com.code_intelligence.jazzer.third_party.jacoco.core.internal.instr.ProbeInserter
+import com.code_intelligence.jazzer.third_party.objectweb.asm.ClassReader
+import com.code_intelligence.jazzer.third_party.objectweb.asm.ClassVisitor
+import com.code_intelligence.jazzer.third_party.objectweb.asm.ClassWriter
+import com.code_intelligence.jazzer.third_party.objectweb.asm.MethodVisitor
+import com.code_intelligence.jazzer.third_party.objectweb.asm.Opcodes
 import kotlin.math.max
 
 class EdgeCoverageInstrumentor(

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/HookInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/HookInstrumentor.kt
@@ -14,10 +14,10 @@
 
 package com.code_intelligence.jazzer.instrumentor
 
-import org.objectweb.asm.ClassReader
-import org.objectweb.asm.ClassVisitor
-import org.objectweb.asm.ClassWriter
-import org.objectweb.asm.MethodVisitor
+import com.code_intelligence.jazzer.third_party.objectweb.asm.ClassReader
+import com.code_intelligence.jazzer.third_party.objectweb.asm.ClassVisitor
+import com.code_intelligence.jazzer.third_party.objectweb.asm.ClassWriter
+import com.code_intelligence.jazzer.third_party.objectweb.asm.MethodVisitor
 
 internal class HookInstrumentor(private val hooks: Iterable<Hook>, private val java6Mode: Boolean) : Instrumentor {
 

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/HookMethodVisitor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/HookMethodVisitor.kt
@@ -15,11 +15,11 @@
 package com.code_intelligence.jazzer.instrumentor
 
 import com.code_intelligence.jazzer.api.HookType
-import org.objectweb.asm.Handle
-import org.objectweb.asm.MethodVisitor
-import org.objectweb.asm.Opcodes
-import org.objectweb.asm.Type
-import org.objectweb.asm.commons.LocalVariablesSorter
+import com.code_intelligence.jazzer.third_party.objectweb.asm.Handle
+import com.code_intelligence.jazzer.third_party.objectweb.asm.MethodVisitor
+import com.code_intelligence.jazzer.third_party.objectweb.asm.Opcodes
+import com.code_intelligence.jazzer.third_party.objectweb.asm.Type
+import com.code_intelligence.jazzer.third_party.objectweb.asm.commons.LocalVariablesSorter
 
 internal fun makeHookMethodVisitor(
     access: Int,

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Instrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Instrumentor.kt
@@ -14,8 +14,8 @@
 
 package com.code_intelligence.jazzer.instrumentor
 
-import org.objectweb.asm.Opcodes
-import org.objectweb.asm.tree.MethodNode
+import com.code_intelligence.jazzer.third_party.objectweb.asm.Opcodes
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.MethodNode
 
 enum class InstrumentationType {
     CMP,

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
@@ -15,19 +15,19 @@
 package com.code_intelligence.jazzer.instrumentor
 
 import com.code_intelligence.jazzer.runtime.TraceDataFlowNativeCallbacks
-import org.objectweb.asm.ClassReader
-import org.objectweb.asm.ClassWriter
-import org.objectweb.asm.Opcodes
-import org.objectweb.asm.tree.AbstractInsnNode
-import org.objectweb.asm.tree.ClassNode
-import org.objectweb.asm.tree.InsnList
-import org.objectweb.asm.tree.InsnNode
-import org.objectweb.asm.tree.IntInsnNode
-import org.objectweb.asm.tree.LdcInsnNode
-import org.objectweb.asm.tree.LookupSwitchInsnNode
-import org.objectweb.asm.tree.MethodInsnNode
-import org.objectweb.asm.tree.MethodNode
-import org.objectweb.asm.tree.TableSwitchInsnNode
+import com.code_intelligence.jazzer.third_party.objectweb.asm.ClassReader
+import com.code_intelligence.jazzer.third_party.objectweb.asm.ClassWriter
+import com.code_intelligence.jazzer.third_party.objectweb.asm.Opcodes
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.AbstractInsnNode
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.ClassNode
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.InsnList
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.InsnNode
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.IntInsnNode
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.LdcInsnNode
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.LookupSwitchInsnNode
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.MethodInsnNode
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.MethodNode
+import com.code_intelligence.jazzer.third_party.objectweb.asm.tree.TableSwitchInsnNode
 
 internal class TraceDataFlowInstrumentor(private val types: Set<InstrumentationType>, callbackClass: Class<*> = TraceDataFlowNativeCallbacks::class.java) : Instrumentor {
 

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/shade_rules
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/shade_rules
@@ -1,0 +1,1 @@
+rule org.** com.code_intelligence.jazzer.third_party.@1


### PR DESCRIPTION
Fuzz targets may use the ASM libraries or JaCoCo themselves, which
can lead to dependency version conflicts.

To counter this, we shade all our external dependencies into the
com.code_intelligence.jazzer.third_party.* package using bazel_jar_jar
when we build the instrumentor library.

The seemingly simpler approach of applying jar shading directly to the
jazzer_agent_deploy.jar does not work as jarjar is unable to handle
some of the Kotlin runtime files in the resulting jar.

Fixes #55.