### PR TITLE
Implement basic remote code execution sanitizers

### DIFF
--- a/agent/BUILD.bazel
+++ b/agent/BUILD.bazel
@@ -1,13 +1,18 @@
 load("@rules_java//java:defs.bzl", "java_binary")
+load("//sanitizers:sanitizers.bzl", "SANITIZER_CLASSES")
 
 java_binary(
     name = "jazzer_agent",
     create_executable = False,
     deploy_manifest_lines = [
         "Premain-Class: com.code_intelligence.jazzer.agent.Agent",
+        "Jazzer-Hook-Classes: {}".format(":".join(SANITIZER_CLASSES)),
     ],
     visibility = ["//visibility:public"],
-    runtime_deps = ["//agent/src/main/java/com/code_intelligence/jazzer/agent:agent_lib"],
+    runtime_deps = [
+        "//agent/src/main/java/com/code_intelligence/jazzer/agent:agent_lib",
+        "//sanitizers",
+    ],
 )
 
 java_binary(

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -42,6 +42,8 @@ private val BASE_EXCLUDED_CLASS_NAME_GLOBS = listOf(
     "com.code_intelligence.jazzer.**",
     "com.sun.**", // package for Proxy objects
     "java.**",
+    "jaz.Ter", // safe companion of the honeypot class used by sanitizers
+    "jaz.Zer", // honeypot class used by sanitizers
     "jdk.**",
     "kotlin.**",
     "sun.**",

--- a/format.sh
+++ b/format.sh
@@ -3,7 +3,7 @@ find -name '*.cpp' -o -name '*.h' -o -name '*.java' | xargs clang-format-11 -i
 
 # Kotlin
 # curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.40.0/ktlint && chmod a+x ktlint
-ktlint -F "agent/**/*.kt" "driver/**/*.kt" "examples/**/*.kt"
+ktlint -F "agent/**/*.kt" "driver/**/*.kt" "examples/**/*.kt" "sanitizers/**/*.kt"
 
 # BUILD files
 # go get github.com/bazelbuild/buildtools/buildifier
@@ -11,4 +11,4 @@ buildifier -r .
 
 # Licence headers
 # go get -u github.com/google/addlicense
-addlicense -c "Code Intelligence GmbH" agent/ driver/ examples/ bazel/ *.bzl
+addlicense -c "Code Intelligence GmbH" agent/ bazel/ driver/ examples/ sanitizers/ *.bzl

--- a/sanitizers/BUILD.bazel
+++ b/sanitizers/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "sanitizers",
+    visibility = ["//agent:__pkg__"],
+    runtime_deps = [
+        "//sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers",
+        "//sanitizers/src/main/java/jaz",
+    ],
+)

--- a/sanitizers/sanitizers.bzl
+++ b/sanitizers/sanitizers.bzl
@@ -16,6 +16,7 @@ _sanitizer_package_prefix = "com.code_intelligence.jazzer.sanitizers."
 
 _sanitizer_class_names = [
     "Deserialization",
+    "ReflectiveCall",
 ]
 
 SANITIZER_CLASSES = [_sanitizer_package_prefix + class_name for class_name in _sanitizer_class_names]

--- a/sanitizers/sanitizers.bzl
+++ b/sanitizers/sanitizers.bzl
@@ -1,0 +1,21 @@
+# Copyright 2021 Code Intelligence GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+_sanitizer_package_prefix = "com.code_intelligence.jazzer.sanitizers."
+
+_sanitizer_class_names = [
+    "Deserialization",
+]
+
+SANITIZER_CLASSES = [_sanitizer_package_prefix + class_name for class_name in _sanitizer_class_names]

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BUILD.bazel
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "sanitizers",
+    srcs = glob([
+        "*.kt",
+    ]),
+    visibility = ["//sanitizers:__pkg__"],
+    deps = [
+        "//agent:jazzer_api_compile_only",
+        "//sanitizers/src/main/java/jaz",
+    ],
+)

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/Deserialization.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/Deserialization.kt
@@ -1,0 +1,172 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.sanitizers
+
+import com.code_intelligence.jazzer.api.HookType
+import com.code_intelligence.jazzer.api.MethodHook
+import com.code_intelligence.jazzer.api.MethodHooks
+import java.io.BufferedInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.ObjectStreamConstants
+import java.lang.invoke.MethodHandle
+import java.util.WeakHashMap
+
+/**
+ * Detects unsafe deserialization that leads to attacker-controlled method calls, in particular to [Object.finalize].
+ */
+object Deserialization {
+
+    /**
+     * jaz.Zer is a honeypot class: All of its methods report a finding when called.
+     */
+    private const val HONEYPOT_CLASS_NAME = "jaz.Zer"
+
+    private val OBJECT_INPUT_STREAM_HEADER =
+        ObjectStreamConstants.STREAM_MAGIC.toBytes() + ObjectStreamConstants.STREAM_VERSION.toBytes()
+
+    /**
+     * Used to memoize the [InputStream] used to construct a given [ObjectInputStream].
+     * [ThreadLocal] is required because the map is not synchronized (and likely cheaper than
+     * synchronization).
+     * [WeakHashMap] ensures that we don't prevent the GC from cleaning up [ObjectInputStream] from
+     * previous fuzzing runs.
+     *
+     * Note: The [InputStream] values can all be assumed to be markable, i.e., their
+     * [InputStream.markSupported] returns true.
+     */
+    private var inputStreamForObjectInputStream: ThreadLocal<WeakHashMap<ObjectInputStream, InputStream>> =
+        ThreadLocal.withInitial {
+            WeakHashMap<ObjectInputStream, InputStream>()
+        }
+
+    /**
+     * A serialized instance of our honeypot class.
+     */
+    private val SERIALIZED_JAZ_ZER_INSTANCE: ByteArray by lazy {
+        // We can't instantiate jaz.Zer directly, so we instantiate and serialize jaz.Ter and then
+        // patch the class name.
+        val baos = ByteArrayOutputStream()
+        ObjectOutputStream(baos).writeObject(jaz.Ter())
+        val serializedJazTerInstance = baos.toByteArray()
+        val posToPatch = serializedJazTerInstance.indexOf("jaz.Ter".toByteArray())
+        serializedJazTerInstance[posToPatch + "jaz.".length] = 'Z'.toByte()
+        serializedJazTerInstance
+    }
+
+    /**
+     * Guides the fuzzer towards producing a valid header for an ObjectInputStream.
+     */
+    @MethodHook(
+        type = HookType.BEFORE,
+        targetClassName = "java.io.ObjectInputStream",
+        targetMethod = "<init>",
+        targetMethodDescriptor = "(Ljava/io/InputStream;)V"
+    )
+    @JvmStatic
+    fun objectInputStreamInitBeforeHook(method: MethodHandle?, alwaysNull: Any?, args: Array<Any?>, hookId: Int) {
+        val originalInputStream = args[0] as? InputStream ?: return
+        val fixedInputStream = if (originalInputStream.markSupported())
+            originalInputStream
+        else
+            BufferedInputStream(originalInputStream)
+        args[0] = fixedInputStream
+        guideMarkableInputStreamTowardsEquality(fixedInputStream, OBJECT_INPUT_STREAM_HEADER, hookId)
+    }
+
+    /**
+     * Memoizes the input stream used for creating the [ObjectInputStream] instance.
+     */
+    @MethodHook(
+        type = HookType.AFTER,
+        targetClassName = "java.io.ObjectInputStream",
+        targetMethod = "<init>",
+        targetMethodDescriptor = "(Ljava/io/InputStream;)V"
+    )
+    @JvmStatic
+    fun objectInputStreamInitAfterHook(
+        method: MethodHandle?,
+        objectInputStream: ObjectInputStream?,
+        args: Array<Any?>,
+        hookId: Int,
+        alwaysNull: Any?,
+    ) {
+        val inputStream = args[0] as? InputStream
+        check(inputStream?.markSupported() == true) {
+            "ObjectInputStream#<init> AFTER hook reached with null or non-markable input stream"
+        }
+        inputStreamForObjectInputStream.get()[objectInputStream] = inputStream
+    }
+
+    /**
+     * Guides the fuzzer towards producing a valid serialized instance of our honeypot class.
+     */
+    @MethodHooks(
+        MethodHook(
+            type = HookType.BEFORE,
+            targetClassName = "java.io.ObjectInputStream",
+            targetMethod = "readObject"
+        ),
+        MethodHook(
+            type = HookType.BEFORE,
+            targetClassName = "java.io.ObjectInputStream",
+            targetMethod = "readObjectOverride"
+        ),
+        MethodHook(
+            type = HookType.BEFORE,
+            targetClassName = "java.io.ObjectInputStream",
+            targetMethod = "readUnshared"
+        ),
+    )
+    @JvmStatic
+    fun readObjectBeforeHook(
+        method: MethodHandle?,
+        objectInputStream: ObjectInputStream?,
+        args: Array<Any?>,
+        hookId: Int,
+    ) {
+        val inputStream = inputStreamForObjectInputStream.get()[objectInputStream]
+        if (inputStream?.markSupported() != true) return
+        guideMarkableInputStreamTowardsEquality(inputStream, SERIALIZED_JAZ_ZER_INSTANCE, hookId)
+    }
+
+    /**
+     * Calls [Object.finalize] early if the returned object is [jaz.Zer]. A call to finalize is
+     * guaranteed to happen at some point, but calling it early means that we can accurately report
+     * the input that lead to its execution.
+     */
+    @MethodHooks(
+        MethodHook(type = HookType.AFTER, targetClassName = "java.io.ObjectInputStream", targetMethod = "readObject"),
+        MethodHook(type = HookType.AFTER, targetClassName = "java.io.ObjectInputStream", targetMethod = "readObjectOverride"),
+        MethodHook(type = HookType.AFTER, targetClassName = "java.io.ObjectInputStream", targetMethod = "readUnshared"),
+    )
+    @JvmStatic
+    fun readObjectAfterHook(
+        method: MethodHandle?,
+        objectInputStream: ObjectInputStream?,
+        args: Array<Any?>,
+        hookId: Int,
+        deserializedObject: Any?,
+    ) {
+        if (deserializedObject?.javaClass?.name == HONEYPOT_CLASS_NAME) {
+            deserializedObject.javaClass.getDeclaredMethod("finalize").run {
+                isAccessible = true
+                invoke(deserializedObject)
+            }
+        }
+    }
+}

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/ReflectiveCall.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/ReflectiveCall.kt
@@ -1,0 +1,38 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.sanitizers
+
+import com.code_intelligence.jazzer.api.HookType
+import com.code_intelligence.jazzer.api.Jazzer
+import com.code_intelligence.jazzer.api.MethodHook
+import java.lang.invoke.MethodHandle
+
+/**
+ * Detects unsafe reflective calls that lead to attacker-controlled method calls.
+ */
+object ReflectiveCall {
+
+    /**
+     * jaz.Zer is a honeypot class: All of its methods report a finding when called.
+     */
+    private const val HONEYPOT_CLASS_NAME = "jaz.Zer"
+
+    @MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.Class", targetMethod = "forName")
+    @JvmStatic
+    fun classForNameHook(method: MethodHandle?, alwaysNull: Any?, args: Array<Any?>, hookId: Int) {
+        val className = args[0] as? String ?: return
+        Jazzer.guideTowardsEquality(className, HONEYPOT_CLASS_NAME, hookId)
+    }
+}

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/Utils.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/Utils.kt
@@ -1,0 +1,46 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.sanitizers
+
+import com.code_intelligence.jazzer.api.Jazzer
+import java.io.InputStream
+
+internal fun Short.toBytes(): ByteArray {
+    return byteArrayOf(
+        ((toInt() shr 8) and 0xFF).toByte(),
+        (toInt() and 0xFF).toByte(),
+    )
+}
+
+// Runtime is only O(size * needle.size), only use for small arrays.
+internal fun ByteArray.indexOf(needle: ByteArray): Int {
+    outer@ for (i in 0 until size - needle.size + 1) {
+        for (j in needle.indices) {
+            if (this[i + j] != needle[j]) {
+                continue@outer
+            }
+        }
+        return i
+    }
+    return -1
+}
+
+internal fun guideMarkableInputStreamTowardsEquality(stream: InputStream, target: ByteArray, id: Int) {
+    check(stream.markSupported())
+    stream.mark(target.size)
+    val current = stream.readNBytes(target.size)
+    stream.reset()
+    Jazzer.guideTowardsEquality(current, target, id)
+}

