### PR TITLE
Synchronize coverage ID generation

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/utils/Utils.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/utils/Utils.kt
@@ -17,6 +17,8 @@ package com.code_intelligence.jazzer.utils
 
 import java.lang.reflect.Executable
 import java.lang.reflect.Method
+import java.nio.ByteBuffer
+import java.nio.channels.FileChannel
 
 val Class<*>.descriptor: String
     get() = when {
@@ -79,4 +81,27 @@ fun simpleFastHash(vararg strings: String): Int {
         }
     }
     return hash
+}
+
+/**
+ * Reads the [FileChannel] to the end as a UTF-8 string.
+ */
+fun FileChannel.readFully(): String {
+    check(size() <= Int.MAX_VALUE)
+    val buffer = ByteBuffer.allocate(size().toInt())
+    while (buffer.hasRemaining()) {
+        when (read(buffer)) {
+            0 -> throw IllegalStateException("No bytes read")
+            -1 -> break
+        }
+    }
+    return String(buffer.array())
+}
+
+/**
+ * Appends [string] to the end of the [FileChannel].
+ */
+fun FileChannel.append(string: String) {
+    position(size())
+    write(ByteBuffer.wrap(string.toByteArray()))
 }


### PR DESCRIPTION
Even though concurrent fuzzing is not fully supported situations arise in which classes are loaded concurrently (e.g. by used frameworks). This could lead to locking issues in the provided file based `SynchronizedCoverageIdStrategy`.

This PR moves the responsibility to guard access to coverage IDs from `RuntimeInstrumentor` to the concrete strategies by changing the `CoverageIdStrategy` interface. Based on their use-cases strategies can now implement different synchronization and error handling.

Now, both provided strategies synchronize coverage ID generation to support concurrent class loading.

This resolves #306 