### PR TITLE
Fix InvocationTargetException in reportFindingFromHook

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/api/Jazzer.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/Jazzer.java
@@ -41,12 +41,19 @@ final public class Jazzer {
   public static void reportFindingFromHook(Throwable finding) {
     try {
       jazzerInternal.getMethod("reportFindingFromHook", Throwable.class).invoke(null, finding);
-    } catch (NullPointerException | IllegalAccessException | InvocationTargetException
-        | NoSuchMethodException e) {
+    } catch (NullPointerException | IllegalAccessException | NoSuchMethodException e) {
       // We can only reach this point if the runtime is not in the classpath, but it must be if
       // hooks work and this function should only be called from them.
       System.err.println("ERROR: Jazzer.reportFindingFromHook must be called from a method hook");
       System.exit(1);
+    } catch (InvocationTargetException e) {
+      // reportFindingFromHook throws a HardToCatchThrowable, which will bubble up wrapped in an
+      // InvocationTargetException that should not be stopped here.
+      if (e.getCause().getClass().getName().endsWith(".HardToCatchError")) {
+        throw(Error) e.getCause();
+      } else {
+        e.printStackTrace();
+      }
     }
   }
 }

--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/HardToCatchError.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/HardToCatchError.java
@@ -20,8 +20,8 @@ import java.io.PrintWriter;
 /**
  * An Error that rethrows itself when any of its getters is invoked.
  */
-public class HardToCatchThrowable extends Error {
-  public HardToCatchThrowable() {
+public class HardToCatchError extends Error {
+  public HardToCatchError() {
     super();
   }
 

--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/JazzerInternal.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/JazzerInternal.java
@@ -24,6 +24,6 @@ final public class JazzerInternal {
     // Throw an Error that is hard to catch (short of outright ignoring it) in order to quickly
     // terminate the execution of the fuzz target. The finding will be reported as soon as the fuzz
     // target returns even if this Error is swallowed.
-    throw new HardToCatchThrowable();
+    throw new HardToCatchError();
   }
 }


### PR DESCRIPTION
The Jazzer API call Jazzer#reportFindingFromHook would attempt to catch
the HardToCatchError (renamed from HardToCatchThrowable) wrapped in an
InvocationTargetException and exit.

With this commit, any InvocationTargetExceptions are unwrapped and the
contained HardToCatchError cause is rethrown.