### PR TITLE
Standalone Autofuzz Java reproducers

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
@@ -79,7 +79,8 @@ public class Meta {
     } else {
       if (visitor != null) {
         // This group will always have two elements: The thisObject and the method call.
-        visitor.pushGroup("", ".", "");
+        // Since the this object can be a complex expression, wrap it in paranthesis.
+        visitor.pushGroup("(", ").", "");
       }
       Object thisObject = consume(data, method.getDeclaringClass(), visitor);
       if (thisObject == null) {

--- a/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
@@ -69,9 +69,12 @@ public class Meta {
         visitor.pushGroup(
             String.format("%s.", method.getDeclaringClass().getCanonicalName()), "", "");
       }
-      result = autofuzz(data, method, null, visitor);
-      if (visitor != null) {
-        visitor.popGroup();
+      try {
+        result = autofuzz(data, method, null, visitor);
+      } finally {
+        if (visitor != null) {
+          visitor.popGroup();
+        }
       }
     } else {
       if (visitor != null) {
@@ -82,9 +85,12 @@ public class Meta {
       if (thisObject == null) {
         throw new AutofuzzConstructionException();
       }
-      result = autofuzz(data, method, thisObject, visitor);
-      if (visitor != null) {
-        visitor.popGroup();
+      try {
+        result = autofuzz(data, method, thisObject, visitor);
+      } finally {
+        if (visitor != null) {
+          visitor.popGroup();
+        }
       }
     }
     return result;

--- a/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/MetaTest.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/MetaTest.java
@@ -169,7 +169,7 @@ public class MetaTest {
         MetaTest.class.getMethod("isFive", int.class), Collections.singletonList(5));
     autofuzzTestCase(false, "com.code_intelligence.jazzer.autofuzz.MetaTest.intEquals(5, 4)",
         MetaTest.class.getMethod("intEquals", int.class, int.class), Arrays.asList(5, 4));
-    autofuzzTestCase("foobar", "\"foo\".concat(\"bar\")",
+    autofuzzTestCase("foobar", "(\"foo\").concat(\"bar\")",
         String.class.getMethod("concat", String.class),
         Arrays.asList((byte) 1, 6, "foo", (byte) 1, 6, "bar"));
     autofuzzTestCase("jazzer", "new java.lang.String(\"jazzer\")",

--- a/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/MetaTest.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/MetaTest.java
@@ -126,7 +126,7 @@ public class MetaTest {
             .collect(java.util.HashMap::new,
                 (map, e) -> map.put(e.getKey(), e.getValue()), java.util.HashMap::putAll);
     consumeTestCase(stringStringMapType, expectedMap,
-        "java.util.stream.Stream.of(new java.util.AbstractMap.SimpleEntry<>(\"key0\", \"value0\"), new java.util.AbstractMap.SimpleEntry<>(\"key1\", \"value1\"), new java.util.AbstractMap.SimpleEntry<>(\"key2\", (java.lang.String) null)).collect(java.util.HashMap::new, (map, e) -> map.put(e.getKey(), e.getValue()), java.util.HashMap::putAll)",
+        "java.util.stream.Stream.<java.util.AbstractMap.SimpleEntry<java.lang.String, java.lang.String>>of(new java.util.AbstractMap.SimpleEntry<>(\"key0\", \"value0\"), new java.util.AbstractMap.SimpleEntry<>(\"key1\", \"value1\"), new java.util.AbstractMap.SimpleEntry<>(\"key2\", (java.lang.String) null)).collect(java.util.HashMap::new, (map, e) -> map.put(e.getKey(), e.getValue()), java.util.HashMap::putAll)",
         Arrays.asList((byte) 1, // do not return null for the map
             32, // remaining bytes
             (byte) 1, // do not return null for the string

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -5,6 +5,7 @@ load("//bazel:fuzz_target.bzl", "java_fuzz_target_test")
 
 java_fuzz_target_test(
     name = "Autofuzz",
+    execute_crash_reproducer = True,
     fuzzer_args = [
         "--autofuzz=com.google.json.JsonSanitizer::sanitize",
         # Exit after the first finding for testing purposes.

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -13,3 +13,17 @@ java_fuzz_target_test(
     target_class = "com.example.LongStringFuzzer",
     verify_crash_input = False,
 )
+
+java_fuzz_target_test(
+    name = "JpegImageParserAutofuzz",
+    execute_crash_reproducer = True,
+    fuzzer_args = [
+        "--autofuzz=org.apache.commons.imaging.formats.jpeg.JpegImageParser::getBufferedImage",
+        # Exit after the first finding for testing purposes.
+        "--keep_going=1",
+        "--autofuzz_ignore=java.lang.NullPointerException",
+    ],
+    runtime_deps = [
+        "@maven//:org_apache_commons_commons_imaging",
+    ],
+)


### PR DESCRIPTION
The Autofuzz Java reproducers are based on the existing codegen
functionality and have the following advantages compared to the usual
Java reproducers generated for Autofuzz findings:
* They are completely independent of Jazzer and can thus be debugged
  easily, even by developers not familiar with Jazzer.
* They are stable with respect to the classpath as they encode all
  choices made during Autofuzz in literal references to classes.
* They are human-readable, especially after a straightforward pass
  through IntelliJ's formatting and code cleanups.