### PR TITLE
Only trim reflection and Autofuzz classes from stack trace

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/FuzzTarget.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/FuzzTarget.java
@@ -285,8 +285,8 @@ public final class FuzzTarget {
     }
   }
 
-  // Removes all stack trace elements that live in the Java standard library, internal JDK classes
-  // or the autofuzz package from the bottom of all stack frames.
+  // Removes all stack trace elements that live in the Java reflection packages or the autofuzz
+  // package from the bottom of all stack frames.
   private static void cleanStackTraces(Throwable t) {
     Throwable cause = t;
     while (cause != null) {
@@ -295,8 +295,9 @@ public final class FuzzTarget {
       for (firstInterestingPos = elements.length - 1; firstInterestingPos > 0;
            firstInterestingPos--) {
         String className = elements[firstInterestingPos].getClassName();
-        if (!className.startsWith("com.code_intelligence.jazzer.autofuzz")
-            && !className.startsWith("java.") && !className.startsWith("jdk.")) {
+        if (!className.startsWith("com.code_intelligence.jazzer.autofuzz.")
+            && !className.startsWith("java.lang.reflect.")
+            && !className.startsWith("jdk.internal.reflect.")) {
           break;
         }
       }


### PR DESCRIPTION
Trimming all classes in java.** and jdk.** from the stack trace made it
useless when fuzzing the Java standard library itself. Also fixes the
matching of Autofuzz classes.