### PR TITLE
Run CI tests against OpenJDK 17

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -15,7 +15,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        jdk: [8, 15]
+        jdk: [8, 15, 17]
+        exclude:
+          # Only test against JDK 15 with Ubuntu since this is what OSS-Fuzz runs on.
+          - os: macos-latest
+            jdk: 15
+          - os: windows-latest
+            jdk: 15
         include:
           - os: ubuntu-latest
             arch: "linux"


### PR DESCRIPTION
Now that 17 is the most recent LTS version, we should test against it.
We keep a single run of ubuntu-latest/JDK 15 to cover OSS-Fuzz.