### PR TITLE
Allow instrumenting internal classes

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
@@ -82,8 +82,13 @@ fun premain(agentArgs: String?, instrumentation: Instrumentation) {
             println("INFO: Synchronizing coverage IDs in ${path.toAbsolutePath()}")
         }
     }
-
-    val runtimeInstrumentor = RuntimeInstrumentor(classNameGlobber, dependencyClassNameGlobber, instrumentationTypes, idSyncFile)
+    val runtimeInstrumentor = RuntimeInstrumentor(
+        instrumentation,
+        classNameGlobber,
+        dependencyClassNameGlobber,
+        instrumentationTypes,
+        idSyncFile
+    )
     instrumentation.apply {
         addTransformer(runtimeInstrumentor)
     }

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -96,7 +96,7 @@ internal class RuntimeInstrumentor(
 
     @OptIn(kotlin.time.ExperimentalTime::class)
     override fun transform(
-        loader: ClassLoader,
+        loader: ClassLoader?,
         internalClassName: String,
         classBeingRedefined: Class<*>?,
         protectionDomain: ProtectionDomain?,

--- a/agent/src/main/java/com/code_intelligence/jazzer/generated/JavaNoThrowMethods.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/generated/JavaNoThrowMethods.kt
@@ -33,6 +33,4 @@ private object JavaNoThrowMethods {
  * Note: Since methods only declare their thrown exceptions that are not subclasses of [java.lang.RuntimeException],
  * this list cannot be generated purely based on information available via reflection.
  */
-val JAVA_NO_THROW_METHODS by lazy {
-    JavaNoThrowMethods.readJavaNoThrowMethods()
-}
+val JAVA_NO_THROW_METHODS = JavaNoThrowMethods.readJavaNoThrowMethods()

--- a/agent/src/main/java/com/code_intelligence/jazzer/generated/JavaNoThrowMethods.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/generated/JavaNoThrowMethods.kt
@@ -19,7 +19,10 @@ private object JavaNoThrowMethods {
     const val dataFileName = "java_no_throw_methods_list.dat"
 
     fun readJavaNoThrowMethods(): Set<String> {
-        val resource = JavaNoThrowMethods.javaClass.classLoader.getResource("$dataFilePath/$dataFileName")!!
+        // If we successfully appended the agent JAR to the bootstrap class loader path in Agent, the classLoader
+        // property of JavaNoThrowMethods returns null and we have to use the system class loader instead.
+        val ownClassLoader = JavaNoThrowMethods::class.java.classLoader ?: ClassLoader.getSystemClassLoader()
+        val resource = ownClassLoader.getResource("$dataFilePath/$dataFileName")!!
         return resource.openStream().bufferedReader().useLines { line -> line.toSet() }.also {
             println("INFO: Loaded ${it.size} no-throw method signatures")
         }

--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/ManifestUtils.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/ManifestUtils.kt
@@ -22,7 +22,7 @@ object ManifestUtils {
     const val HOOK_CLASSES = "Jazzer-Hook-Classes"
 
     fun combineManifestValues(attribute: String): List<String> {
-        val manifests = ManifestUtils::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
+        val manifests = ClassLoader.getSystemResources("META-INF/MANIFEST.MF")
         return manifests.asSequence().mapNotNull { url ->
             url.openStream().use { inputStream ->
                 val manifest = Manifest(inputStream)


### PR DESCRIPTION
Previously these would silently remain uninstrumented as they come with
a null ClassLoader that does not pass the null check.