### PR TITLE
Transition on cc_library rather than cc_binary

### DIFF
--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
-load("//bazel:cc.bzl", "cc_17_binary")
+load("//bazel:cc.bzl", "cc_17_library")
 
 cc_library(
     name = "sanitizer_hooks_with_pc",
@@ -56,22 +56,29 @@ cc_library(
     ],
 )
 
-cc_17_binary(
-    name = "jazzer_driver",
-    srcs = ["libfuzzer_fuzz_target.cpp"],
-    data = [
-        "//agent:jazzer_agent_deploy.jar",
+cc_17_library(
+    name = "driver_lib",
+    srcs = [
+        "libfuzzer_fuzz_target.cpp",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         ":jvm_tooling_lib",
         "@jazzer_libfuzzer//:libFuzzer",
     ],
+    alwayslink = True,
 )
 
-cc_17_binary(
+cc_binary(
+    name = "jazzer_driver",
+    data = [
+        "//agent:jazzer_agent_deploy.jar",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [":driver_lib"],
+)
+
+cc_binary(
     name = "jazzer_driver_asan",
-    srcs = ["libfuzzer_fuzz_target.cpp"],
     data = [
         "//agent:jazzer_agent_deploy.jar",
     ],
@@ -79,10 +86,7 @@ cc_17_binary(
         "-fsanitize=address",
     ],
     visibility = ["//visibility:public"],
-    deps = [
-        ":jvm_tooling_lib",
-        "@jazzer_libfuzzer//:libFuzzer",
-    ],
+    deps = [":driver_lib"],
 )
 
 cc_test(


### PR DESCRIPTION
Applying the -std=c++17 transition on a cc_library rather than a
cc_binary has three advantages:
* saves an unnecessary transitioned build of the agent
* makes it faster to compile the driver for multiple sanitizers
* does not require a symlink in the transitioned rule