### PR TITLE
Make trampoline smaller

### DIFF
--- a/driver/sanitizer_hooks_with_pc.h
+++ b/driver/sanitizer_hooks_with_pc.h
@@ -26,8 +26,7 @@
 // which it records detailed information about the result of compares and
 // associates it with particular coverage locations.
 //
-// Note: Only the lower 12 bits of the caller_pc argument are used by
-// libFuzzer.
+// Note: Only the lower 9 bits of the caller_pc argument are used by libFuzzer.
 extern "C" {
 void __sanitizer_cov_trace_cmp4_with_pc(void *caller_pc, uint32_t arg1,
                                         uint32_t arg2);

--- a/driver/sanitizer_hooks_with_pc_test.cpp
+++ b/driver/sanitizer_hooks_with_pc_test.cpp
@@ -21,7 +21,7 @@
 
 #include "gtest/gtest.h"
 
-static std::vector<uint16_t> gCoverageMap(4096);
+static std::vector<uint16_t> gCoverageMap(512);
 
 inline void __attribute__((always_inline)) RecordCoverage() {
   auto return_address =
@@ -65,7 +65,7 @@ bool HasSingleCoveredPc() {
 
 std::string PrettyPrintCoverage() {
   std::ostringstream out;
-  std::size_t break_after = sqrt(gCoverageMap.size());
+  std::size_t break_after = 16;
   out << "Coverage:" << std::endl;
   for (uintptr_t i = 0; i < gCoverageMap.size(); i++) {
     out << (gCoverageMap[i] ? "X" : "_");


### PR DESCRIPTION
Since libFuzzer's integer compare hooks only feed the lowest 9 bits of
the address of the compare instruction into the value profile map, we
can reduce the size of the trampoline from 2^12 to 2^9.