### PR TITLE
Fix failure with --config=toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -30,7 +30,7 @@ test:windows --noincompatible_strict_action_env
 run:windows --noincompatible_strict_action_env
 
 # Toolchain
-build:toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux,@llvm_toolchain//:cc-toolchain-x86_64-darwin
+# Since the toolchain is conditional on OS and architecture, set it on the particular GitHub Action.
 build:toolchain --//third_party:toolchain
 
 # CI tests (not using the toolchain to test OSS-Fuzz & local compatibility)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
         include:
           - os: ubuntu-latest
             arch: "linux"
-            bazel_args: "--config=toolchain"
+            bazel_args: "--config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux"
           - os: macos-10.15
             arch: "macos-x86_64"
-            bazel_args: "--config=toolchain"
+            bazel_args: "--config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-darwin"
           - os: windows-2016
             arch: "windows"
             bazel_args: ""

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -29,7 +29,7 @@ jobs:
           - os: macos-11
             arch: "macos-x86_64"
             # Always use the toolchain as UBSan produces linker errors with Apple LLVM 13.
-            bazel_args: "--config=toolchain"
+            bazel_args: "--config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-darwin"
             cache: "/private/var/tmp/bazel-disk"
           - os: windows-latest
             arch: "windows"

--- a/docker/jazzer/Dockerfile
+++ b/docker/jazzer/Dockerfile
@@ -24,7 +24,8 @@ RUN git clone --depth=1 https://github.com/CodeIntelligenceTesting/jazzer.git &&
     touch /usr/bin/ld && \
     touch /usr/bin/ld.gold && \
     BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
-    ./bazelisk-linux-amd64 build --config=toolchain //agent:jazzer_agent_deploy.jar //driver:jazzer_driver
+    ./bazelisk-linux-amd64 build --config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux \
+      //agent:jazzer_agent_deploy.jar //driver:jazzer_driver
 
 FROM gcr.io/distroless/java
 


### PR DESCRIPTION
Since our toolchain is loaded dynamically depending on the OS and
architecture, we can't have a static --extra_toolchains in our .bazelrc.
Instead, enable the toolchains in the specific GitHub Actions.

Fixes #260.