### PR TITLE
Honor JAVA_OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,10 @@ to [its documentation](https://llvm.org/docs/LibFuzzer.html) for a detailed desc
 
 ### Passing JVM arguments
 
-Arguments for the JVM started by Jazzer can be supplied via the `--jvm_args` argument.
+When Jazzer is launched, it starts a JVM in which it executes the fuzz target.
+Arguments for this JVM can be provided via the `JAVA_OPTS` environment variable.
+
+Alternatively, arguments can also be supplied via the `--jvm_args` argument.
 Multiple arguments are delimited by the classpath separator, which is `;` on Windows and `:` else.
 For example, to enable preview features as well as set a maximum heap size, add the following to the Jazzer invocation:
 
@@ -406,6 +409,8 @@ For example, to enable preview features as well as set a maximum heap size, add 
 # Linux & macOS
 --jvm_args=--enable-preview:-Xmx1000m
 ```
+
+Arguments specified with `--jvm_args` take precendence over those in `JAVA_OPTS`.
 
 ### Coverage Instrumentation
 

--- a/bazel/fuzz_target.bzl
+++ b/bazel/fuzz_target.bzl
@@ -25,6 +25,7 @@ def java_fuzz_target_test(
         srcs = [],
         size = None,
         timeout = None,
+        env = None,
         **kwargs):
     target_name = name + "_target"
     deploy_manifest_lines = []
@@ -72,6 +73,7 @@ def java_fuzz_target_test(
             "//agent:jazzer_agent_deploy.jar",
             driver,
         ] + native_libs,
+        env = env,
         main_class = "FuzzTargetTestWrapper",
         use_testrunner = False,
         tags = tags,

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -129,6 +129,9 @@ java_fuzz_target_test(
     srcs = [
         "src/main/java/com/example/JpegImageParserFuzzer.java",
     ],
+    env = {
+        "JAVA_OPTS": "-Dfoo=not_foo -Djava_opts=1",
+    },
     fuzzer_args = [
         "-fork=5",
         "--additional_jvm_args=-Dbaz=baz",

--- a/examples/src/main/java/com/example/JpegImageParserFuzzer.java
+++ b/examples/src/main/java/com/example/JpegImageParserFuzzer.java
@@ -34,6 +34,14 @@ public class JpegImageParserFuzzer {
       System.err.printf("foo: %s%nbar: %s%nbaz: %s%n", foo, bar, baz);
       System.exit(3);
     }
+    // Only used to verify that Jazzer honors the JAVA_OPTS env var.
+    String javaOpts = System.getProperty("java_opts");
+    if (javaOpts == null || !javaOpts.equals("1")) {
+      // Exit the process with an exit code different from that for a finding.
+      System.err.println("ERROR: Did not honor JAVA_OPTS.");
+      System.err.printf("java_opts: %s%n", javaOpts);
+      System.exit(4);
+    }
   }
 
   public static void fuzzerTestOneInput(byte[] input) {


### PR DESCRIPTION
The only mechanism to specify JVM arguments currently supported by Jazzer is the `--jvm_args` argument, which has a syntax that differs between OSes and may require shell quoting.

This commit makes Jazzer honor the `JAVA_OPTS` environment variable, which is used by many popular Java tools to specify arguments to the JVMs they invoke.

Related to #279.