--- a/sanitizers/src/main/java/jaz/BUILD.bazel
+++ b/sanitizers/src/main/java/jaz/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "jaz",
+    srcs = [
+        "Ter.java",
+        "Zer.java",
+    ],
+    visibility = [
+        "//sanitizers:__pkg__",
+        "//sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers:__pkg__",
+    ],
+    deps = ["//agent:jazzer_api_compile_only"],
+)

--- a/sanitizers/src/main/java/jaz/Ter.java
+++ b/sanitizers/src/main/java/jaz/Ter.java
@@ -1,0 +1,24 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaz;
+
+/**
+ * A safe to use companion of {@link jaz.Zer} that is used to produce serializable instances of it
+ * with only light patching.
+ */
+@SuppressWarnings("unused")
+public class Ter implements java.io.Serializable {
+  static final long serialVersionUID = 42L;
+}

--- a/sanitizers/src/main/java/jaz/Zer.java
+++ b/sanitizers/src/main/java/jaz/Zer.java
@@ -1,0 +1,97 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jaz;
+
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.code_intelligence.jazzer.api.Jazzer;
+
+/**
+ * A honeypot class that reports an appropriate finding on any interaction with one of its methods
+ * or initializers.
+ *
+ * Note: This class must not be referenced in any way by the rest of the code, not even statically.
+ * When referring to it, always use its hardcoded class name "jaz.Zer".
+ */
+@SuppressWarnings("unused")
+public class Zer implements java.io.Serializable {
+  static final long serialVersionUID = 42L;
+
+  private static final Throwable staticInitializerCause;
+
+  static {
+    staticInitializerCause = new FuzzerSecurityIssueMedium("finalize call on arbitrary object");
+  }
+
+  public Zer() {
+    Jazzer.reportFindingFromHook(
+        new FuzzerSecurityIssueMedium("default constructor call on arbitrary object"));
+  }
+
+  public Zer(String arg1) {
+    Jazzer.reportFindingFromHook(
+        new FuzzerSecurityIssueMedium("String constructor call on arbitrary object"));
+  }
+
+  public Zer(String arg1, Throwable arg2) {
+    Jazzer.reportFindingFromHook(
+        new FuzzerSecurityIssueMedium("(String, Throwable) constructor call on arbitrary object"));
+  }
+
+  private String jaz;
+
+  public String getJaz() {
+    Jazzer.reportFindingFromHook(new FuzzerSecurityIssueMedium("getter call on arbitrary object"));
+    return jaz;
+  }
+
+  public void setJaz(String jaz) {
+    Jazzer.reportFindingFromHook(new FuzzerSecurityIssueMedium("setter call on arbitrary object"));
+    this.jaz = jaz;
+  }
+
+  @Override
+  public int hashCode() {
+    Jazzer.reportFindingFromHook(
+        new FuzzerSecurityIssueMedium("hashCode call on arbitrary object"));
+    return super.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    Jazzer.reportFindingFromHook(new FuzzerSecurityIssueMedium("equals call on arbitrary object"));
+    return super.equals(obj);
+  }
+
+  @Override
+  protected Object clone() throws CloneNotSupportedException {
+    Jazzer.reportFindingFromHook(new FuzzerSecurityIssueMedium("clone call on arbitrary object"));
+    return super.clone();
+  }
+
+  @Override
+  public String toString() {
+    Jazzer.reportFindingFromHook(
+        new FuzzerSecurityIssueMedium("toString call on arbitrary object"));
+    return super.toString();
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    // finalize is invoked automatically by the GC with an uninformative stack trace. We use the
+    // stack trace prerecorded in the static initializer.
+    Jazzer.reportFindingFromHook(staticInitializerCause);
+    super.finalize();
+  }
+}

