### PR TITLE
Use Bazel runfiles library to locate agent

### DIFF
--- a/bazel/fuzz_target.bzl
+++ b/bazel/fuzz_target.bzl
@@ -62,7 +62,6 @@ def java_fuzz_target_test(
         args = [
             "$(rootpath %s)" % driver,
             "--cp=$(rootpath :%s_deploy.jar)" % target_name,
-            "--agent_path=$(rootpath //agent:jazzer_agent_deploy.jar)",
         ] + additional_args + fuzzer_args,
         data = [
             ":%s_deploy.jar" % target_name,

--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -48,6 +48,7 @@ cc_library(
     deps = [
         ":sanitizer_hooks_with_pc",
         "//third_party/jni:jni_libs",
+        "@bazel_tools//tools/cpp/runfiles",
         "@bazel_tools//tools/jdk:jni",
         "@com_google_absl//absl/strings",
         "@com_google_absl//absl/strings:str_format",


### PR DESCRIPTION
Tests automatically set `RUNFILES_DIR`, so the Bash runfiles library is not needed in the fuzz test wrapper.