### PR TITLE
Improve hooks and the Jazzer API

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/HookMethodVisitor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/HookMethodVisitor.kt
@@ -96,8 +96,12 @@ private class HookMethodVisitor(
             // Special case for constructors:
             // We cannot create a MethodHandle for a constructor, so we push null instead.
             mv.visitInsn(Opcodes.ACONST_NULL) // push nullref
-            // We also cannot use the uninitialized object as parameter, so we do the same here.
-            mv.visitInsn(Opcodes.ACONST_NULL) // push nullref
+            // Only pass the this object if it has been initialized by the time the hook is invoked.
+            if (hook.hookType == HookType.AFTER) {
+                mv.visitVarInsn(Opcodes.ALOAD, localOwnerObj)
+            } else {
+                mv.visitInsn(Opcodes.ACONST_NULL) // push nullref
+            }
         } else {
             // Push a MethodHandle representing the hooked method.
             val handleOpcode = when (opcode) {

--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/ManifestUtils.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/ManifestUtils.kt
@@ -18,8 +18,8 @@ import java.util.jar.Manifest
 
 object ManifestUtils {
 
-    val FUZZ_TARGET_CLASS = "Jazzer-Fuzz-Target-Class"
-    val HOOK_CLASSES = "Jazzer-Hook-Classes"
+    const val FUZZ_TARGET_CLASS = "Jazzer-Fuzz-Target-Class"
+    const val HOOK_CLASSES = "Jazzer-Hook-Classes"
 
     fun combineManifestValues(attribute: String): List<String> {
         val manifests = ManifestUtils::class.java.classLoader.getResources("META-INF/MANIFEST.MF")

--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
@@ -199,8 +199,7 @@ final public class TraceCmpHooks {
     byte[] first = (byte[]) arguments[0];
     byte[] second = (byte[]) arguments[1];
     if (!returnValue) {
-      TraceDataFlowNativeCallbacks.traceMemcmp(
-          first, first.length, second, second.length, 1, hookId);
+      TraceDataFlowNativeCallbacks.traceMemcmp(first, second, 1, hookId);
     }
   }
 
@@ -214,8 +213,7 @@ final public class TraceCmpHooks {
     byte[] second =
         Arrays.copyOfRange((byte[]) arguments[3], (int) arguments[4], (int) arguments[5]);
     if (!returnValue) {
-      TraceDataFlowNativeCallbacks.traceMemcmp(
-          first, first.length, second, second.length, 1, hookId);
+      TraceDataFlowNativeCallbacks.traceMemcmp(first, second, 1, hookId);
     }
   }
 
@@ -229,8 +227,7 @@ final public class TraceCmpHooks {
     byte[] first = (byte[]) arguments[0];
     byte[] second = (byte[]) arguments[1];
     if (returnValue != 0) {
-      TraceDataFlowNativeCallbacks.traceMemcmp(
-          first, first.length, second, second.length, returnValue, hookId);
+      TraceDataFlowNativeCallbacks.traceMemcmp(first, second, returnValue, hookId);
     }
   }
 
@@ -246,8 +243,7 @@ final public class TraceCmpHooks {
     byte[] second =
         Arrays.copyOfRange((byte[]) arguments[3], (int) arguments[4], (int) arguments[5]);
     if (returnValue != 0) {
-      TraceDataFlowNativeCallbacks.traceMemcmp(
-          first, first.length, second, second.length, returnValue, hookId);
+      TraceDataFlowNativeCallbacks.traceMemcmp(first, second, returnValue, hookId);
     }
   }
 }

--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/TraceDataFlowNativeCallbacks.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/TraceDataFlowNativeCallbacks.java
@@ -34,8 +34,7 @@ final public class TraceDataFlowNativeCallbacks {
 
   // Calls: void __sanitizer_weak_hook_memcmp(void *caller_pc, const void *b1, const void *b2,
   // size_t n, int result);
-  public static native void traceMemcmp(
-      byte[] b1, int b1Length, byte[] b2, int b2Length, int result, int pc);
+  public static native void traceMemcmp(byte[] b1, byte[] b2, int result, int pc);
 
   // Calls: void __sanitizer_weak_hook_strcmp(void *called_pc, const char *s1, const char *s2, int
   // result);

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooks.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooks.java
@@ -45,8 +45,8 @@ public class AfterHooks {
       targetClassName = "com.code_intelligence.jazzer.instrumentor.AfterHooksTarget",
       targetMethod = "getFirstSecret", targetMethodDescriptor = "()Ljava/lang/String;")
   public static void
-  patchGetFirstSecret(MethodHandle method, Object thisObject, Object[] arguments, int hookId,
-      String returnValue) throws Throwable {
+  patchGetFirstSecret(
+      MethodHandle method, Object thisObject, Object[] arguments, int hookId, String returnValue) {
     // Use the returned secret to pass the test.
     ((AfterHooksTargetContract) thisObject).verifyFirstSecret(returnValue);
   }
@@ -55,8 +55,8 @@ public class AfterHooks {
       targetClassName = "com.code_intelligence.jazzer.instrumentor.AfterHooksTarget",
       targetMethod = "getSecondSecret")
   public static void
-  patchGetSecondSecret(MethodHandle method, Object thisObject, Object[] arguments, int hookId,
-      Object returnValue) throws Throwable {
+  patchGetSecondSecret(
+      MethodHandle method, Object thisObject, Object[] arguments, int hookId, Object returnValue) {
     // Use the returned secret to pass the test.
     ((AfterHooksTargetContract) thisObject).verifySecondSecret((String) returnValue);
   }

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooks.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooks.java
@@ -19,12 +19,15 @@ import com.code_intelligence.jazzer.api.MethodHook;
 import java.lang.invoke.MethodHandle;
 
 public class AfterHooks {
+  static AfterHooksTargetContract instance;
+
   @MethodHook(type = HookType.AFTER,
       targetClassName = "com.code_intelligence.jazzer.instrumentor.AfterHooksTarget",
       targetMethod = "func1")
   public static void
   patchFunc1(
       MethodHandle method, Object thisObject, Object[] arguments, int hookId, Object returnValue) {
+    instance = (AfterHooksTargetContract) thisObject;
     ((AfterHooksTargetContract) thisObject).registerHasFunc1BeenCalled();
   }
 
@@ -56,5 +59,29 @@ public class AfterHooks {
       Object returnValue) throws Throwable {
     // Use the returned secret to pass the test.
     ((AfterHooksTargetContract) thisObject).verifySecondSecret((String) returnValue);
+  }
+
+  // Verify the interaction of a BEFORE and an AFTER hook. The BEFORE hook modifies the argument of
+  // the StringBuilder constructor.
+  @MethodHook(
+      type = HookType.BEFORE, targetClassName = "java.lang.StringBuilder", targetMethod = "<init>")
+  public static void
+  patchStringBuilderBeforeInit(
+      MethodHandle method, Object thisObject, Object[] arguments, int hookId) {
+    arguments[0] = "hunter3";
+  }
+
+  @MethodHook(
+      type = HookType.AFTER, targetClassName = "java.lang.StringBuilder", targetMethod = "<init>")
+  public static void
+  patchStringBuilderInit(
+      MethodHandle method, Object thisObject, Object[] arguments, int hookId, Object returnValue) {
+    String secret = ((StringBuilder) thisObject).toString();
+    // Verify that the argument passed to this AFTER hook agrees with the argument passed to the
+    // StringBuilder constructor, which has been modified by the BEFORE hook.
+    if (secret.equals(arguments[0])) {
+      // Verify that the argument has been modified to the correct value "hunter3".
+      instance.verifyThirdSecret(secret);
+    }
   }
 }

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooksTarget.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooksTarget.java
@@ -45,6 +45,9 @@ public class AfterHooksTarget implements AfterHooksTargetContract {
     verifySecondSecret("not_secret_at_all");
     getSecondSecret();
 
+    verifyThirdSecret("not_the_secret");
+    new StringBuilder("not_hunter3");
+
     return results;
   }
 
@@ -74,5 +77,9 @@ public class AfterHooksTarget implements AfterHooksTargetContract {
   @SuppressWarnings("SameParameterValue")
   public void verifySecondSecret(String secret) {
     results.put("verifySecondSecret", secret.equals("hunter2!"));
+  }
+
+  public void verifyThirdSecret(String secret) {
+    results.put("verifyThirdSecret", secret.equals("hunter3"));
   }
 }

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooksTargetContract.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooksTargetContract.java
@@ -24,4 +24,6 @@ public interface AfterHooksTargetContract extends DynamicTestContract {
   void verifyFirstSecret(String secret);
 
   void verifySecondSecret(String secret);
+
+  void verifyThirdSecret(String secret);
 }

--- a/driver/libfuzzer_callbacks.cpp
+++ b/driver/libfuzzer_callbacks.cpp
@@ -99,12 +99,15 @@ void JNICALL libfuzzerStringContainCallback(JNIEnv &env, jclass cls, jstring s1,
 }
 
 void JNICALL libfuzzerByteCompareCallback(JNIEnv &env, jclass cls,
-                                          jbyteArray b1, jint b1_length,
-                                          jbyteArray b2, jint b2_length,
+                                          jbyteArray b1, jbyteArray b2,
                                           jint result, jint id) {
   jbyte *b1_native = env.GetByteArrayElements(b1, nullptr);
   if (env.ExceptionCheck()) env.ExceptionDescribe();
   jbyte *b2_native = env.GetByteArrayElements(b2, nullptr);
+  if (env.ExceptionCheck()) env.ExceptionDescribe();
+  jint b1_length = env.GetArrayLength(b1);
+  if (env.ExceptionCheck()) env.ExceptionDescribe();
+  jint b2_length = env.GetArrayLength(b2);
   if (env.ExceptionCheck()) env.ExceptionDescribe();
   __sanitizer_weak_hook_compare_bytes(idToPc(id), b1_native, b2_native,
                                       b1_length, b2_length, result);
@@ -326,7 +329,7 @@ bool registerFuzzerCallbacks(JNIEnv &env) {
   }
   {
     JNINativeMethod string_methods[]{
-        {(char *)"traceMemcmp", (char *)"([BI[BIII)V",
+        {(char *)"traceMemcmp", (char *)"([B[BII)V",
          (void *)&libfuzzerByteCompareCallback},
         {(char *)"traceStrcmp",
          (char *)"(Ljava/lang/String;Ljava/lang/String;II)V",


### PR DESCRIPTION
A mix of improvements to the hooks and `Jazzer` API with the common goal to facilitate stand-alone sanitizers for e.g. SQL injections and RCE.

See the commit messages for further details.