### PR TITLE
Add an onFuzzTargetReady callback to the Java agent

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/JazzerInternal.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/JazzerInternal.java
@@ -26,4 +26,7 @@ final public class JazzerInternal {
     // target returns even if this Error is swallowed.
     throw new HardToCatchError();
   }
+
+  // Accessed from native code.
+  public static void onFuzzTargetReady(String fuzzTargetClass) {}
 }

--- a/driver/fuzz_target_runner.cpp
+++ b/driver/fuzz_target_runner.cpp
@@ -183,6 +183,17 @@ FuzzTargetRunner::FuzzTargetRunner(
     exit(1);
   }
 
+  // Inform the agent about the fuzz target class.
+  auto on_fuzz_target_ready = jvm.GetStaticMethodID(
+      jazzer_, "onFuzzTargetReady", "(Ljava/lang/String;)V", true);
+  jstring fuzz_target_class = env.NewStringUTF(FLAGS_target_class.c_str());
+  env.CallStaticObjectMethod(jazzer_, on_fuzz_target_ready, fuzz_target_class);
+  if (env.ExceptionCheck()) {
+    env.ExceptionDescribe();
+    return;
+  }
+  env.DeleteLocalRef(fuzz_target_class);
+
   // check existence of optional methods for initialization and destruction
   fuzzer_initialize_ =
       jvm.GetStaticMethodID(jclass_, "fuzzerInitialize", "()V", false);


### PR DESCRIPTION
This can be used to integrate agent functionality that needs to know the fuzz target class.