### PR TITLE
Disable caching on macOS

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -37,6 +37,7 @@ jobs:
           java-version: ${{ matrix.jdk }}
 
       - name: Mount Bazel disk cache
+        if: matrix.arch != 'darwin'
         uses: actions/cache@v2
         with:
           path: ${{ matrix.cache }}


### PR DESCRIPTION
The caching action fails on macOS after hanging in the Post hook for a few minutes.