### PR TITLE
Use lld only with clang on Linux

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -81,3 +81,16 @@ alias(
     name = "jazzer-api.publish",
     actual = "//agent/src/main/java/com/code_intelligence/jazzer/api:api_export.publish",
 )
+
+config_setting(
+    name = "clang",
+    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang"},
+)
+
+alias(
+    name = "clang_on_linux",
+    actual = select({
+        ":clang": "@platforms//os:linux",
+        "//conditions:default": ":clang",
+    }),
+)

--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -91,7 +91,7 @@ cc_binary(
     linkopts = [
         "-rdynamic",
     ] + select({
-        "@platforms//os:linux": ["-fuse-ld=lld"],
+        "//:clang_on_linux": ["-fuse-ld=lld"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
@@ -118,7 +118,7 @@ cc_binary(
         "-static-libsan",
         "-rdynamic",
     ] + select({
-        "@platforms//os:linux": ["-fuse-ld=lld"],
+        "//:clang_on_linux": ["-fuse-ld=lld"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],
@@ -142,7 +142,7 @@ cc_binary(
         "-fsanitize-link-c++-runtime",
         "-rdynamic",
     ] + select({
-        "@platforms//os:linux": ["-fuse-ld=lld"],
+        "//:clang_on_linux": ["-fuse-ld=lld"],
         "//conditions:default": [],
     }),
     visibility = ["//visibility:public"],

--- a/examples/src/main/native/BUILD.bazel
+++ b/examples/src/main/native/BUILD.bazel
@@ -10,7 +10,7 @@ cc_shared_library(
         "-fsanitize=fuzzer-no-link,address",
     ],
     linkopts = select({
-        "@platforms//os:linux": ["-fuse-ld=lld"],
+        "//:clang_on_linux": ["-fuse-ld=lld"],
         "//conditions:default": [],
     }),
     visibility = ["//examples:__pkg__"],
@@ -30,7 +30,7 @@ cc_shared_library(
         "-fno-sanitize-recover=all",
     ],
     linkopts = select({
-        "@platforms//os:linux": ["-fuse-ld=lld"],
+        "//:clang_on_linux": ["-fuse-ld=lld"],
         "//conditions:default": [],
     }),
     visibility = ["//examples:__pkg__"],


### PR DESCRIPTION
Restores compatibility with gcc on linux.