### PR TITLE
Terminate libFuzzer on second SIGINT

### DIFF
--- a/driver/signal_handler.cpp
+++ b/driver/signal_handler.cpp
@@ -29,6 +29,9 @@ void JNICALL handleInterrupt(JNIEnv, jclass) {
   if (!already_exiting.exchange(true)) {
     // Let libFuzzer exit gracefully when the JVM received SIGINT.
     raise(SIGUSR1);
+  } else {
+    // Exit libFuzzer forcefully on repeated SIGINTs.
+    raise(SIGTERM);
   }
 }
 


### PR DESCRIPTION
Makes it possible to stop the fuzzer even if the fuzz target is in an
infinite loop. The first SIGINT lets the fuzzer exit gracefully if
possible, the second now triggers a hard exit.