### PR TITLE
Remove checked-in bazelisk and update README

### DIFF
--- a/docker/jazzer/Dockerfile
+++ b/docker/jazzer/Dockerfile
@@ -15,16 +15,18 @@
 FROM ubuntu:20.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y git python3 python-is-python3 openjdk-11-jdk-headless
+RUN apt-get update && apt-get install -y curl git python3 python-is-python3 openjdk-11-jdk-headless
 
 WORKDIR /root
-RUN git clone --depth=1 https://github.com/CodeIntelligenceTesting/jazzer.git && \
+RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64 -o /usr/bin/bazelisk && \
+    chmod +x /usr/bin/bazelisk && \
+    git clone --depth=1 https://github.com/CodeIntelligenceTesting/jazzer.git && \
     cd jazzer && \
     # The LLVM toolchain requires ld and ld.gold to exist, but does not use them.
     touch /usr/bin/ld && \
     touch /usr/bin/ld.gold && \
     BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
-    ./bazelisk-linux-amd64 build --config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux \
+    bazelisk build --config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux \
       //agent:jazzer_agent_deploy.jar //driver:jazzer_driver
 
 FROM gcr.io/distroless/java


### PR DESCRIPTION
Now that we support three different platforms and two architectures,
maintaining an in-repo Bazelisk binary for just a single pair doesn't
make much sense anymore. Instead, provide clear and up-to-date
instructions on how to obtain and use Bazelisk to build Jazzer.

Also includes a general overhaul of the "Getting Jazzer" section of the
README and updates the Docker image to function without a checked-in
Bazelisk.