### PR TITLE
Replace hardcoded repository name in rlocation paths

### DIFF
--- a/bazel/constants.bzl
+++ b/bazel/constants.bzl
@@ -12,6 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+def jazzer_repo_name():
+    # Skip over the '@'.
+    repo_name = native.repository_name()[1:]
+    if repo_name:
+        return repo_name
+    else:
+        # repository_name returns "@" for the main repo. In this case, we know that the name of the
+        # repository is also the name of the workspace or module we define, which is always just
+        # "jazzer".
+        return "jazzer"
+
+def jazzer_repo_name_define_value():
+    # One level of quoting for Starlark, one for the shell.
+    return "\\\"%s\\\"" % jazzer_repo_name()
+
 SKIP_ON_MACOS = select({
     "@platforms//os:macos": ["@platforms//:incompatible"],
     "//conditions:default": [],

--- a/bazel/fuzz_target.bzl
+++ b/bazel/fuzz_target.bzl
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load(":constants.bzl", "jazzer_repo_name")
+
 def java_fuzz_target_test(
         name,
         target_class = None,
@@ -64,8 +66,8 @@ def java_fuzz_target_test(
         size = size or "enormous",
         timeout = timeout or "moderate",
         args = [
-            "$(rootpath %s)" % driver,
-            "$(rootpath :%s_deploy.jar)" % target_name,
+            "%s/$(rootpath %s)" % (jazzer_repo_name(), driver),
+            "%s/$(rootpath :%s_deploy.jar)" % (jazzer_repo_name(), target_name),
         ] + additional_args + fuzzer_args,
         data = [
             ":%s_deploy.jar" % target_name,

--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:cc.bzl", "cc_17_library")
+load("//bazel:constants.bzl", "jazzer_repo_name_define_value")
 
 cc_library(
     name = "sanitizer_hooks_with_pc",
@@ -71,7 +72,9 @@ cc_library(
         # libFuzzer. Instead, trigger a hard exit.
         "@platforms//os:windows": ["SIGUSR1=SIGTERM"],
         "//conditions:default": [],
-    }),
+    }) + [
+        "JAZZER_REPO_NAME=%s" % jazzer_repo_name_define_value(),
+    ],
     tags = [
         # Should be built through the cc_17_library driver_lib.
         "manual",

--- a/driver/jvm_tooling.cpp
+++ b/driver/jvm_tooling.cpp
@@ -116,7 +116,9 @@ extern "C" JNIEXPORT jint JNICALL JNI_OnLoad_jazzer_initialize(JavaVM *vm,
 }
 
 namespace {
-constexpr auto kAgentBazelRunfilesPath = "jazzer/agent/jazzer_agent_deploy.jar";
+// The name of the Jazzer repository is injected as a define.
+constexpr auto kAgentBazelRunfilesPath =
+    JAZZER_REPO_NAME "/agent/jazzer_agent_deploy.jar";
 constexpr auto kAgentFileName = "jazzer_agent_deploy.jar";
 constexpr const char kExceptionUtilsClassName[] =
     "com/code_intelligence/jazzer/runtime/ExceptionUtils";

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@fmeum_rules_jni//jni:defs.bzl", "java_jni_library")
-load("//bazel:compat.bzl", "SKIP_ON_MACOS", "SKIP_ON_WINDOWS")
+load("//bazel:constants.bzl", "SKIP_ON_MACOS", "SKIP_ON_WINDOWS", "jazzer_repo_name")
 load("//bazel:fuzz_target.bzl", "java_fuzz_target_test")
 
 java_fuzz_target_test(
@@ -207,9 +207,9 @@ sh_test(
     name = "JsonSanitizerReplayerCrashTest",
     srcs = ["check_for_finding.sh"],
     args = [
-        "jazzer/$(rootpath :JsonSanitizerReplayerCrash)",
+        "%s/$(rootpath :JsonSanitizerReplayerCrash)" % jazzer_repo_name(),
         "com.example.JsonSanitizerDenylistFuzzer",
-        "jazzer/$(rootpath :json_sanitizer_denylist_crash)",
+        "%s/$(rootpath :json_sanitizer_denylist_crash)" % jazzer_repo_name(),
     ],
     data = [
         ":JsonSanitizerReplayerCrash",


### PR DESCRIPTION
This is in preparation for Bazel module support, where repositories are
assigned internal names different from their declared user-facing name.