### PR TITLE
Refactor EdgeCoverageInstrumentor

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
@@ -8,6 +8,7 @@ kt_jvm_library(
         "CoverageRecorder.kt",
         "DescriptorUtils.kt",
         "DeterministicRandom.kt",
+        "DirectByteBufferStrategy.kt",
         "EdgeCoverageInstrumentor.kt",
         "Hook.kt",
         "HookInstrumentor.kt",

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/ClassInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/ClassInstrumentor.kt
@@ -14,6 +14,8 @@
 
 package com.code_intelligence.jazzer.instrumentor
 
+import com.code_intelligence.jazzer.runtime.CoverageMap
+
 fun extractClassFileMajorVersion(classfileBuffer: ByteArray): Int {
     return ((classfileBuffer[6].toInt() and 0xff) shl 8) or (classfileBuffer[7].toInt() and 0xff)
 }
@@ -24,7 +26,11 @@ class ClassInstrumentor constructor(bytecode: ByteArray) {
         private set
 
     fun coverage(initialEdgeId: Int): Int {
-        val edgeCoverageInstrumentor = EdgeCoverageInstrumentor(initialEdgeId)
+        val edgeCoverageInstrumentor = EdgeCoverageInstrumentor(
+            defaultEdgeCoverageStrategy,
+            defaultCoverageMap,
+            initialEdgeId,
+        )
         instrumentedBytecode = edgeCoverageInstrumentor.instrument(instrumentedBytecode)
         return edgeCoverageInstrumentor.numEdges
     }
@@ -49,5 +55,8 @@ class ClassInstrumentor constructor(bytecode: ByteArray) {
                 // Make it possible to use (parts of) the agent without the driver.
             }
         }
+
+        val defaultEdgeCoverageStrategy = DirectByteBufferStrategy
+        val defaultCoverageMap = CoverageMap::class.java
     }
 }

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/DirectByteBufferStrategy.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/DirectByteBufferStrategy.kt
@@ -1,0 +1,81 @@
+// Copyright 2022 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.instrumentor
+
+import org.objectweb.asm.MethodVisitor
+import org.objectweb.asm.Opcodes
+
+object DirectByteBufferStrategy : EdgeCoverageStrategy {
+
+    override fun instrumentControlFlowEdge(
+        mv: MethodVisitor,
+        edgeId: Int,
+        variable: Int,
+        coverageMapInternalClassName: String
+    ) {
+        mv.apply {
+            visitVarInsn(Opcodes.ALOAD, variable)
+            // Stack: counters
+            push(edgeId)
+            // Stack: counters | edgeId
+            visitInsn(Opcodes.DUP2)
+            // Stack: counters | edgeId | counters | edgeId
+            visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/nio/ByteBuffer", "get", "(I)B", false)
+            // Increment the counter, but ensure that it never stays at 0 after an overflow by incrementing it again in
+            // that case.
+            // This approach performs better than saturating the counter at 255 (see Section 3.3 of
+            // https://www.usenix.org/system/files/woot20-paper-fioraldi.pdf)
+            // Stack: counters | edgeId | counter (sign-extended to int)
+            push(0xff)
+            // Stack: counters | edgeId | counter (sign-extended to int) | 0x000000ff
+            visitInsn(Opcodes.IAND)
+            // Stack: counters | edgeId | counter (zero-extended to int)
+            push(1)
+            // Stack: counters | edgeId | counter | 1
+            visitInsn(Opcodes.IADD)
+            // Stack: counters | edgeId | counter + 1
+            visitInsn(Opcodes.DUP)
+            // Stack: counters | edgeId | counter + 1 | counter + 1
+            push(8)
+            // Stack: counters | edgeId | counter + 1 | counter + 1 | 8 (maxStack: +5)
+            visitInsn(Opcodes.ISHR)
+            // Stack: counters | edgeId | counter + 1 | 1 if the increment overflowed to 0, 0 otherwise
+            visitInsn(Opcodes.IADD)
+            // Stack: counters | edgeId | counter + 2 if the increment overflowed, counter + 1 otherwise
+            visitMethodInsn(Opcodes.INVOKEVIRTUAL, "java/nio/ByteBuffer", "put", "(IB)Ljava/nio/ByteBuffer;", false)
+            // Stack: counters
+            visitInsn(Opcodes.POP)
+        }
+    }
+
+    override val instrumentControlFlowEdgeStackSize = 5
+
+    override val localVariableType get() = "java/nio/ByteBuffer"
+
+    override fun loadLocalVariable(mv: MethodVisitor, variable: Int, coverageMapInternalClassName: String) {
+        mv.apply {
+            visitFieldInsn(
+                Opcodes.GETSTATIC,
+                coverageMapInternalClassName,
+                "counters",
+                "Ljava/nio/ByteBuffer;",
+            )
+            // Stack: counters (maxStack: 1)
+            visitVarInsn(Opcodes.ASTORE, variable)
+        }
+    }
+
+    override val loadLocalVariableStackSize = 1
+}

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/EdgeCoverageInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/EdgeCoverageInstrumentor.kt
@@ -170,6 +170,8 @@ class EdgeCoverageInstrumentor(
             val newMaxStack = max(maxStack + instrumentControlFlowEdgeStackSize, loadCoverageMapStackSize)
             mv.visitMaxs(newMaxStack, maxLocals + 1)
         }
