### PR TITLE
Disallow REPLACE hooks on <init>

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Hook.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Hook.kt
@@ -55,6 +55,10 @@ class Hook private constructor(hookMethod: Method, annotation: MethodHook) {
             require(Modifier.isPublic(hookMethod.modifiers)) { "$potentialHook: hook method must be public" }
             require(Modifier.isStatic(hookMethod.modifiers)) { "$potentialHook: hook method must be static" }
 
+            require(hookData.targetMethod != "<init>" || hookData.type != HookType.REPLACE) {
+                "$potentialHook: REPLACE hooks can't be applied to <init>"
+            }
+
             // Verify the hook method's parameter count.
             val numParameters = hookMethod.parameters.size
             when (hookData.type) {

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/InvalidHookMocks.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/InvalidHookMocks.java
@@ -45,7 +45,7 @@ class InvalidHookMocks {
     return true;
   }
 
-  @MethodHook(type = HookType.REPLACE, targetClassName = "java.lang.StringBuilder",
+  @MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.StringBuilder",
       targetMethod = "<init>", targetMethodDescriptor = "(Ljava/lang/String;)V")
   public static Object
   invalidReturnType(MethodHandle method, Object thisObject, Object[] arguments, int hookId)
@@ -58,4 +58,10 @@ class InvalidHookMocks {
   public static void
   primitiveReturnValueMustBeWrapped(MethodHandle method, String thisObject, Object[] arguments,
       int hookId, boolean returnValue) {}
+
+  @MethodHook(type = HookType.REPLACE, targetClassName = "java.lang.StringBuilder",
+      targetMethod = "<init>", targetMethodDescriptor = "(Ljava/lang/String;)V")
+  public static void
+  replaceOnInit(MethodHandle method, Object thisObject, Object[] arguments, int hookId)
+      throws Throwable {}
 }


### PR DESCRIPTION
REPLACE hooks on <init> can't work as only <init> can mark the stack variable as initialized.