### PR TITLE
Revert "Switch to __sanitizer_weak_hook_compare_bytes"

### DIFF
--- a/driver/libfuzzer_callbacks.cpp
+++ b/driver/libfuzzer_callbacks.cpp
@@ -42,9 +42,6 @@ const char kLibfuzzerTraceDataFlowHooksClass[] =
 extern "C" {
 void __sanitizer_weak_hook_memcmp(void *caller_pc, const void *s1,
                                   const void *s2, std::size_t n, int result);
-void __sanitizer_weak_hook_compare_bytes(void *caller_pc, const void *s1,
-                                         const void *s2, std::size_t n1,
-                                         std::size_t n2, int result);
 void __sanitizer_weak_hook_strcmp(void *caller_pc, const char *s1,
                                   const char *s2, int result);
 void __sanitizer_weak_hook_strstr(void *caller_pc, const char *s1,
@@ -68,14 +65,9 @@ void JNICALL libfuzzerStringCompareCallback(JNIEnv &env, jclass cls, jstring s1,
                                             jstring s2, jint result, jint id) {
   const char *s1_native = env.GetStringUTFChars(s1, nullptr);
   if (env.ExceptionCheck()) env.ExceptionDescribe();
-  std::size_t n1 = env.GetStringUTFLength(s1);
-  if (env.ExceptionCheck()) env.ExceptionDescribe();
   const char *s2_native = env.GetStringUTFChars(s2, nullptr);
   if (env.ExceptionCheck()) env.ExceptionDescribe();
-  std::size_t n2 = env.GetStringUTFLength(s2);
-  if (env.ExceptionCheck()) env.ExceptionDescribe();
-  __sanitizer_weak_hook_compare_bytes(idToPc(id), s1_native, s2_native, n1, n2,
-                                      result);
+  __sanitizer_weak_hook_strcmp(idToPc(id), s1_native, s2_native, result);
   env.ReleaseStringUTFChars(s1, s1_native);
   if (env.ExceptionCheck()) env.ExceptionDescribe();
   env.ReleaseStringUTFChars(s2, s2_native);
@@ -106,8 +98,8 @@ void JNICALL libfuzzerByteCompareCallback(JNIEnv &env, jclass cls,
   if (env.ExceptionCheck()) env.ExceptionDescribe();
   jbyte *b2_native = env.GetByteArrayElements(b2, nullptr);
   if (env.ExceptionCheck()) env.ExceptionDescribe();
-  __sanitizer_weak_hook_compare_bytes(idToPc(id), b1_native, b2_native,
-                                      b1_length, b2_length, result);
+  __sanitizer_weak_hook_memcmp(idToPc(id), b1_native, b2_native,
+                               std::min(b1_length, b2_length), result);
   env.ReleaseByteArrayElements(b1, b1_native, JNI_ABORT);
   if (env.ExceptionCheck()) env.ExceptionDescribe();
   env.ReleaseByteArrayElements(b2, b2_native, JNI_ABORT);

--- a/driver/sanitizer_symbols_for_tests.cpp
+++ b/driver/sanitizer_symbols_for_tests.cpp
@@ -29,9 +29,6 @@ void __sanitizer_weak_hook_memcmp(void *caller_pc, const void *s1,
                                   const void *s2, std::size_t n, int result) {}
 void __sanitizer_weak_hook_strcmp(void *caller_pc, const char *s1,
                                   const char *s2, int result) {}
-void __sanitizer_weak_hook_compare_bytes(void *caller_pc, const void *s1,
-                                         const void *s2, std::size_t n1,
-                                         std::size_t n2, int result) {}
 void __sanitizer_weak_hook_strstr(void *caller_pc, const char *s1,
                                   const char *s2, int result) {}
 void __sanitizer_cov_trace_cmp4(uint32_t arg1, uint32_t arg2) {}

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -134,7 +134,7 @@ def jazzer_dependencies():
         patches = [
             "@jazzer//third_party:libFuzzer-get-covered-pcs.patch",
         ],
-        sha256 = "4aba69716993cc5d5361ddec99bdf53a7a20de91511d2b04e430650d5a2a8b4b",
-        strip_prefix = "llvm-project-jazzer-69c3fe6175b0bc8f8a5a6be3a9e66a5502d98915",
-        url = "https://github.com/CodeIntelligenceTesting/llvm-project-jazzer/archive/69c3fe6175b0bc8f8a5a6be3a9e66a5502d98915.tar.gz",
+        sha256 = "",
+        strip_prefix = "llvm-project-jazzer-323a61f95560431042f906f424a23b5ebd5e566c",
+        url = "https://github.com/CodeIntelligenceTesting/llvm-project-jazzer/archive/323a61f95560431042f906f424a23b5ebd5e566c.tar.gz",
     )


### PR DESCRIPTION
This reverts commit 519d7b95b8df9abb4f872edea7313305fdab5c3c and updates
to a new version of jazzer_libfuzzer with a few reverts.

Speculative fix for crashes in memmove.