### PR TITLE
Exit early for transform on internal classes

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -38,7 +38,6 @@ private val BASE_INCLUDED_CLASS_NAME_GLOBS = listOf(
 
 private val BASE_EXCLUDED_CLASS_NAME_GLOBS = listOf(
     "\\[**", // array types
-    "com.code_intelligence.jazzer.**",
     "com.sun.**", // package for Proxy objects
     "java.**",
     "jaz.Ter", // safe companion of the honeypot class used by sanitizers
@@ -149,6 +148,10 @@ internal class RuntimeInstrumentor(
         classfileBuffer: ByteArray,
     ): ByteArray? {
         return try {
+            // Bail out early if we would instrument ourselves. This prevents ClassCircularityErrors as we might need to
+            // load additional Jazzer classes until we reach the full exclusion logic.
+            if (internalClassName.startsWith("com/code_intelligence/jazzer/"))
+                return null
             transformInternal(internalClassName, classfileBuffer)
         } catch (t: Throwable) {
             // Throwables raised from transform are silently dropped, making it extremely hard to detect instrumentation


### PR DESCRIPTION
Bail out early if we would instrument ourselves. This prevents
ClassCircularityErrors as we might need to load additional Jazzer
classes until we reach the full exclusion logic.