### PR TITLE
Use the system linker even with clang

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -57,21 +57,6 @@ exports_files([
     "jazzer-api.pom",
 ])
 
-config_setting(
-    name = "clang",
-    flag_values = {"@bazel_tools//tools/cpp:compiler": "clang"},
-    visibility = ["//visibility:public"],
-)
-
-alias(
-    name = "clang_on_linux",
-    actual = select({
-        ":clang": "@platforms//os:linux",
-        "//conditions:default": ":clang",
-    }),
-    visibility = ["//visibility:public"],
-)
-
 platform(
     name = "x64_windows-clang-cl",
     constraint_values = [

--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -118,9 +118,6 @@ cc_binary(
         "//conditions:default": [
             "-rdynamic",
         ],
-    }) + select({
-        "//:clang_on_linux": ["-fuse-ld=lld"],
-        "//conditions:default": [],
     }),
     linkstatic = True,
     visibility = ["//visibility:public"],
@@ -155,9 +152,6 @@ cc_binary(
             "-static-libsan",
             "-rdynamic",
         ],
-    }) + select({
-        "//:clang_on_linux": ["-fuse-ld=lld"],
-        "//conditions:default": [],
     }),
     linkstatic = True,
     visibility = ["//visibility:public"],
@@ -189,9 +183,6 @@ cc_binary(
             "-fsanitize-link-c++-runtime",
             "-rdynamic",
         ],
-    }) + select({
-        "//:clang_on_linux": ["-fuse-ld=lld"],
-        "//conditions:default": [],
     }),
     linkstatic = True,
     visibility = ["//visibility:public"],

--- a/examples/src/main/native/com/example/BUILD.bazel
+++ b/examples/src/main/native/com/example/BUILD.bazel
@@ -10,7 +10,6 @@ cc_jni_library(
         "-fno-sanitize-blacklist",
     ],
     linkopts = select({
-        "//:clang_on_linux": ["-fuse-ld=lld"],
         "@platforms//os:windows": [
             # Windows requires all symbols that should be imported from the main
             # executable to be defined by an import lib.
@@ -34,7 +33,6 @@ cc_jni_library(
         "-fno-sanitize-recover=all",
     ],
     linkopts = select({
-        "//:clang_on_linux": ["-fuse-ld=lld"],
         "@platforms//os:windows": [
             # Using the asan thunk is correct here as it contains symbols for
             # UBSan and SanCov as well.


### PR DESCRIPTION
Many Linux distributions do not install lld when installing clang. Since
Jazzer does build with ld, use it instead of lld so that building from
source has less requirements.