### PR TITLE
Move java_export to separate package

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,8 +1,6 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain")
 load("@io_bazel_rules_kotlin//kotlin/internal:opts.bzl", "kt_javac_options", "kt_kotlinc_options")
-load("@rules_jvm_external//:defs.bzl", "java_export")
-load("//:maven.bzl", "JAZZER_API_COORDINATES")
 
 exports_files(["LICENSE"])
 
@@ -80,15 +78,4 @@ platform(
         "@platforms//os:windows",
         "@bazel_tools//tools/cpp:clang-cl",
     ],
-)
-
-# To publish a new release of the Jazzer API to Maven, run:
-# bazel run --config=maven --define "maven_user=..." --define "maven_password=..." --define gpg_sign=true //:api.publish
-# Build //:api-docs.jar to generate javadocs for the API.
-java_export(
-    name = "api",
-    maven_coordinates = JAZZER_API_COORDINATES,
-    pom_template = "//:jazzer-api.pom",
-    visibility = ["//visibility:public"],
-    runtime_deps = ["//agent/src/main/java/com/code_intelligence/jazzer/api"],
 )

--- a/deploy/BUILD.bazel
+++ b/deploy/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_jvm_external//:defs.bzl", "java_export")
+load("//:maven.bzl", "JAZZER_API_COORDINATES")
+
+# To publish a new release of the Jazzer API to Maven, run:
+# bazel run --config=maven --define "maven_user=..." --define "maven_password=..." --define gpg_sign=true //:api.publish
+# Build //:api-docs.jar to generate javadocs for the API.
+java_export(
+    name = "api",
+    maven_coordinates = JAZZER_API_COORDINATES,
+    pom_template = "//:jazzer-api.pom",
+    visibility = ["//visibility:public"],
+    runtime_deps = ["//agent/src/main/java/com/code_intelligence/jazzer/api"],
+)

--- a/format.sh
+++ b/format.sh
@@ -11,4 +11,4 @@ buildifier -r .
 
 # Licence headers
 # go get -u github.com/google/addlicense
-addlicense -c "Code Intelligence GmbH" agent/ bazel/ docker/ driver/ examples/ sanitizers/ *.bzl
+addlicense -c "Code Intelligence GmbH" agent/ bazel/ deploy/ docker/ driver/ examples/ sanitizers/ *.bzl


### PR DESCRIPTION
Since repositories.bzl no longer declares rules_jvm_external, depending
Bazel projects otherwise fail to parse the top-level BUILD.bazel.