### PR TITLE
Switch to .tar.gz for all dependency archives

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -57,9 +57,9 @@ def jazzer_dependencies():
     maybe(
         http_archive,
         name = "com_google_absl",
-        sha256 = "5e1cbf25bf501f8e37866000a6052d02dbdd7b19a5b592251c59a4c9aa5c71ae",
-        strip_prefix = "abseil-cpp-f2dbd918d8d08529800eb72f23bd2829f92104a4",
-        url = "https://github.com/abseil/abseil-cpp/archive/f2dbd918d8d08529800eb72f23bd2829f92104a4.zip",
+        sha256 = "dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4",
+        strip_prefix = "abseil-cpp-20211102.0",
+        url = "https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.tar.gz",
     )
 
     maybe(


### PR DESCRIPTION
Also update abseil-cpp to the latest release.