### PR TITLE
Register native callbacks on ClassInstrumentor initialization

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/ClassInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/ClassInstrumentor.kt
@@ -39,4 +39,11 @@ class ClassInstrumentor constructor(bytecode: ByteArray) {
             java6Mode = extractClassFileMajorVersion(instrumentedBytecode) < 51
         ).instrument(instrumentedBytecode)
     }
+
+    companion object {
+        init {
+            // Calls JNI_OnLoad_jazzer_initialize in the driver, which registers the native methods.
+            System.loadLibrary("jazzer_initialize")
+        }
+    }
 }

--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -44,6 +44,9 @@ cc_library(
     linkopts = [
         "-ldl",
     ],
+    # Needs to be linked statically for JNI_OnLoad_jazzer_initialize to be found
+    # by the JVM.
+    linkstatic = True,
     visibility = ["//visibility:public"],
     deps = [
         ":sanitizer_hooks_with_pc",
@@ -123,6 +126,11 @@ cc_test(
         "//driver/testdata:fuzz_target_mocks_deploy.jar",
     ],
     includes = ["."],
+    linkopts = [
+        # Needs to export symbols dynamically for JNI_OnLoad_jazzer_initialize
+        # to be found by the JVM.
+        "-rdynamic",
+    ],
     deps = [
         ":jvm_tooling_lib",
         ":test_main",

--- a/driver/jvm_tooling_test.cpp
+++ b/driver/jvm_tooling_test.cpp
@@ -45,7 +45,6 @@ class JvmToolingTest : public ::testing::Test {
     FLAGS_instrumentation_excludes = "**";
 
     jvm_ = std::make_unique<JVM>("test_executable");
-    CoverageTracker::Setup(jvm_->GetEnv());
   }
 
   static void TearDownTestCase() { jvm_.reset(nullptr); }

--- a/driver/libfuzzer_driver.cpp
+++ b/driver/libfuzzer_driver.cpp
@@ -34,13 +34,6 @@
 
 using namespace std::string_literals;
 
-DEFINE_bool(hooks, true,
-            "Use JVM hooks to provide coverage information to the fuzzer. The "
-            "fuzzer uses the coverage information to perform smarter input "
-            "selection and mutation. If set to false no "
-            "coverage information will be processed. This can be useful for "
-            "running a regression test on non-instrumented bytecode.");
-
 // Defined by glog
 DECLARE_bool(log_prefix);
 
@@ -176,13 +169,6 @@ AbstractLibfuzzerDriver::AbstractLibfuzzerDriver(
 
 void AbstractLibfuzzerDriver::initJvm(const std::string &executable_path) {
   jvm_ = std::make_unique<jazzer::JVM>(executable_path);
-  if (FLAGS_hooks) {
-    jazzer::registerFuzzerCallbacks(jvm_->GetEnv());
-    CoverageTracker::Setup(jvm_->GetEnv());
-    // SignalHandler registers its own native methods
-    signal_handler_ = std::make_unique<jazzer::SignalHandler>(*jvm_);
-    signal_handler_->SetupSignalHandlers();
-  }
 }
 
 LibfuzzerDriver::LibfuzzerDriver(int *argc, char ***argv)

--- a/driver/libfuzzer_driver.h
+++ b/driver/libfuzzer_driver.h
@@ -20,7 +20,6 @@
 #include <string>
 
 #include "absl/strings/match.h"
-#include "coverage_tracker.h"
 #include "fuzz_target_runner.h"
 #include "fuzzed_data_provider.h"
 #include "jvm_tooling.h"
@@ -50,9 +49,6 @@ class AbstractLibfuzzerDriver {
   std::unique_ptr<jazzer::JVM> jvm_;
 
  private:
-  // handles clearing and reading of the coverage map
-  std::unique_ptr<jazzer::CoverageTracker> coverage_tracker_;
-
   // forwards signals caught while the JVM is running
   std::unique_ptr<jazzer::SignalHandler> signal_handler_;
 

--- a/driver/signal_handler.h
+++ b/driver/signal_handler.h
@@ -18,23 +18,12 @@
 
 #include <jni.h>
 
-#include "jvm_tooling.h"
-
 namespace jazzer {
 // SignalHandler registers handlers for signals (e.g. SIGINT) in Java and
 // notifies the driver via native callbacks when the handlers fire.
 class SignalHandler {
- private:
-  const JVM &jvm_;
-  jclass jclass_;
-  jmethodID setup_signal_handlers_method_;
-
  public:
-  // Throws std::runtime_error if the corresponding Java class and method cannot
-  // be found.
-  explicit SignalHandler(JVM &);
-
   // Set up handlers for signal in Java.
-  void SetupSignalHandlers();
+  static void Setup(JNIEnv &env);
 };
 }  // namespace jazzer


### PR DESCRIPTION
The native callbacks in the driver should be registered as early as
possible since they may already be needed during agent startup (e.g.,
if a JDK-internal class is to be instrumented).