### PR TITLE
Print JVM stack traces on timeouts

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/ExceptionUtils.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/ExceptionUtils.kt
@@ -143,3 +143,24 @@ private fun readJavaFullFinalFlags(): String? {
             .joinToString("\n")
     }
 }
+
+fun dumpAllStackTraces() {
+    System.err.println("\nStack traces of all JVM threads:\n")
+    for ((thread, stack) in Thread.getAllStackTraces()) {
+        System.err.println(thread)
+        // Remove traces of this method and the methods it calls.
+        stack.asList()
+            .asReversed()
+            .takeWhile {
+                !(
+                    it.className == "com.code_intelligence.jazzer.runtime.ExceptionUtils" &&
+                        it.methodName == "dumpAllStackTraces"
+                    )
+            }
+            .asReversed()
+            .forEach { frame ->
+                System.err.println("\tat $frame")
+            }
+        System.err.println()
+    }
+}

--- a/driver/jvm_tooling.h
+++ b/driver/jvm_tooling.h
@@ -22,6 +22,8 @@
 
 namespace jazzer {
 
+void DumpJvmStackTraces();
+
 // JVM is a thin wrapper around JNI_CreateJavaVM and DestroyJavaVM. The JVM
 // instance is created inside the constructor with some default JNI options
 // + options which can be added to via command line flags.

--- a/driver/libfuzzer_driver.cpp
+++ b/driver/libfuzzer_driver.cpp
@@ -25,12 +25,10 @@
 
 #include "absl/strings/match.h"
 #include "absl/strings/str_format.h"
-#include "coverage_tracker.h"
-#include "driver/libfuzzer_callbacks.h"
 #include "fuzz_target_runner.h"
 #include "gflags/gflags.h"
 #include "glog/logging.h"
-#include "signal_handler.h"
+#include "jvm_tooling.h"
 
 using namespace std::string_literals;
 
@@ -64,7 +62,9 @@ extern "C" __attribute__((weak)) int __sanitizer_acquire_crash_state() {
   return true;
 }
 
-extern "C" __attribute__((weak)) void __sanitizer_print_stack_trace() {}
+extern "C" __attribute__((weak)) void __sanitizer_print_stack_trace() {
+  jazzer::DumpJvmStackTraces();
+}
 
 namespace {
 char *additional_arg;


### PR DESCRIPTION
When libFuzzer without a sanitizer times out, this prints the current stack traces of all JVM threads, e.g.:

```
==1235420== ERROR: libFuzzer: timeout after 3 seconds

Stack traces of all JVM threads:

Thread[Signal Dispatcher,9,system]

Thread[Notification Thread,9,system]

Thread[Reference Handler,10,system]
	at java.base@15.0.3/java.lang.ref.Reference.waitForReferencePendingList(Native Method)
	at java.base@15.0.3/java.lang.ref.Reference.processPendingReferences(Reference.java:241)
	at java.base@15.0.3/java.lang.ref.Reference$ReferenceHandler.run(Reference.java:213)

Thread[Finalizer,8,system]
	at java.base@15.0.3/java.lang.Object.wait(Native Method)
	at java.base@15.0.3/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:155)
	at java.base@15.0.3/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:176)
	at java.base@15.0.3/java.lang.ref.Finalizer$FinalizerThread.run(Finalizer.java:170)

Thread[main,5,main]
	at com.code_intelligence.jazzer.runtime.TraceDataFlowNativeCallbacks.traceCmpInt(Native Method)
	at app//com.example.ExampleFuzzer.fuzzerTestOneInput(ExampleFuzzer.java:28)

Thread[Common-Cleaner,8,InnocuousThreadGroup]
	at java.base@15.0.3/java.lang.Object.wait(Native Method)
	at java.base@15.0.3/java.lang.ref.ReferenceQueue.remove(ReferenceQueue.java:155)
	at java.base@15.0.3/jdk.internal.ref.CleanerImpl.run(CleanerImpl.java:148)
	at java.base@15.0.3/java.lang.Thread.run(Thread.java:832)
	at java.base@15.0.3/jdk.internal.misc.InnocuousThread.run(InnocuousThread.java:134)

SUMMARY: libFuzzer: timeout
Unexpected exit code: 70
```