### PR TITLE
Do not emit unnecessarily large fake PCs

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
@@ -133,7 +133,7 @@ internal class TraceDataFlowInstrumentor(private val types: Set<InstrumentationT
     }
 
     private fun InsnList.pushFakePc() {
-        add(LdcInsnNode(random.nextInt(4096)))
+        add(LdcInsnNode(random.nextInt(512)))
     }
 
     private fun longCmpInstrumentation() = InsnList().apply {


### PR DESCRIPTION
Now that our trampoline rightfully only forwards the lower 9 bits of the fake PC, we don't have to emit PCs larger than this in the first place.