### PR TITLE
OS command injection sanitizer

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
@@ -83,7 +83,7 @@ fun premain(agentArgs: String?, instrumentation: Instrumentation) {
         (argumentMap["instrumentation_excludes"] ?: emptyList()) + customHookNames
     )
     CoverageRecorder.classNameGlobber = classNameGlobber
-    val dependencyClassNameGlobber = ClassNameGlobber(
+    val customHookClassNameGlobber = ClassNameGlobber(
         argumentMap["custom_hook_includes"] ?: emptyList(),
         (argumentMap["custom_hook_excludes"] ?: emptyList()) + customHookNames
     )
@@ -123,7 +123,7 @@ fun premain(agentArgs: String?, instrumentation: Instrumentation) {
     val runtimeInstrumentor = RuntimeInstrumentor(
         instrumentation,
         classNameGlobber,
-        dependencyClassNameGlobber,
+        customHookClassNameGlobber,
         instrumentationTypes,
         idSyncFile,
         dumpClassesDir,
@@ -134,7 +134,7 @@ fun premain(agentArgs: String?, instrumentation: Instrumentation) {
 
     val relevantClassesLoadedBeforeCustomHooks = instrumentation.allLoadedClasses
         .map { it.name }
-        .filter { classNameGlobber.includes(it) || dependencyClassNameGlobber.includes(it) }
+        .filter { classNameGlobber.includes(it) || customHookClassNameGlobber.includes(it) }
         .toSet()
     val customHooks = customHookNames.toSet().flatMap { hookClassName ->
         try {
@@ -148,7 +148,7 @@ fun premain(agentArgs: String?, instrumentation: Instrumentation) {
     }
     val relevantClassesLoadedAfterCustomHooks = instrumentation.allLoadedClasses
         .map { it.name }
-        .filter { classNameGlobber.includes(it) || dependencyClassNameGlobber.includes(it) }
+        .filter { classNameGlobber.includes(it) || customHookClassNameGlobber.includes(it) }
         .toSet()
     val nonHookClassesLoadedByHooks = relevantClassesLoadedAfterCustomHooks - relevantClassesLoadedBeforeCustomHooks
     if (nonHookClassesLoadedByHooks.isNotEmpty()) {

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/MethodHook.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/MethodHook.java
@@ -23,11 +23,12 @@ import java.lang.annotation.Target;
 import java.lang.invoke.MethodType;
 
 /**
- * Registers this method as a hook that should run after the method
- * specified by the annotation parameters has returned.
+ * Registers the annotated method as a hook that should run before, instead or
+ * after the method specified by the annotation parameters.
  * <p>
- * This method will be called after every call to the target method and has
- * access to its return value. The target method is specified by
+ * Depending on {@link #type()} this method will be called after, instead or
+ * before every call to the target method and has
+ * access to its parameters and return value. The target method is specified by
  * {@link #targetClassName()} and {@link #targetMethod()}. In case of an
  * overloaded method, {@link #targetMethodDescriptor()} can be used to restrict
  * the application of the hook to a particular overload.
@@ -180,4 +181,15 @@ public @interface MethodHook {
    * @return the descriptor of the method to be hooked
    */
   String targetMethodDescriptor() default "";
+
+  /**
+   * Array of additional classes to hook.
+   * <p>
+   * Hooks are applied on call sites. This means that classes calling the one
+   * defined in this annotation need to be instrumented to actually execute
+   * the hook. This property can be used to hook normally ignored classes.
+   *
+   * @return fully qualified class names to hook
+   */
+  String[] additionalClassesToHook() default {};
 }

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Hook.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Hook.kt
@@ -28,9 +28,10 @@ class Hook private constructor(hookMethod: Method, annotation: MethodHook) {
     // Allowing arbitrary exterior whitespace in the target class name allows for an easy workaround
     // for mangled hooks due to shading applied to hooks.
     private val targetClassName = annotation.targetClassName.trim()
-    val targetMethodName = annotation.targetMethod
-    val targetMethodDescriptor = annotation.targetMethodDescriptor.takeIf { it.isNotEmpty() }
     val hookType = annotation.type
+    val targetMethodName = annotation.targetMethod
+    val targetMethodDescriptor = annotation.targetMethodDescriptor.takeIf { it.isNotBlank() }
+    val additionalClassesToHook = annotation.additionalClassesToHook.asList()
 
     val targetInternalClassName = targetClassName.replace('.', '/')
     private val targetReturnTypeDescriptor = targetMethodDescriptor?.let { extractReturnTypeDescriptor(it) }
@@ -42,7 +43,7 @@ class Hook private constructor(hookMethod: Method, annotation: MethodHook) {
     val hookMethodDescriptor = hookMethod.descriptor
 
     override fun toString(): String {
-        return "$hookType $targetClassName.$targetMethodName: $hookClassName.$hookMethodName"
+        return "$hookType $targetClassName.$targetMethodName: $hookClassName.$hookMethodName $additionalClassesToHook"
     }
 
     companion object {

--- a/agent/src/main/java/com/code_intelligence/jazzer/utils/ClassNameGlobber.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/utils/ClassNameGlobber.kt
@@ -33,7 +33,7 @@ private val BASE_EXCLUDED_CLASS_NAME_GLOBS = listOf(
     "sun.**",
 )
 
-class ClassNameGlobber(includes: List<String>, excludes: List<String>) {
+class ClassNameGlobber(private val includes: List<String>, private val excludes: List<String>) {
     // If no include globs are provided, start with all classes.
     private val includeMatchers = (if (includes.isEmpty()) BASE_INCLUDED_CLASS_NAME_GLOBS else includes)
         .map(::SimpleGlobMatcher)
@@ -45,6 +45,9 @@ class ClassNameGlobber(includes: List<String>, excludes: List<String>) {
     fun includes(className: String): Boolean {
         return includeMatchers.any { it.matches(className) } && excludeMatchers.none { it.matches(className) }
     }
+
+    fun withAdditionalIncludes(includes: List<String>): ClassNameGlobber =
+        ClassNameGlobber(this.includes + includes, excludes)
 }
 
 class SimpleGlobMatcher(val glob: String) {

--- a/sanitizers/sanitizers.bzl
+++ b/sanitizers/sanitizers.bzl
@@ -18,6 +18,7 @@ _sanitizer_class_names = [
     "Deserialization",
     "ExpressionLanguageInjection",
     "NamingContextLookup",
+    "OsCommandInjection",
     "ReflectiveCall",
 ]
 

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BUILD.bazel
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BUILD.bazel
@@ -6,6 +6,7 @@ kt_jvm_library(
         "Deserialization.kt",
         "ExpressionLanguageInjection.kt",
         "NamingContextLookup.kt",
+        "OsCommandInjection.kt",
         "ReflectiveCall.kt",
         "Utils.kt",
     ],

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/OsCommandInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/OsCommandInjection.kt
@@ -1,0 +1,58 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.sanitizers
+
+import com.code_intelligence.jazzer.api.*
+import java.lang.invoke.MethodHandle
+
+/**
+ * Detects unsafe execution of OS commands using [ProcessBuilder].
+ * Executing OS commands based on attacker-controlled data could lead to arbitrary could execution.
+ *
+ * All public methods providing the command to execute end up in [java.lang.ProcessImpl.start],
+ * so calls to this method are hooked.
+ * Only the first entry of the given command array is analyzed. It states the executable and must
+ * not include attacker provided data.
+ */
+@Suppress("unused_parameter", "unused")
+object OsCommandInjection {
+
+    // Short and probably non-existing command name
+    private const val COMMAND = "jazze"
+
+    @MethodHook(
+        type = HookType.BEFORE,
+        targetClassName = "java.lang.ProcessImpl",
+        targetMethod = "start",
+        additionalClassesToHook = ["java.lang.ProcessBuilder"]
+    )
+    @JvmStatic
+    fun processImplStartHook(method: MethodHandle?, alwaysNull: Any?, args: Array<Any?>, hookId: Int) {
+        // Calling ProcessBuilder already checks if command array is empty
+        @Suppress("UNCHECKED_CAST")
+        (args[0] as? Array<String>)?.first().let { cmd ->
+            if (cmd == COMMAND) {
+                Jazzer.reportFindingFromHook(
+                    FuzzerSecurityIssueCritical(
+                        """OS Command Injection
+Executing OS commands with attacker-controlled data can lead to remote code execution."""
+                    )
+                )
+            } else {
+                Jazzer.guideTowardsEquality(cmd, COMMAND, hookId)
+            }
+        }
+    }
+}

--- a/sanitizers/src/test/java/com/example/BUILD.bazel
+++ b/sanitizers/src/test/java/com/example/BUILD.bazel
@@ -30,3 +30,19 @@ java_fuzz_target_test(
         "@maven//:org_hibernate_hibernate_validator",
     ],
 )
+
+java_fuzz_target_test(
+    name = "OsCommandInjectionProcessBuilder",
+    srcs = [
+        "OsCommandInjectionProcessBuilder.java",
+    ],
+    target_class = "com.example.OsCommandInjectionProcessBuilder",
+)
+
+java_fuzz_target_test(
+    name = "OsCommandInjectionRuntimeExec",
+    srcs = [
+        "OsCommandInjectionRuntimeExec.java",
+    ],
+    target_class = "com.example.OsCommandInjectionRuntimeExec",
+)

--- a/sanitizers/src/test/java/com/example/OsCommandInjectionProcessBuilder.java
+++ b/sanitizers/src/test/java/com/example/OsCommandInjectionProcessBuilder.java
@@ -1,0 +1,34 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class OsCommandInjectionProcessBuilder {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    String input = data.consumeRemainingAsAsciiString();
+    try {
+      Process process = new ProcessBuilder(input).start();
+      // This should be way faster, but we have to wait until the call is done
+      if (!process.waitFor(10, TimeUnit.MILLISECONDS)) {
+        process.destroyForcibly();
+      }
+    } catch (Exception ignored) {
+      // Ignore execution and setup exceptions
+    }
+  }
+}

--- a/sanitizers/src/test/java/com/example/OsCommandInjectionRuntimeExec.java
+++ b/sanitizers/src/test/java/com/example/OsCommandInjectionRuntimeExec.java
@@ -1,0 +1,36 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import static java.lang.Runtime.getRuntime;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+public class OsCommandInjectionRuntimeExec {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    String input = data.consumeRemainingAsAsciiString();
+    try {
+      Process process = getRuntime().exec(input);
+      // This should be way faster, but we have to wait until the call is done
+      if (!process.waitFor(10, TimeUnit.MILLISECONDS)) {
+        process.destroyForcibly();
+      }
+    } catch (Exception ignored) {
+      // Ignore execution and setup exceptions
+    }
+  }
+}


### PR DESCRIPTION
The OS command injection sanitizer checks if fuzzer provided data reaches command execution code in `ProcessImpl::start`.

Furthermore the PR includes an extension to the `@MethodHook` annotation. The `additionalClassesToHook` property can  provide an array of classes that should be included in the hook instrumentation.