### PR TITLE
Clean up CI setup

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -29,10 +29,6 @@ build:windows --features=static_link_msvcrt
 test:windows --noincompatible_strict_action_env
 run:windows --noincompatible_strict_action_env
 
-# macOS
-# Always use the toolchain as UBSan produces linker errors with Apple LLVM 13.
-build:macos --config=toolchain
-
 # Toolchain
 build:toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux,@llvm_toolchain//:cc-toolchain-x86_64-darwin
 build:toolchain --//third_party:toolchain

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
             arch: "linux"
             bazel_args: "--config=toolchain"
           - os: macos-10.15
-            arch: "darwin"
+            arch: "macos-x86_64"
             bazel_args: "--config=toolchain"
           - os: windows-2016
             arch: "windows"

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -14,11 +14,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-10.15, windows-latest]
         jdk: [8, 15, 17]
         exclude:
-          # Only test against JDK 15 with Ubuntu since this is what OSS-Fuzz runs on.
-          - os: macos-latest
+          # Only test against JDK 15 with Ubuntu since this is what OSS-Fuzz uses.
+          - os: macos-10.15
             jdk: 15
           - os: windows-latest
             jdk: 15
@@ -26,8 +26,10 @@ jobs:
           - os: ubuntu-latest
             arch: "linux"
             cache: "/home/runner/.cache/bazel-disk"
-          - os: macos-latest
-            arch: "darwin"
+          - os: macos-10.15
+            arch: "macos-x86_64"
+            # Always use the toolchain as UBSan produces linker errors with Apple LLVM 13.
+            bazel_args: "--config=toolchain"
             cache: "/private/var/tmp/bazel-disk"
           - os: windows-latest
             arch: "windows"
@@ -48,10 +50,10 @@ jobs:
           key: bazel-disk-cache-${{ matrix.arch }}-${{ matrix.jdk }}
 
       - name: Build
-        run: bazelisk build --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }} --disk_cache=${{ matrix.cache }} --java_runtime_version=localjdk_${{ matrix.jdk }} //...
+        run: bazelisk build --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }} --disk_cache=${{ matrix.cache }} --java_runtime_version=localjdk_${{ matrix.jdk }} ${{ matrix.bazel_args }} //...
 
       - name: Test
-        run: bazelisk test --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }} --disk_cache=${{ matrix.cache }} --java_runtime_version=localjdk_${{ matrix.jdk }} //...
+        run: bazelisk test --config=ci --remote_header=x-buildbuddy-api-key=${{ secrets.BUILDBUDDY_API_KEY }} --disk_cache=${{ matrix.cache }} --java_runtime_version=localjdk_${{ matrix.jdk }} ${{ matrix.bazel_args }} //...
 
       - name: Upload test logs
         if: always()


### PR DESCRIPTION
* Explicitly use macos-10.15 instead of macos-latest and reflect the
  architecture in the arch key.
* Move the toolchain declaration into the CI so that local users on
  macOS can use their local setup. Apple LLVM 13 may break us, but
  other versions as well as mainline LLVM should work.
* Make the Ubuntu JDK 15 run an include rather than an exclude.