### PR TITLE
Make crash-reproducers compile properly

### DIFF
--- a/driver/java_reproducer_templates.h
+++ b/driver/java_reproducer_templates.h
@@ -34,7 +34,7 @@ public class Crash_$0 {
             try {
                 Method fuzzerInitialize = $2.class.getMethod("fuzzerInitialize", String[].class);
                 fuzzerInitialize.invoke(null, (Object) args);
-            } catch (NoSuchMethodException ignored) {
+            } catch (NoSuchMethodException ignored1) {
             } catch (IllegalAccessException | InvocationTargetException e) {
                 e.printStackTrace();
                 System.exit(1);


### PR DESCRIPTION
There is a nested catch in the crash-template which uses the 
same name "ignored" for the caught Exception as the catch on 
the outer level. 

This does not compile in Java and thus currently requires changes to crash-reproducers.

When using a unique name, this is resolved.