### PR TITLE
Allow dumping instrumented classes

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -122,6 +122,7 @@ internal class RuntimeInstrumentor(
     private val dependencyClassesToInstrument: ClassNameGlobber,
     private val instrumentationTypes: Set<InstrumentationType>,
     idSyncFile: Path?,
+    private val dumpClassesDir: Path?,
 ) : ClassFileTransformer {
 
     private val coverageIdSynchronizer = if (idSyncFile != null)
@@ -166,6 +167,15 @@ internal class RuntimeInstrumentor(
             // https://docs.oracle.com/javase/9/docs/api/java/lang/instrument/ClassFileTransformer.html
             t.printStackTrace()
             throw t
+        }.also { instrumentedByteCode ->
+            // Only dump classes that were instrumented.
+            if (instrumentedByteCode != null && dumpClassesDir != null) {
+                val relativePath = "$internalClassName.class"
+                val absolutePath = dumpClassesDir.resolve(relativePath)
+                val dumpFile = absolutePath.toFile()
+                dumpFile.parentFile.mkdirs()
+                dumpFile.writeBytes(instrumentedByteCode)
+            }
         }
     }
 

--- a/driver/jvm_tooling.cpp
+++ b/driver/jvm_tooling.cpp
@@ -72,6 +72,9 @@ DEFINE_string(
     "path to a file that should be used to synchronize coverage IDs "
     "between parallel fuzzing processes. Defaults to a temporary file "
     "created for this purpose if running in parallel.");
+DEFINE_string(
+    dump_classes_dir, "",
+    "path to a directory in which Jazzer should dump the instrumented classes");
 
 DECLARE_bool(hooks);
 
@@ -140,6 +143,7 @@ std::string agentArgsFromFlags() {
            {"custom_hook_excludes", FLAGS_custom_hook_excludes},
            {"trace", FLAGS_trace},
            {"id_sync_file", FLAGS_id_sync_file},
+           {"dump_classes_dir", FLAGS_dump_classes_dir},
        }) {
     if (!flag_pair.second.empty()) {
       args.push_back(flag_pair.first + "=" + flag_pair.second);


### PR DESCRIPTION
With `--dump_classes_dir=<dir>`, all classes that are instrumented by the
agent at runtime will be dumped into a subdirectory of `<dir>` according
to their internal class name.