### PR TITLE
Fix default method recording

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
@@ -5,7 +5,10 @@ java_library(
     srcs = [
         "FuzzedDataProviderImpl.java",
     ],
-    visibility = ["//agent/src/main/java/com/code_intelligence/jazzer/replay:__pkg__"],
+    visibility = [
+        "//agent/src/main/java/com/code_intelligence/jazzer/replay:__pkg__",
+        "//agent/src/test/java/com/code_intelligence/jazzer/runtime:__pkg__",
+    ],
     deps = [
         "//agent/src/main/java/com/code_intelligence/jazzer/api",
     ],

--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/RecordingFuzzedDataProvider.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/RecordingFuzzedDataProvider.java
@@ -26,39 +26,32 @@ import java.util.Base64;
 
 // Wraps the native FuzzedDataProviderImpl and serializes all its return values
 // into a Base64-encoded string.
-final class RecordingFuzzedDataProvider implements InvocationHandler {
-  private final FuzzedDataProvider target = new FuzzedDataProviderImpl();
+final class RecordingFuzzedDataProvider implements FuzzedDataProvider {
+  private final FuzzedDataProvider target;
   private final ArrayList<Object> recordedReplies = new ArrayList<>();
 
-  private RecordingFuzzedDataProvider() {}
+  private RecordingFuzzedDataProvider(FuzzedDataProvider target) {
+    this.target = target;
+  }
 
   // Called from native code.
   public static FuzzedDataProvider makeFuzzedDataProviderProxy() {
-    return (FuzzedDataProvider) Proxy.newProxyInstance(
-        RecordingFuzzedDataProvider.class.getClassLoader(), new Class[] {FuzzedDataProvider.class},
-        new RecordingFuzzedDataProvider());
+    return makeFuzzedDataProviderProxy(new FuzzedDataProviderImpl());
+  }
+
+  static FuzzedDataProvider makeFuzzedDataProviderProxy(FuzzedDataProvider target) {
+    return new RecordingFuzzedDataProvider(target);
   }
 
   // Called from native code.
   public static String serializeFuzzedDataProviderProxy(FuzzedDataProvider proxy)
       throws IOException {
-    return ((RecordingFuzzedDataProvider) Proxy.getInvocationHandler(proxy)).serialize();
+    return ((RecordingFuzzedDataProvider) proxy).serialize();
   }
 
-  private Object recordAndReturn(Object object) {
+  private <T> T recordAndReturn(T object) {
     recordedReplies.add(object);
     return object;
-  }
-
-  @Override
-  public Object invoke(Object object, Method method, Object[] args) throws Throwable {
-    if (method.isDefault()) {
-      // Default methods in FuzzedDataProvider are implemented in Java and
-      // don't need to be recorded.
-      return method.invoke(target, args);
-    } else {
-      return recordAndReturn(method.invoke(target, args));
-    }
   }
 
   private String serialize() throws IOException {
@@ -70,5 +63,160 @@ final class RecordingFuzzedDataProvider implements InvocationHandler {
       rawOut = byteStream.toByteArray();
     }
     return Base64.getEncoder().encodeToString(rawOut);
+  }
+
+  @Override
+  public boolean consumeBoolean() {
+    return recordAndReturn(target.consumeBoolean());
+  }
+
+  @Override
+  public boolean[] consumeBooleans(int maxLength) {
+    return recordAndReturn(target.consumeBooleans(maxLength));
+  }
+
+  @Override
+  public byte consumeByte() {
+    return recordAndReturn(target.consumeByte());
+  }
+
+  @Override
+  public byte consumeByte(byte min, byte max) {
+    return recordAndReturn(target.consumeByte(min, max));
+  }
+
+  @Override
+  public byte[] consumeBytes(int maxLength) {
+    return recordAndReturn(target.consumeBytes(maxLength));
+  }
+
+  @Override
+  public byte[] consumeRemainingAsBytes() {
+    return recordAndReturn(target.consumeRemainingAsBytes());
+  }
+
+  @Override
+  public short consumeShort() {
+    return recordAndReturn(target.consumeShort());
+  }
+
+  @Override
+  public short consumeShort(short min, short max) {
+    return recordAndReturn(target.consumeShort(min, max));
+  }
+
+  @Override
+  public short[] consumeShorts(int maxLength) {
+    return recordAndReturn(target.consumeShorts(maxLength));
+  }
+
+  @Override
+  public int consumeInt() {
+    return recordAndReturn(target.consumeInt());
+  }
+
+  @Override
+  public int consumeInt(int min, int max) {
+    return recordAndReturn(target.consumeInt(min, max));
+  }
+
+  @Override
+  public int[] consumeInts(int maxLength) {
+    return recordAndReturn(target.consumeInts(maxLength));
+  }
+
+  @Override
+  public long consumeLong() {
+    return recordAndReturn(target.consumeLong());
+  }
+
+  @Override
+  public long consumeLong(long min, long max) {
+    return recordAndReturn(target.consumeLong(min, max));
+  }
+
+  @Override
+  public long[] consumeLongs(int maxLength) {
+    return recordAndReturn(target.consumeLongs(maxLength));
+  }
+
+  @Override
+  public float consumeFloat() {
+    return recordAndReturn(target.consumeFloat());
+  }
+
+  @Override
+  public float consumeRegularFloat() {
+    return recordAndReturn(target.consumeRegularFloat());
+  }
+
+  @Override
+  public float consumeRegularFloat(float min, float max) {
+    return recordAndReturn(target.consumeRegularFloat(min, max));
+  }
+
+  @Override
+  public float consumeProbabilityFloat() {
+    return recordAndReturn(target.consumeProbabilityFloat());
+  }
+
+  @Override
+  public double consumeDouble() {
+    return recordAndReturn(target.consumeDouble());
+  }
+
+  @Override
+  public double consumeRegularDouble() {
+    return recordAndReturn(target.consumeRegularDouble());
+  }
+
+  @Override
+  public double consumeRegularDouble(double min, double max) {
+    return recordAndReturn(target.consumeRegularDouble(min, max));
+  }
+
+  @Override
+  public double consumeProbabilityDouble() {
+    return recordAndReturn(target.consumeProbabilityDouble());
+  }
+
+  @Override
+  public char consumeChar() {
+    return recordAndReturn(target.consumeChar());
+  }
+
+  @Override
+  public char consumeChar(char min, char max) {
+    return recordAndReturn(target.consumeChar(min, max));
+  }
+
+  @Override
+  public char consumeCharNoSurrogates() {
+    return recordAndReturn(target.consumeCharNoSurrogates());
+  }
+
+  @Override
+  public String consumeString(int maxLength) {
+    return recordAndReturn(target.consumeString(maxLength));
+  }
+
+  @Override
+  public String consumeRemainingAsString() {
+    return recordAndReturn(target.consumeRemainingAsString());
+  }
+
+  @Override
+  public String consumeAsciiString(int maxLength) {
+    return recordAndReturn(target.consumeAsciiString(maxLength));
+  }
+
+  @Override
+  public String consumeRemainingAsAsciiString() {
+    return recordAndReturn(target.consumeRemainingAsAsciiString());
+  }
+
+  @Override
+  public int remainingBytes() {
+    return recordAndReturn(target.remainingBytes());
   }
 }

--- a/agent/src/test/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
+++ b/agent/src/test/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
@@ -1,0 +1,12 @@
+java_test(
+    name = "RecordingFuzzedDataProviderTest",
+    srcs = [
+        "RecordingFuzzedDataProviderTest.java",
+    ],
+    deps = [
+        "//agent/src/main/java/com/code_intelligence/jazzer/api",
+        "//agent/src/main/java/com/code_intelligence/jazzer/runtime",
+        "//agent/src/main/java/com/code_intelligence/jazzer/runtime:fuzzed_data_provider",
+        "@maven//:junit_junit",
+    ],
+)

--- a/agent/src/test/java/com/code_intelligence/jazzer/runtime/RecordingFuzzedDataProviderTest.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/runtime/RecordingFuzzedDataProviderTest.java
@@ -1,0 +1,214 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.runtime;
+
+import com.code_intelligence.jazzer.api.CannedFuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RecordingFuzzedDataProviderTest {
+  @Test
+  public void testRecordingFuzzedDataProvider() throws IOException {
+    FuzzedDataProvider mockData = new MockFuzzedDataProvider();
+    String referenceResult = sampleFuzzTarget(mockData);
+
+    FuzzedDataProvider recordingMockData =
+        RecordingFuzzedDataProvider.makeFuzzedDataProviderProxy(mockData);
+    Assert.assertEquals(referenceResult, sampleFuzzTarget(recordingMockData));
+
+    String cannedMockDataString =
+        RecordingFuzzedDataProvider.serializeFuzzedDataProviderProxy(recordingMockData);
+    FuzzedDataProvider cannedMockData = new CannedFuzzedDataProvider(cannedMockDataString);
+    Assert.assertEquals(referenceResult, sampleFuzzTarget(cannedMockData));
+  }
+
+  private String sampleFuzzTarget(FuzzedDataProvider data) {
+    StringBuilder result = new StringBuilder();
+    result.append(data.consumeString(10));
+    int[] ints = data.consumeInts(5);
+    result.append(Arrays.stream(ints).mapToObj(Integer::toString).collect(Collectors.joining(",")));
+    result.append(data.pickValue(ints));
+    result.append(data.consumeString(20));
+    result.append(data.pickValues(Arrays.stream(ints).boxed().collect(Collectors.toSet()), 5)
+                      .stream()
+                      .map(Integer::toHexString)
+                      .collect(Collectors.joining(",")));
+    result.append(data.remainingBytes());
+    return result.toString();
+  }
+
+  private static final class MockFuzzedDataProvider extends FuzzedDataProviderImpl {
+    @Override
+    public boolean consumeBoolean() {
+      return true;
+    }
+
+    @Override
+    public boolean[] consumeBooleans(int maxLength) {
+      return new boolean[] {false, true};
+    }
+
+    @Override
+    public byte consumeByte() {
+      return 2;
+    }
+
+    @Override
+    public byte consumeByte(byte min, byte max) {
+      return max;
+    }
+
+    @Override
+    public short consumeShort() {
+      return 2;
+    }
+
+    @Override
+    public short consumeShort(short min, short max) {
+      return min;
+    }
+
+    @Override
+    public short[] consumeShorts(int maxLength) {
+      return new short[] {2, 4, 7};
+    }
+
+    @Override
+    public int consumeInt() {
+      return 5;
+    }
+
+    @Override
+    public int consumeInt(int min, int max) {
+      return max;
+    }
+
+    @Override
+    public int[] consumeInts(int maxLength) {
+      return IntStream.range(0, maxLength).toArray();
+    }
+
+    @Override
+    public long consumeLong() {
+      return 42;
+    }
+
+    @Override
+    public long consumeLong(long min, long max) {
+      return min;
+    }
+
+    @Override
+    public long[] consumeLongs(int maxLength) {
+      return LongStream.range(0, maxLength).toArray();
+    }
+
+    @Override
+    public float consumeFloat() {
+      return Float.NaN;
+    }
+
+    @Override
+    public float consumeRegularFloat() {
+      return 0.3f;
+    }
+
+    @Override
+    public float consumeRegularFloat(float min, float max) {
+      return min;
+    }
+
+    @Override
+    public float consumeProbabilityFloat() {
+      return 0.2f;
+    }
+
+    @Override
+    public double consumeDouble() {
+      return Double.NaN;
+    }
+
+    @Override
+    public double consumeRegularDouble(double min, double max) {
+      return max;
+    }
+
+    @Override
+    public double consumeRegularDouble() {
+      return Math.PI;
+    }
+
+    @Override
+    public double consumeProbabilityDouble() {
+      return 0.5;
+    }
+
+    @Override
+    public char consumeChar() {
+      return 'C';
+    }
+
+    @Override
+    public char consumeChar(char min, char max) {
+      return min;
+    }
+
+    @Override
+    public char consumeCharNoSurrogates() {
+      return 'C';
+    }
+
+    @Override
+    public String consumeAsciiString(int maxLength) {
+      return "foobar";
+    }
+
+    @Override
+    public String consumeString(int maxLength) {
+      return "foo€ä";
+    }
+
+    @Override
+    public String consumeRemainingAsAsciiString() {
+      return "foobar";
+    }
+
+    @Override
+    public String consumeRemainingAsString() {
+      return "foobar";
+    }
+
+    @Override
+    public byte[] consumeBytes(int maxLength) {
+      return new byte[maxLength];
+    }
+
+    @Override
+    public byte[] consumeRemainingAsBytes() {
+      return new byte[] {1};
+    }
+
+    @Override
+    public int remainingBytes() {
+      return 1;
+    }
+  }
+}


### PR DESCRIPTION
Using a proxy to implement RecordingFuzzedDataProvider led to a subtle
bug related to default methods: Since the invocation handler cannot pass
the proxy instance itself to invoke (this would create a cycle), calls
to non-default methods that were internal to default methods were not
recorded as they occured on the original object.

There does not seem to be a way to fix this with proxies without either
making the FuzzedDataProvider interface aware of it being proxied (which
likely incurs a performance penalty while fuzzing) or duplicating
default method implementations.

A simple and less laborious fix is to implement the proxy object by hand
with every method delegating to the target and recording the return
value.

Fixes #265