+
+        override fun getLocalType() = "java/nio/ByteBuffer"
     }
 
     private val edgeCoverageProbeInserterFactory =

--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/CoverageMap.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/CoverageMap.java
@@ -22,11 +22,15 @@ import java.nio.ByteBuffer;
  * native code.
  */
 final public class CoverageMap {
-  public static ByteBuffer mem = ByteBuffer.allocateDirect(0);
+  public static ByteBuffer counters = ByteBuffer.allocateDirect(0);
 
-  public static void enlargeCoverageMap() {
-    registerNewCoverageCounters();
-    System.out.println("INFO: New number of inline 8-bit counters: " + mem.capacity());
+  // Called via reflection.
+  @SuppressWarnings("unused")
+  public static void enlargeIfNeeded(int nextId) {
+    if (nextId >= counters.capacity()) {
+      registerNewCoverageCounters();
+      System.out.println("INFO: New number of inline 8-bit counters: " + counters.capacity());
+    }
   }
 
   private static native void registerNewCoverageCounters();

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/MockCoverageMap.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/MockCoverageMap.java
@@ -20,8 +20,7 @@ import java.util.Arrays;
 
 public class MockCoverageMap {
   public static final int SIZE = 65536;
-  public static final ByteBuffer mem = ByteBuffer.allocate(SIZE);
-  public static int prev_location = 0; // is used in byte code directly
+  public static final ByteBuffer counters = ByteBuffer.allocate(SIZE);
 
   private static final ByteBuffer previous_mem = ByteBuffer.allocate(SIZE);
   public static ArrayList<Integer> locations = new ArrayList<>();
@@ -29,16 +28,20 @@ public class MockCoverageMap {
   public static void updated() {
     int updated_pos = -1;
     for (int i = 0; i < SIZE; i++) {
-      if (previous_mem.get(i) != mem.get(i)) {
+      if (previous_mem.get(i) != counters.get(i)) {
         updated_pos = i;
       }
     }
     locations.add(updated_pos);
-    System.arraycopy(mem.array(), 0, previous_mem.array(), 0, SIZE);
+    System.arraycopy(counters.array(), 0, previous_mem.array(), 0, SIZE);
+  }
+
+  public static void enlargeIfNeeded(int nextId) {
+    // This mock coverage map is statically sized.
   }
 
   public static void clear() {
-    Arrays.fill(mem.array(), (byte) 0);
+    Arrays.fill(counters.array(), (byte) 0);
     Arrays.fill(previous_mem.array(), (byte) 0);
     locations.clear();
   }

--- a/driver/coverage_tracker.cpp
+++ b/driver/coverage_tracker.cpp
@@ -104,8 +104,9 @@ void JNICALL CoverageTracker::RegisterNewCoverageCounters(JNIEnv &env,
                                                           jclass cls) {
   jclass coverage_map = env.FindClass(kCoverageMapClass);
   AssertNoException(env);
-  jfieldID counters_buffer_id = env.GetStaticFieldID(
-      coverage_map, "mem", absl::StrFormat("L%s;", kByteBufferClass).c_str());
+  jfieldID counters_buffer_id =
+      env.GetStaticFieldID(coverage_map, "counters",
+                           absl::StrFormat("L%s;", kByteBufferClass).c_str());
   AssertNoException(env);
   jobject counters_buffer =
       env.GetStaticObjectField(coverage_map, counters_buffer_id);

--- a/driver/testdata/test/FuzzTargetWithCoverage.java
+++ b/driver/testdata/test/FuzzTargetWithCoverage.java
@@ -19,10 +19,10 @@ import com.code_intelligence.jazzer.runtime.CoverageMap;
 public class FuzzTargetWithCoverage {
   public static void fuzzerTestOneInput(byte[] input) {
     // manually increase the first coverage counter
-    byte counter = CoverageMap.mem.get(0);
+    byte counter = CoverageMap.counters.get(0);
     counter++;
     if (counter == 0)
       counter--;
-    CoverageMap.mem.put(0, counter);
+    CoverageMap.counters.put(0, counter);
   }
 }

--- a/third_party/jacoco-make-probe-inserter-subclassable.patch
+++ b/third_party/jacoco-make-probe-inserter-subclassable.patch
@@ -63,21 +63,8 @@ index 00000000..19c2a7e2
 +    ProbeInserter makeProbeInserter(int access, String name, String desc,
 +            MethodVisitor mv, IProbeArrayStrategy arrayStrategy);
 +}
-diff --git org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
-index 71808ac8..3df93f63 100644
---- org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
-+++ org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
-@@ -78,7 +78,7 @@ public final class InstrSupport {
- 	 * Data type of the field that stores coverage information for a class (
- 	 * <code>boolean[]</code>).
- 	 */
--	public static final String DATAFIELD_DESC = "[Z";
-+	public static final String DATAFIELD_DESC = "java/nio/ByteBuffer";
- 
- 	// === Init Method ===
- 
 diff --git org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
-index 0f5b99ff..ba5daa6d 100644
+index 0f5b99ff..80965dfe 100644
 --- org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
 +++ org.jacoco.core/src/org/jacoco/core/internal/instr/ProbeInserter.java
 @@ -25,7 +25,7 @@ import org.objectweb.asm.TypePath;
@@ -107,3 +94,55 @@ index 0f5b99ff..ba5daa6d 100644
  			final MethodVisitor mv, final IProbeArrayStrategy arrayStrategy) {
  		super(InstrSupport.ASM_API_VERSION, mv);
  		this.clinit = InstrSupport.CLINIT_NAME.equals(name);
+@@ -91,6 +91,10 @@ class ProbeInserter extends MethodVisitor implements IProbeInserter {
+ 		mv.visitInsn(Opcodes.BASTORE);
+ 	}
+ 
++	protected Object getLocalVariableType() {
++		return InstrSupport.DATAFIELD_DESC;
++	}
++
+ 	@Override
+ 	public void visitCode() {
+ 		accessorStackSize = arrayStrategy.storeInstance(mv, clinit, variable);
+@@ -118,6 +122,10 @@ class ProbeInserter extends MethodVisitor implements IProbeInserter {
+ 	public AnnotationVisitor visitLocalVariableAnnotation(final int typeRef,
+ 			final TypePath typePath, final Label[] start, final Label[] end,
+ 			final int[] index, final String descriptor, final boolean visible) {
++		if (getLocalVariableType() == null) {
++			return visitLocalVariableAnnotation(typeRef, typePath, start, end, index, descriptor, visible);
++		}
++
+ 		final int[] newIndex = new int[index.length];
+ 		for (int i = 0; i < newIndex.length; i++) {
+ 			newIndex[i] = map(index[i]);
+@@ -137,6 +145,9 @@ class ProbeInserter extends MethodVisitor implements IProbeInserter {
+ 	}
+ 
+ 	private int map(final int var) {
++		if (getLocalVariableType() == null) {
++			return var;
++		}
+ 		if (var < variable) {
+ 			return var;
+ 		} else {
+@@ -153,13 +164,18 @@ class ProbeInserter extends MethodVisitor implements IProbeInserter {
+ 					"ClassReader.accept() should be called with EXPAND_FRAMES flag");
+ 		}
+ 
++        if (getLocalVariableType() == null) {
++			mv.visitFrame(type, nLocal, local, nStack, stack);
++			return;
++		}
++
+ 		final Object[] newLocal = new Object[Math.max(nLocal, variable) + 1];
+ 		int idx = 0; // Arrays index for existing locals
+ 		int newIdx = 0; // Array index for new locals
+ 		int pos = 0; // Current variable position
+ 		while (idx < nLocal || pos <= variable) {
+ 			if (pos == variable) {
+-				newLocal[newIdx++] = InstrSupport.DATAFIELD_DESC;
++				newLocal[newIdx++] = getLocalVariableType();
+ 				pos++;
+ 			} else {
+ 				if (idx < nLocal) {


### PR DESCRIPTION
The aim of this refactoring is to decouple the edge coverage instrumentation from the coverage map class as well as split its logic into three clearly defined parts:

* An EdgeCoverageStrategy determines the actual type of bytecode instrumentation applied, which depends on the particular nature of the counters field of the coverage map class.
* The EdgeCoverageInstrumentor class, which realizes the instrumentation strategy described by an EdgeCoverageStrategy using JaCoCo. This is the only part of the code that uses JaCoCo classes.
* The makeTestable function in the test module, which can now mock the coverage map without requiring testing-related hooks in the other parts.

This refactoring should make it easier to modify and replace parts of the edge coverage instrumenation mechanism more easily, as well as test and benchmark them in isolation.