### PR TITLE
Fix TurbojpegFuzzer native library path

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -325,6 +325,7 @@ java_fuzz_target_test(
     ],
     fuzzer_args = [
         "-rss_limit_mb=8196",
+        "--jvm_args=-Djava.library.path=../libjpeg_turbo",
     ],
     sanitizer = "address",
     tags = ["manual"],

--- a/third_party/libjpeg_turbo.BUILD
+++ b/third_party/libjpeg_turbo.BUILD
@@ -23,13 +23,16 @@ cc_import(
 cmake(
     name = "libjpeg_turbo",
     cache_entries = {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_C_COMPILER": "clang",
-        "CMAKE_C_FLAGS": "-fsanitize=address,fuzzer-no-link",
-        "CMAKE_SHARED_LINKER_FLAGS": "-fsanitize=address,fuzzer-no-link",
         "WITH_JAVA": "1",
     },
+    copts = [
+        "-fsanitize=address,fuzzer-no-link",
+        "-fPIC",
+    ],
     lib_source = ":all_files",
+    linkopts = [
+        "-fsanitize=address,fuzzer-no-link",
+    ],
     out_shared_libs = [
         "libjpeg.so",
         "libturbojpeg.so",


### PR DESCRIPTION
The native library path for this example got lost during the migration to rules_jni and is required for the fuzz target to be functional.