### PR TITLE
Prevent redundant Jazzer builds

### DIFF
--- a/bazel/cc.bzl
+++ b/bazel/cc.bzl
@@ -34,13 +34,7 @@ def _cc_17_binary_impl(ctx):
         target_file = ctx.executable.binary,
         is_executable = True,
     )
-    binary_runfiles = ctx.attr.binary[0][DefaultInfo].default_runfiles
-    return [
-        DefaultInfo(
-            executable = output_file,
-            runfiles = binary_runfiles,
-        ),
-    ]
+    return [DefaultInfo(executable = output_file)]
 
 _cc_17_binary = rule(
     implementation = _cc_17_binary_impl,


### PR DESCRIPTION
The driver built through the C++17 transition does not need to have the native `cc_binary` target in its runfiles, which cuts the build time almost in half and simplifies the runfiles tree.