### PR TITLE
Update and remove dependencies

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain")
 load("@io_bazel_rules_kotlin//kotlin/internal:opts.bzl", "kt_javac_options", "kt_kotlinc_options")
+load("@rules_jvm_external//:defs.bzl", "java_export")
+load("//:maven.bzl", "JAZZER_API_COORDINATES")
 
 exports_files(["LICENSE"])
 
@@ -57,13 +59,6 @@ exports_files([
     "jazzer-api.pom",
 ])
 
-# To publish a new release to Maven, run:
-# bazel run --config=maven --define "maven_user=..." --define "maven_password=..." --define gpg_sign=true //:jazzer-api.publish
-alias(
-    name = "jazzer-api.publish",
-    actual = "//agent/src/main/java/com/code_intelligence/jazzer/api:api_export.publish",
-)
-
 config_setting(
     name = "clang",
     flag_values = {"@bazel_tools//tools/cpp:compiler": "clang"},
@@ -85,4 +80,15 @@ platform(
         "@platforms//os:windows",
         "@bazel_tools//tools/cpp:clang-cl",
     ],
+)
+
+# To publish a new release of the Jazzer API to Maven, run:
+# bazel run --config=maven --define "maven_user=..." --define "maven_password=..." --define gpg_sign=true //:api.publish
+# Build //:api-docs.jar to generate javadocs for the API.
+java_export(
+    name = "api",
+    maven_coordinates = JAZZER_API_COORDINATES,
+    pom_template = "//:jazzer-api.pom",
+    visibility = ["//visibility:public"],
+    runtime_deps = ["//agent/src/main/java/com/code_intelligence/jazzer/api"],
 )

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -51,6 +51,13 @@ http_archive(
 )
 
 http_archive(
+    name = "rules_jvm_external",
+    sha256 = "f36441aa876c4f6427bfb2d1f2d723b48e9d930b62662bf723ddfb8fc80f0140",
+    strip_prefix = "rules_jvm_external-4.1",
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.1.zip",
+)
+
+http_archive(
     name = "libjpeg_turbo",
     build_file = "//third_party:libjpeg_turbo.BUILD",
     sha256 = "6a965adb02ad898b2ae48214244618fe342baea79db97157fdc70d8844ac6f09",

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@bazel_common//tools/javadoc:javadoc.bzl", "javadoc_library")
-load("@rules_jvm_external//:defs.bzl", "java_export")
+load("@rules_jvm_external//:defs.bzl", "javadoc", "java_export")
 load("//:maven.bzl", "JAZZER_API_COORDINATES")
 
 java_library(
@@ -8,9 +7,9 @@ java_library(
     visibility = ["//visibility:public"],
 )
 
-javadoc_library(
+javadoc(
     name = "api_javadoc",
-    srcs = glob(["*.java"]),
+    deps = [":api"],
 )
 
 java_export(

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/BUILD.bazel
@@ -1,21 +1,5 @@
-load("@rules_jvm_external//:defs.bzl", "javadoc", "java_export")
-load("//:maven.bzl", "JAZZER_API_COORDINATES")
-
 java_library(
     name = "api",
     srcs = glob(["*.java"]),
-    visibility = ["//visibility:public"],
-)
-
-javadoc(
-    name = "api_javadoc",
-    deps = [":api"],
-)
-
-java_export(
-    name = "api_export",
-    srcs = glob(["*.java"]),
-    maven_coordinates = JAZZER_API_COORDINATES,
-    pom_template = "//:jazzer-api.pom",
     visibility = ["//visibility:public"],
 )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -31,11 +31,10 @@ def jazzer_dependencies():
     maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "37fbe6e229f28dfda55d9c9a305235b882a1cf6cff746ce448b8b870ecfdf620",
-        strip_prefix = "bazel-skylib-fd75066f159234265efb8f838b056be5a2e00a59",
+        sha256 = "c6966ec828da198c5d9adbaa94c05e3a1c7f21bd012a0b29ba8ddbccb2c93b0d",
         urls = [
-            "https://github.com/bazelbuild/bazel-skylib/archive/fd75066f159234265efb8f838b056be5a2e00a59.tar.gz",
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/fd75066f159234265efb8f838b056be5a2e00a59.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.1.1/bazel-skylib-1.1.1.tar.gz",
         ],
     )
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -30,14 +30,6 @@ def jazzer_dependencies():
 
     maybe(
         http_archive,
-        name = "bazel_common",
-        sha256 = "8b6aebdc095c8448b2f6a72bb8eae4a563891467e2d20c943f21940b1c444e38",
-        strip_prefix = "bazel-common-3d0e5005cfcbee836e31695d4ab91b5328ccc506",
-        url = "https://github.com/google/bazel-common/archive/3d0e5005cfcbee836e31695d4ab91b5328ccc506.zip",
-    )
-
-    maybe(
-        http_archive,
         name = "bazel_skylib",
         sha256 = "37fbe6e229f28dfda55d9c9a305235b882a1cf6cff746ce448b8b870ecfdf620",
         strip_prefix = "bazel-skylib-fd75066f159234265efb8f838b056be5a2e00a59",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -41,14 +41,6 @@ def jazzer_dependencies():
 
     maybe(
         http_archive,
-        name = "rules_jvm_external",
-        sha256 = "f36441aa876c4f6427bfb2d1f2d723b48e9d930b62662bf723ddfb8fc80f0140",
-        strip_prefix = "rules_jvm_external-4.1",
-        url = "https://github.com/bazelbuild/rules_jvm_external/archive/4.1.zip",
-    )
-
-    maybe(
-        http_archive,
         name = "io_bazel_rules_kotlin",
         sha256 = "6cbd4e5768bdfae1598662e40272729ec9ece8b7bded8f0d2c81c8ff96dc139d",
         url = "https://github.com/bazelbuild/rules_kotlin/releases/download/v1.5.0-beta-4/rules_kotlin_release.tgz",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -83,9 +83,9 @@ def jazzer_dependencies():
         http_archive,
         build_file = "@jazzer//third_party:classgraph.BUILD",
         name = "com_github_classgraph_classgraph",
-        sha256 = "c1804c9c657b0c6781af694443e140efc8178b8f2469d59f18bf1e6cfaafc284",
-        strip_prefix = "classgraph-classgraph-4.8.126",
-        url = "https://github.com/classgraph/classgraph/archive/refs/tags/classgraph-4.8.126.tar.gz",
+        sha256 = "535159d80c163d5b4d025c402b4562c92ed2d6d963db8c6c5255c0eb2c4e9f39",
+        strip_prefix = "classgraph-classgraph-4.8.128",
+        url = "https://github.com/classgraph/classgraph/archive/refs/tags/classgraph-4.8.128.tar.gz",
     )
 
     maybe(


### PR DESCRIPTION
Ideally, all our prod dependencies in `repositories.bzl` would link to stable release archives, which won't change even when GitHub updates their archiver. But most dependencies don't offer such archives and `git_repository` either emits warnings about missing `shallow_since` or risks breaking builds due to https://github.com/bazelbuild/bazel/issues/10292. No good solution here, so switch to releases where possible and leave the rest as is.