### PR TITLE
Revert "Disable broken tests on OSX."

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -27,9 +27,9 @@ java_fuzz_target_test(
         "src/main/java/com/example/ExampleFuzzerWithNative.java",
     ],
     native_libs = ["//examples/src/main/native"],
-    target_class = "com.example.ExampleFuzzerWithNative",
     # Bazel creates shared libraries with an incorrect extension on macOS.
     target_compatible_with = NOT_OSX,
+    target_class = "com.example.ExampleFuzzerWithNative",
     use_asan = True,
     deps = [
         "//agent:jazzer_api_deploy.jar",
@@ -70,9 +70,9 @@ java_fuzz_target_test(
     srcs = [
         "src/main/java/com/example/ExampleStackOverflowFuzzer.java",
     ],
-    target_class = "com.example.ExampleStackOverflowFuzzer",
     # Crashes with a segfault before any stack trace printing is reached.
     target_compatible_with = NOT_OSX,
+    target_class = "com.example.ExampleStackOverflowFuzzer",
 )
 
 java_fuzz_target_test(
@@ -81,9 +81,9 @@ java_fuzz_target_test(
         "src/main/java/com/example/JpegImageParserFuzzer.java",
     ],
     fuzzer_args = ["-fork=5"],
-    target_class = "com.example.JpegImageParserFuzzer",
     # The exit codes of the forked libFuzzer processes are not picked up correctly.
     target_compatible_with = NOT_OSX,
+    target_class = "com.example.JpegImageParserFuzzer",
     deps = [
         "@maven//:org_apache_commons_commons_imaging",
     ],

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2,14 +2,6 @@ load("@rules_java//java:defs.bzl", "java_binary")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
 load("//bazel:fuzz_target.bzl", "java_fuzz_target_test")
 
-# List of all platforms except OSX. Set this value to attribute
-# "target_compatible_with" of targets that should not be executed on OSX.
-NOT_OSX = [
-    "@bazel_tools//platforms:freebsd",
-    "@bazel_tools//platforms:linux",
-    "@bazel_tools//platforms:windows",
-]
-
 java_fuzz_target_test(
     name = "ExampleFuzzer",
     srcs = [
@@ -28,7 +20,7 @@ java_fuzz_target_test(
     ],
     native_libs = ["//examples/src/main/native"],
     # Bazel creates shared libraries with an incorrect extension on macOS.
-    target_compatible_with = NOT_OSX,
+    tags = ["broken-on-darwin"],
     target_class = "com.example.ExampleFuzzerWithNative",
     use_asan = True,
     deps = [
@@ -71,7 +63,7 @@ java_fuzz_target_test(
         "src/main/java/com/example/ExampleStackOverflowFuzzer.java",
     ],
     # Crashes with a segfault before any stack trace printing is reached.
-    target_compatible_with = NOT_OSX,
+    tags = ["broken-on-darwin"],
     target_class = "com.example.ExampleStackOverflowFuzzer",
 )
 
@@ -82,7 +74,7 @@ java_fuzz_target_test(
     ],
     fuzzer_args = ["-fork=5"],
     # The exit codes of the forked libFuzzer processes are not picked up correctly.
-    target_compatible_with = NOT_OSX,
+    tags = ["broken-on-darwin"],
     target_class = "com.example.JpegImageParserFuzzer",
     deps = [
         "@maven//:org_apache_commons_commons_imaging",


### PR DESCRIPTION
Reverts CodeIntelligenceTesting/jazzer#66

The PR breaks the IntelliJ Bazel plugin sync.