### PR TITLE
Ensure default -Xmx value is below -rss_limit_mb

### DIFF
--- a/bazel/fuzz_target.bzl
+++ b/bazel/fuzz_target.bzl
@@ -63,8 +63,6 @@ def java_fuzz_target_test(
             "$(rootpath %s)" % driver,
             "--cp=$(rootpath :%s_deploy.jar)" % target_name,
             "--agent_path=$(rootpath //agent:jazzer_agent_deploy.jar)",
-            # Should be bigger than the JVM max heap size (4096m)
-            "-rss_limit_mb=5000",
         ] + additional_args + fuzzer_args,
         data = [
             ":%s_deploy.jar" % target_name,

--- a/driver/jvm_tooling.cpp
+++ b/driver/jvm_tooling.cpp
@@ -153,8 +153,9 @@ JVM::JVM(const std::string &executable_path) {
   std::vector<JavaVMOption> options;
   options.push_back(
       JavaVMOption{.optionString = const_cast<char *>(class_path.c_str())});
-  // set the maximum heap size
-  options.push_back(JavaVMOption{.optionString = (char *)"-Xmx4096m"});
+  // Set the maximum heap size to a value that is slightly smaller than
+  // libFuzzer's default rss_limit_mb. This prevents erroneous oom reports.
+  options.push_back(JavaVMOption{.optionString = (char *)"-Xmx2040m"});
   options.push_back(JavaVMOption{.optionString = (char *)"-enableassertions"});
   // Preserve and emit stack trace information even on hot paths.
   // This may hurt performance, but also helps find flaky bugs.


### PR DESCRIPTION
libFuzzer defaults to an rss_limit_mb of 2048, but we start the JVM with
-Xmx4096m. This can lead to libFuzzer OOM reports when a single
allocation in Java exceeds 2 GB but still fits into the JVM heap.

This is solved by letting the JVM heap size default to slightly less
than 2 GB.

This change is not fully backwards compatible, but will only cause
targets to crash more often than they used to.