### PR TITLE
Fix runfiles handling with jazzer_wrapper.sh

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -44,6 +44,9 @@ sh_binary(
     data = [
         "//driver:jazzer_driver",
     ],
+    deps = [
+        "@bazel_tools//tools/bash/runfiles",
+    ],
 )
 
 sh_binary(

--- a/bazel/jazzer_wrapper.sh
+++ b/bazel/jazzer_wrapper.sh
@@ -13,6 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# --- begin runfiles.bash initialization v2 ---
+# Copy-pasted from the Bazel Bash runfiles library v2.
+set -uo pipefail; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+source "$0.runfiles/$f" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+{ echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v2 --
+
 DEFAULT_CRASH_PREFIX="/tmp/jazzer"
 mkdir -p $DEFAULT_CRASH_PREFIX
 eval "$1" -artifact_prefix="$DEFAULT_CRASH_PREFIX/" --reproducer_path="$DEFAULT_CRASH_PREFIX" "${@:2}"


### PR DESCRIPTION
The wrapper needs to load the Bazel Bash runfiles library to pass the
runfiles directory to jazzer_driver.