### PR TITLE
Add additional_jvm_args flag

### DIFF
--- a/driver/jvm_tooling.cpp
+++ b/driver/jvm_tooling.cpp
@@ -33,6 +33,10 @@ DEFINE_string(cp, ".",
               "runtime and further dependencies separated by a colon \":\"");
 DEFINE_string(jvm_args, "",
               "arguments passed to the jvm separated by semicolon \";\"");
+DEFINE_string(additional_jvm_args, "",
+              "additional arguments passed to the jvm separated by semicolon "
+              "\";\". Use this option to set further JVM args that should not "
+              "interfere with those provided via --jvm_args.");
 DEFINE_string(agent_path, "", "location of the fuzzing instrumentation agent");
 
 // Arguments that are passed to the instrumentation agent.
@@ -167,6 +171,14 @@ JVM::JVM(const std::string &executable_path) {
     jvm_args = absl::StrSplit(FLAGS_jvm_args, ';');
   }
   for (const auto &arg : jvm_args) {
+    options.push_back(
+        JavaVMOption{.optionString = const_cast<char *>(arg.c_str())});
+  }
+  std::vector<std::string> additional_jvm_args;
+  if (!FLAGS_additional_jvm_args.empty()) {
+    additional_jvm_args = absl::StrSplit(FLAGS_additional_jvm_args, ';');
+  }
+  for (const auto &arg : additional_jvm_args) {
     options.push_back(
         JavaVMOption{.optionString = const_cast<char *>(arg.c_str())});
   }

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -75,6 +75,7 @@ java_fuzz_target_test(
         # processes. Quoting with both " and ' is necessary in this test since
         # one level of quoting is lost when passing through jazzer_wrapper.sh
         "--jvm_args=\"'-Dfoo=foo;-Dbar=bar'\"",
+        "--additional_jvm_args=\"'-Dbaz=baz'\"",
     ],
     # The exit codes of the forked libFuzzer processes are not picked up correctly.
     tags = ["broken-on-darwin"],

--- a/examples/src/main/java/com/example/JpegImageParserFuzzer.java
+++ b/examples/src/main/java/com/example/JpegImageParserFuzzer.java
@@ -24,7 +24,8 @@ import org.apache.commons.imaging.formats.jpeg.JpegImageParser;
 public class JpegImageParserFuzzer {
   public static void fuzzerInitialize() {
     // Only used to verify that arguments are correctly passed down to child processes.
-    if (System.getProperty("foo") == null || System.getProperty("bar") == null) {
+    if (System.getProperty("foo") == null || System.getProperty("bar") == null
+        || System.getProperty("baz") == null) {
       // Exit the process with an exit code different from that for a finding.
       System.err.println("ERROR: Did not pass all jvm_args to child process.");
       System.exit(3);


### PR DESCRIPTION
In certain situations, such as OSS-Fuzz coverage reports, additional
JVM args need to be specified on the command line after --jvm_args has
already been used. Specifying --jvm_args again overrides the previous
arguments rather than appending to them.

This commit adds an additional flag for adding JVM args that will be
emitted after the flags specified in --jvm_args.