### PR TITLE
Pass quoted arguments to child processes

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -69,7 +69,13 @@ java_fuzz_target_test(
     srcs = [
         "src/main/java/com/example/JpegImageParserFuzzer.java",
     ],
-    fuzzer_args = ["-fork=5"],
+    fuzzer_args = [
+        "-fork=5",
+        # Only used to verify that arguments are correctly passed down to child
+        # processes. Quoting with both " and ' is necessary in this test since
+        # one level of quoting is lost when passing through jazzer_wrapper.sh
+        "--jvm_args=\"'-Dfoo=foo;-Dbar=bar'\"",
+    ],
     # The exit codes of the forked libFuzzer processes are not picked up correctly.
     tags = ["broken-on-darwin"],
     target_class = "com.example.JpegImageParserFuzzer",

--- a/examples/src/main/java/com/example/JpegImageParserFuzzer.java
+++ b/examples/src/main/java/com/example/JpegImageParserFuzzer.java
@@ -22,6 +22,16 @@ import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 
 // Found https://issues.apache.org/jira/browse/IMAGING-275.
 public class JpegImageParserFuzzer {
+  public static void fuzzerInitialize() {
+    // Only used to verify that arguments are correctly passed down to child processes.
+    if (System.getProperty("foo") == null || System.getProperty("bar") == null) {
+      // The child process did not have a sufficiently high memory limit,
+      // Exit the process with an exit code different from that for a finding.
+      System.err.println("ERROR: Did not pass all jvm_args to child process.");
+      System.exit(3);
+    }
+  }
+
   public static void fuzzerTestOneInput(byte[] input) {
     try {
       new JpegImageParser().getBufferedImage(new ByteSourceArray(input), new HashMap<>());

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -131,6 +131,9 @@ def jazzer_dependencies():
         http_archive,
         name = "jazzer_libfuzzer",
         build_file = "@jazzer//third_party:libFuzzer.BUILD",
+        patches = [
+            "@jazzer//third_party:libFuzzer-quote-command-args.patch",
+        ],
         sha256 = "bb9245e3749a40fcc3dbf5d24d6ff3b41965066f2081b26c47815585a2a5d81b",
         strip_prefix = "llvm-project-jazzer-10f9541ad4a15f2e4efad991bef33d99e16fad90",
         url = "https://github.com/CodeIntelligenceTesting/llvm-project-jazzer/archive/10f9541ad4a15f2e4efad991bef33d99e16fad90.tar.gz",

--- a/third_party/BUILD.bazel
+++ b/third_party/BUILD.bazel
@@ -1,5 +1,5 @@
 exports_files([
     "gflags-use-double-dash-args.patch",
     "jacoco-make-probe-inserter-subclassable.patch",
-    "libFuzzer-get-covered-pcs.patch",
+    "libFuzzer-quote-command-args.patch",
 ])

--- a/third_party/libFuzzer-quote-command-args.patch
+++ b/third_party/libFuzzer-quote-command-args.patch
@@ -1,0 +1,13 @@
+diff --git compiler-rt/lib/fuzzer/FuzzerCommand.h compiler-rt/lib/fuzzer/FuzzerCommand.h
+index 87308864af53..145063d000fb 100644
+--- compiler-rt/lib/fuzzer/FuzzerCommand.h
++++ compiler-rt/lib/fuzzer/FuzzerCommand.h
+@@ -140,7 +140,7 @@ public:
+   std::string toString() const {
+     std::stringstream SS;
+     for (auto arg : getArguments())
+-      SS << arg << " ";
++      SS << "\"" << arg << "\" ";
+     if (hasOutputFile())
+       SS << ">" << getOutputFile() << " ";
+     if (isOutAndErrCombined())


### PR DESCRIPTION
libFuzzer does not quote the arguments it passes to child processes during merge
and fork, which leads to arguments being lost if passing multiple jvm_args with
delimiter ';'.

This commit adds a libFuzzer patch that properly quotes all arguments as well as
a test that fails if quoting is not appropriate.