--- a/sanitizers/src/test/java/com/example/BUILD.bazel
+++ b/sanitizers/src/test/java/com/example/BUILD.bazel
@@ -7,3 +7,11 @@ java_fuzz_target_test(
     ],
     target_class = "com.example.ObjectInputStreamDeserialization",
 )
+
+java_fuzz_target_test(
+    name = "ReflectiveCall",
+    srcs = [
+        "ReflectiveCall.java",
+    ],
+    target_class = "com.example.ReflectiveCall",
+)

--- a/sanitizers/src/test/java/com/example/BUILD.bazel
+++ b/sanitizers/src/test/java/com/example/BUILD.bazel
@@ -1,0 +1,9 @@
+load("//bazel:fuzz_target.bzl", "java_fuzz_target_test")
+
+java_fuzz_target_test(
+    name = "ObjectInputStreamDeserialization",
+    srcs = [
+        "ObjectInputStreamDeserialization.java",
+    ],
+    target_class = "com.example.ObjectInputStreamDeserialization",
+)

--- a/sanitizers/src/test/java/com/example/ObjectInputStreamDeserialization.java
+++ b/sanitizers/src/test/java/com/example/ObjectInputStreamDeserialization.java
@@ -1,0 +1,32 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+
+public class ObjectInputStreamDeserialization {
+  public static void fuzzerTestOneInput(byte[] data) {
+    try {
+      ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data));
+      ois.readObject();
+    } catch (IOException | ClassNotFoundException ignored) {
+      // Ignored checked exception.
+    } catch (NullPointerException | NegativeArraySizeException ignored) {
+      // Ignored RuntimeExceptions thrown by readObject().
+    }
+  }
+}

--- a/sanitizers/src/test/java/com/example/ReflectiveCall.java
+++ b/sanitizers/src/test/java/com/example/ReflectiveCall.java
@@ -1,0 +1,32 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import java.lang.reflect.InvocationTargetException;
+
+public class ReflectiveCall {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    String input = data.consumeRemainingAsAsciiString();
+    if (input.startsWith("@")) {
+      String className = input.substring(1);
+      try {
+        Class.forName(className).getConstructor().newInstance();
+      } catch (InstantiationException | IllegalAccessException | InvocationTargetException
+          | NoSuchMethodException | ClassNotFoundException ignored) {
+      }
+    }
+  }
+}


### PR DESCRIPTION
The sanitizers combine mutation guides with a dynamic proof of reachability in the form of a honeypot class that raises findings whenever it is interacted with.

The suggested severities are not fixed yet as there doesn't appear to be a broad consensus on this matter. I'm open for suggestions here. Later, we would want to extend the findings with more detailed information on the type of vulnerability.