### PR TITLE
Allow making hook target class name shade-proof

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Hook.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Hook.kt
@@ -25,7 +25,9 @@ import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 
 class Hook private constructor(hookMethod: Method, annotation: MethodHook) {
-    private val targetClassName = annotation.targetClassName
+    // Allowing arbitrary exterior whitespace in the target class name allows for an easy workaround
+    // for mangled hooks due to shading applied to hooks.
+    private val targetClassName = annotation.targetClassName.trim()
     val targetMethodName = annotation.targetMethod
     val targetMethodDescriptor = annotation.targetMethodDescriptor.takeIf { it.isNotEmpty() }
     val hookType = annotation.type


### PR DESCRIPTION
Prepending whitespace to the target class name of a hook can now be used
to work around shading applied to hooks.