### PR TITLE
Warn when additionalClassesToHook are not hooked

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
@@ -41,11 +41,13 @@ val KNOWN_ARGUMENTS = listOf(
 )
 
 private object AgentJarFinder {
-    private val agentJarPath = AgentJarFinder::class.java.protectionDomain?.codeSource?.location?.toURI()
+    private val agentJarPath =
+        AgentJarFinder::class.java.protectionDomain?.codeSource?.location?.toURI()
     val agentJarFile = agentJarPath?.let { JarFile(File(it)) }
 }
 
-private val argumentDelimiter = if (System.getProperty("os.name").startsWith("Windows")) ";" else ":"
+private val argumentDelimiter =
+    if (System.getProperty("os.name").startsWith("Windows")) ";" else ":"
 
 @OptIn(ExperimentalPathApi::class)
 fun premain(agentArgs: String?, instrumentation: Instrumentation) {
@@ -74,9 +76,10 @@ fun premain(agentArgs: String?, instrumentation: Instrumentation) {
                 else -> splitArg[0] to splitArg[1].split(argumentDelimiter)
             }
         }.toMap()
-    val manifestCustomHookNames = ManifestUtils.combineManifestValues(ManifestUtils.HOOK_CLASSES).flatMap {
-        it.split(':')
-    }
+    val manifestCustomHookNames =
+        ManifestUtils.combineManifestValues(ManifestUtils.HOOK_CLASSES).flatMap {
+            it.split(':')
+        }
     val customHookNames = manifestCustomHookNames + (argumentMap["custom_hooks"] ?: emptyList())
     val classNameGlobber = ClassNameGlobber(
         argumentMap["instrumentation_includes"] ?: emptyList(),

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -68,11 +68,14 @@ internal class RuntimeInstrumentor(
     private var additionalClassesToHookInstrument: ClassNameGlobber = ClassNameGlobber(emptyList(), listOf())
     private val customHooks = mutableListOf<Hook>()
 
-    fun registerCustomHooks(hooks: List<Hook>) {
+    // Returns the globber of all classes to be instrumented with hooks that were added upon a
+    // hook's request.
+    fun registerCustomHooks(hooks: List<Hook>): ClassNameGlobber {
         customHooks.addAll(hooks)
         additionalClassesToHookInstrument = additionalClassesToHookInstrument.withAdditionalIncludes(
             hooks.flatMap(Hook::additionalClassesToHook)
         )
+        return additionalClassesToHookInstrument
     }
 
     @OptIn(kotlin.time.ExperimentalTime::class)


### PR DESCRIPTION
This can happen when a hook depends on the classes to hook, e.g. because
it references the classes in a static initializer. If it turns out that
this is necessary, we would have to consider reinstrumentation.