### PR TITLE
Report coverage for all classes on the classpath 

### DIFF
--- a/agent/agent_shade_rules
+++ b/agent/agent_shade_rules
@@ -1,1 +1,3 @@
 rule kotlin.** com.code_intelligence.jazzer.third_party.kotlin.@1
+rule io.** com.code_intelligence.jazzer.third_party.io.@1
+rule nonapi.** com.code_intelligence.jazzer.third_party.nonapi.@1

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
@@ -17,6 +17,7 @@
 package com.code_intelligence.jazzer.agent
 
 import com.code_intelligence.jazzer.instrumentor.ClassNameGlobber
+import com.code_intelligence.jazzer.instrumentor.CoverageRecorder
 import com.code_intelligence.jazzer.instrumentor.InstrumentationType
 import com.code_intelligence.jazzer.instrumentor.loadHooks
 import com.code_intelligence.jazzer.runtime.ManifestUtils
@@ -79,6 +80,7 @@ fun premain(agentArgs: String?, instrumentation: Instrumentation) {
         argumentMap["instrumentation_includes"] ?: emptyList(),
         (argumentMap["instrumentation_excludes"] ?: emptyList()) + customHookNames
     )
+    CoverageRecorder.classNameGlobber = classNameGlobber
     val dependencyClassNameGlobber = ClassNameGlobber(
         argumentMap["custom_hook_includes"] ?: emptyList(),
         (argumentMap["custom_hook_excludes"] ?: emptyList()) + customHookNames

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
@@ -16,6 +16,7 @@
 
 package com.code_intelligence.jazzer.agent
 
+import com.code_intelligence.jazzer.instrumentor.ClassNameGlobber
 import com.code_intelligence.jazzer.instrumentor.InstrumentationType
 import com.code_intelligence.jazzer.instrumentor.loadHooks
 import com.code_intelligence.jazzer.runtime.ManifestUtils

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -15,6 +15,7 @@
 package com.code_intelligence.jazzer.agent
 
 import com.code_intelligence.jazzer.instrumentor.ClassInstrumentor
+import com.code_intelligence.jazzer.instrumentor.ClassNameGlobber
 import com.code_intelligence.jazzer.instrumentor.CoverageRecorder
 import com.code_intelligence.jazzer.instrumentor.Hook
 import com.code_intelligence.jazzer.instrumentor.InstrumentationType
@@ -23,7 +24,6 @@ import com.code_intelligence.jazzer.runtime.NativeLibHooks
 import com.code_intelligence.jazzer.runtime.TraceCmpHooks
 import com.code_intelligence.jazzer.runtime.TraceDivHooks
 import com.code_intelligence.jazzer.runtime.TraceIndirHooks
-import java.lang.IllegalArgumentException
 import java.lang.instrument.ClassFileTransformer
 import java.lang.instrument.Instrumentation
 import java.nio.file.Path
@@ -31,93 +31,6 @@ import java.security.ProtectionDomain
 import kotlin.math.roundToInt
 import kotlin.system.exitProcess
 import kotlin.time.measureTimedValue
-
-private val BASE_INCLUDED_CLASS_NAME_GLOBS = listOf(
-    "**", // everything
-)
-
-private val BASE_EXCLUDED_CLASS_NAME_GLOBS = listOf(
-    "\\[**", // array types
-    "com.code_intelligence.jazzer.**",
-    "com.sun.**", // package for Proxy objects
-    "java.**",
-    "jaz.Ter", // safe companion of the honeypot class used by sanitizers
-    "jaz.Zer", // honeypot class used by sanitizers
-    "jdk.**",
-    "kotlin.**",
-    "sun.**",
-    "javax.management.DynamicMBean", // used by ManagementFactory.getRuntimeMXBean()
-    "javax.management.NotificationEmitter", // used by ManagementFactory.getRuntimeMXBean()
-    "javax.management.NotificationBroadcaster", // used by ManagementFactory.getRuntimeMXBean()
-)
-
-class SimpleGlobMatcher(val glob: String) {
-    private enum class Type {
-        // foo.bar (matches foo.bar only)
-        FULL_MATCH,
-        // foo.** (matches foo.bar and foo.bar.baz)
-        PATH_WILDCARD_SUFFIX,
-        // foo.* (matches foo.bar, but not foo.bar.baz)
-        SEGMENT_WILDCARD_SUFFIX,
-    }
-
-    private val type: Type
-    private val prefix: String
-
-    init {
-        // Remain compatible with globs such as "\\[" that use escaping.
-        val pattern = glob.replace("\\", "")
-        when {
-            !pattern.contains('*') -> {
-                type = Type.FULL_MATCH
-                prefix = pattern
-            }
-            // Ends with "**" and contains no other '*'.
-            pattern.endsWith("**") && pattern.indexOf('*') == pattern.length - 2 -> {
-                type = Type.PATH_WILDCARD_SUFFIX
-                prefix = pattern.removeSuffix("**")
-            }
-            // Ends with "*" and contains no other '*'.
-            pattern.endsWith('*') && pattern.indexOf('*') == pattern.length - 1 -> {
-                type = Type.SEGMENT_WILDCARD_SUFFIX
-                prefix = pattern.removeSuffix("*")
-            }
-            else -> throw IllegalArgumentException(
-                "Unsupported glob pattern (only foo.bar, foo.* and foo.** are supported): $pattern"
-            )
-        }
-    }
-
-    /**
-     * Checks whether [maybeInternalClassName], which may be internal (foo/bar) or not (foo.bar), matches [glob].
-     */
-    fun matches(maybeInternalClassName: String): Boolean {
-        val className = maybeInternalClassName.replace('/', '.')
-        return when (type) {
-            Type.FULL_MATCH -> className == prefix
-            Type.PATH_WILDCARD_SUFFIX -> className.startsWith(prefix)
-            Type.SEGMENT_WILDCARD_SUFFIX -> {
-                // className starts with prefix and contains no further '.'.
-                className.startsWith(prefix) &&
-                    className.indexOf('.', startIndex = prefix.length) == -1
-            }
-        }
-    }
-}
-
-internal class ClassNameGlobber(includes: List<String>, excludes: List<String>) {
-    // If no include globs are provided, start with all classes.
-    private val includeMatchers = (if (includes.isEmpty()) BASE_INCLUDED_CLASS_NAME_GLOBS else includes)
-        .map(::SimpleGlobMatcher)
-
-    // If no include globs are provided, additionally exclude stdlib classes as well as our own classes.
-    private val excludeMatchers = (if (includes.isEmpty()) BASE_EXCLUDED_CLASS_NAME_GLOBS + excludes else excludes)
-        .map(::SimpleGlobMatcher)
-
-    fun includes(className: String): Boolean {
-        return includeMatchers.any { it.matches(className) } && excludeMatchers.none { it.matches(className) }
-    }
-}
 
 internal class RuntimeInstrumentor(
     private val instrumentation: Instrumentation,

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
@@ -15,6 +15,7 @@ kt_jvm_library(
         "//agent/src/main/java/com/code_intelligence/jazzer/generated:JavaNoThrowMethods",
         "//agent/src/main/java/com/code_intelligence/jazzer/runtime",
         "//agent/src/main/java/com/code_intelligence/jazzer/utils",
+        "@com_github_classgraph_classgraph//:classgraph",
         "@com_github_jetbrains_kotlin//:kotlin-reflect",
     ],
 )

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/ClassNameGlobber.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/ClassNameGlobber.kt
@@ -1,0 +1,102 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.instrumentor
+
+import java.lang.IllegalArgumentException
+
+private val BASE_INCLUDED_CLASS_NAME_GLOBS = listOf(
+    "**", // everything
+)
+
+private val BASE_EXCLUDED_CLASS_NAME_GLOBS = listOf(
+    "\\[**", // array types
+    "com.code_intelligence.jazzer.**",
+    "com.sun.**", // package for Proxy objects
+    "java.**",
+    "javax.**",
+    "jaz.Ter", // safe companion of the honeypot class used by sanitizers
+    "jaz.Zer", // honeypot class used by sanitizers
+    "jdk.**",
+    "kotlin.**",
+    "sun.**",
+)
+
+class ClassNameGlobber(includes: List<String>, excludes: List<String>) {
+    // If no include globs are provided, start with all classes.
+    private val includeMatchers = (if (includes.isEmpty()) BASE_INCLUDED_CLASS_NAME_GLOBS else includes)
+        .map(::SimpleGlobMatcher)
+
+    // If no include globs are provided, additionally exclude stdlib classes as well as our own classes.
+    private val excludeMatchers = (if (includes.isEmpty()) BASE_EXCLUDED_CLASS_NAME_GLOBS + excludes else excludes)
+        .map(::SimpleGlobMatcher)
+
+    fun includes(className: String): Boolean {
+        return includeMatchers.any { it.matches(className) } && excludeMatchers.none { it.matches(className) }
+    }
+}
+
+private class SimpleGlobMatcher(val glob: String) {
+    private enum class Type {
+        // foo.bar (matches foo.bar only)
+        FULL_MATCH,
+        // foo.** (matches foo.bar and foo.bar.baz)
+        PATH_WILDCARD_SUFFIX,
+        // foo.* (matches foo.bar, but not foo.bar.baz)
+        SEGMENT_WILDCARD_SUFFIX,
+    }
+
+    private val type: Type
+    private val prefix: String
+
+    init {
+        // Remain compatible with globs such as "\\[" that use escaping.
+        val pattern = glob.replace("\\", "")
+        when {
+            !pattern.contains('*') -> {
+                type = Type.FULL_MATCH
+                prefix = pattern
+            }
+            // Ends with "**" and contains no other '*'.
+            pattern.endsWith("**") && pattern.indexOf('*') == pattern.length - 2 -> {
+                type = Type.PATH_WILDCARD_SUFFIX
+                prefix = pattern.removeSuffix("**")
+            }
+            // Ends with "*" and contains no other '*'.
+            pattern.endsWith('*') && pattern.indexOf('*') == pattern.length - 1 -> {
+                type = Type.SEGMENT_WILDCARD_SUFFIX
+                prefix = pattern.removeSuffix("*")
+            }
+            else -> throw IllegalArgumentException(
+                "Unsupported glob pattern (only foo.bar, foo.* and foo.** are supported): $pattern"
+            )
+        }
+    }
+
+    /**
+     * Checks whether [maybeInternalClassName], which may be internal (foo/bar) or not (foo.bar), matches [glob].
+     */
+    fun matches(maybeInternalClassName: String): Boolean {
+        val className = maybeInternalClassName.replace('/', '.')
+        return when (type) {
+            Type.FULL_MATCH -> className == prefix
+            Type.PATH_WILDCARD_SUFFIX -> className.startsWith(prefix)
+            Type.SEGMENT_WILDCARD_SUFFIX -> {
+                // className starts with prefix and contains no further '.'.
+                className.startsWith(prefix) &&
+                    className.indexOf('.', startIndex = prefix.length) == -1
+            }
+        }
+    }
+}

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/CoverageRecorder.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/CoverageRecorder.kt
@@ -23,6 +23,7 @@ import com.code_intelligence.jazzer.third_party.jacoco.core.data.ExecutionDataWr
 import com.code_intelligence.jazzer.third_party.jacoco.core.data.SessionInfo
 import com.code_intelligence.jazzer.third_party.jacoco.core.data.SessionInfoStore
 import com.code_intelligence.jazzer.third_party.jacoco.core.internal.data.CRC64
+import io.github.classgraph.ClassGraph
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.time.Instant
@@ -32,10 +33,11 @@ private data class InstrumentedClassInfo(
     val classId: Long,
     val initialEdgeId: Int,
     val nextEdgeId: Int,
-    val bytecode: ByteArray
+    val bytecode: ByteArray,
 )
 
 object CoverageRecorder {
+    var classNameGlobber = ClassNameGlobber(emptyList(), emptyList())
     private val instrumentedClassInfo = mutableMapOf<String, InstrumentedClassInfo>()
     private var startTimestamp: Instant? = null
     private val additionalCoverage = mutableSetOf<Int>()
@@ -150,6 +152,7 @@ object CoverageRecorder {
     private fun analyzeCoverage(coveredIds: Set<Int>): CoverageBuilder? {
         return try {
             val coverage = CoverageBuilder()
+            analyzeAllUncoveredClasses(coverage)
             val rawExecutionData = dumpJacocoCoverage(coveredIds) ?: return null
             val executionDataStore = ExecutionDataStore()
             val sessionInfoStore = SessionInfoStore()
@@ -173,5 +176,45 @@ object CoverageRecorder {
             e.printStackTrace()
             null
         }
+    }
+
+    /**
+     * Traverses the entire classpath and analyzes all uncovered classes that match the include/exclude pattern.
+     * The returned [CoverageBuilder] will report coverage information for *all* classes on the classpath, not just
+     * those that were loaded while the fuzzer ran.
+     */
+    private fun analyzeAllUncoveredClasses(coverage: CoverageBuilder): CoverageBuilder {
+        val coveredClassNames = instrumentedClassInfo
+            .keys
+            .asSequence()
+            .map { it.replace('/', '.') }
+            .toSet()
+        val emptyExecutionDataStore = ExecutionDataStore()
+        ClassGraph()
+            .enableClassInfo()
+            .ignoreClassVisibility()
+            .rejectPackages(
+                // Always exclude Jazzer-internal packages (including ClassGraph itself) from coverage reports. Classes
+                // from the Java standard library are never traversed.
+                "com.code_intelligence.jazzer.*",
+                "jaz",
+            )
+            .scan().use { result ->
+                result.allClasses
+                    .asSequence()
+                    .filter { classInfo -> classNameGlobber.includes(classInfo.name) }
+                    .filterNot { classInfo -> classInfo.name in coveredClassNames }
+                    .forEach { classInfo ->
+                        classInfo.resource.use { resource ->
+                            EdgeCoverageInstrumentor(0).analyze(
+                                emptyExecutionDataStore,
+                                coverage,
+                                resource.load(),
+                                classInfo.name.replace('.', '/')
+                            )
+                        }
+                    }
+            }
+        return coverage
     }
 }

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -90,6 +90,15 @@ def jazzer_dependencies():
 
     maybe(
         http_archive,
+        build_file = "@jazzer//third_party:classgraph.BUILD",
+        name = "com_github_classgraph_classgraph",
+        sha256 = "2b7c3930f007e4acca8a50a26957b09a55b2fabd23ed00715516a114ae3f1c1e",
+        strip_prefix = "classgraph-classgraph-4.8.116",
+        url = "https://github.com/classgraph/classgraph/archive/refs/tags/classgraph-4.8.116.tar.gz",
+    )
+
+    maybe(
+        http_archive,
         build_file = "@jazzer//third_party:asm.BUILD",
         name = "jazzer_ow2_asm",
         sha256 = "7b596cc584b241619911e99c5c96366fccd533b1a50b8720c151c2f74b5915e3",

--- a/third_party/classgraph.BUILD
+++ b/third_party/classgraph.BUILD
@@ -1,0 +1,10 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "classgraph",
+    srcs = glob([
+        "src/main/java/io/github/classgraph/**/*.java",
+        "src/main/java/nonapi/io/github/classgraph/**/*.java",
+    ]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
Using the (very fast) classpath traverser ClassPath, we can generate
coverage data for *all* classes on the classpath rather than just those
that were loaded during the fuzzing run.