### PR TITLE
Make `//:clang_on_linux` public

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -69,6 +69,7 @@ alias(
         ":clang": "@platforms//os:linux",
         "//conditions:default": ":clang",
     }),
+    visibility = ["//visibility:public"],
 )
 
 platform(


### PR DESCRIPTION
Fixes breakage with future incompatible changes.