### PR TITLE
Allow custom hooks to statically reference classes to hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ for more details.
 
 To use the compiled method hooks they have to be available on the classpath provided by `--cp` and can then be loaded by providing the
 flag `--custom_hooks`, which takes a colon-separated list of names of classes to load hooks from.
+If a hook is meant to be applied to a class in the Java standard library, it has to be loaded from a JAR file so that Jazzer can [add it to the bootstrap class loader search](https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/Instrumentation.html#appendToBootstrapClassLoaderSearch-java.util.jar.JarFile-).
 This list of custom hooks can alternatively be specified via the `Jazzer-Hook-Classes` attribute in the fuzz target
 JAR's manifest.
 

--- a/agent/BUILD.bazel
+++ b/agent/BUILD.bazel
@@ -7,6 +7,7 @@ java_binary(
     create_executable = False,
     deploy_manifest_lines = [
         "Premain-Class: com.code_intelligence.jazzer.agent.Agent",
+        "Can-Retransform-Classes: true",
         "Jazzer-Hook-Classes: {}".format(":".join(SANITIZER_CLASSES)),
     ],
     runtime_deps = [

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -27,3 +27,10 @@ java_fuzz_target_test(
         "@maven//:org_apache_commons_commons_imaging",
     ],
 )
+
+java_fuzz_target_test(
+    name = "HookDependenciesFuzzer",
+    srcs = ["src/test/java/com/example/HookDependenciesFuzzer.java"],
+    hook_classes = ["com.example.HookDependenciesFuzzer"],
+    target_class = "com.example.HookDependenciesFuzzer",
+)

--- a/tests/src/test/java/com/example/HookDependenciesFuzzer.java
+++ b/tests/src/test/java/com/example/HookDependenciesFuzzer.java
@@ -1,0 +1,67 @@
+// Copyright 2022 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueLow;
+import com.code_intelligence.jazzer.api.HookType;
+import com.code_intelligence.jazzer.api.MethodHook;
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Field;
+import java.util.regex.Pattern;
+
+// This fuzzer verifies that:
+// 1. a class referenced in a static initializer of a hook is still instrumented with the hook;
+// 2. hooks that are not shipped in the Jazzer agent JAR can still instrument Java standard library
+//    classes.
+public class HookDependenciesFuzzer {
+  private static final Field PATTERN_ROOT;
+
+  static {
+    Field root;
+    try {
+      root = Pattern.class.getDeclaredField("root");
+    } catch (NoSuchFieldException e) {
+      root = null;
+    }
+    PATTERN_ROOT = root;
+  }
+
+  @MethodHook(type = HookType.AFTER, targetClassName = "java.util.regex.Matcher",
+      targetMethod = "matches", additionalClassesToHook = {"java.util.regex.Pattern"})
+  public static void
+  matcherMatchesHook(MethodHandle method, Object alwaysNull, Object[] alwaysEmpty, int hookId,
+      boolean returnValue) {
+    if (PATTERN_ROOT != null) {
+      throw new FuzzerSecurityIssueLow("Hook applied even though it depends on the class to hook");
+    }
+  }
+
+  public static void fuzzerTestOneInput(byte[] data) {
+    try {
+      Pattern.matches("foobar", "foobar");
+    } catch (Throwable t) {
+      if (t instanceof FuzzerSecurityIssueLow) {
+        throw t;
+      } else {
+        // Unexpected exception, exit without producing a finding to let the test fail due to the
+        // missing Java reproducer.
+        // FIXME(fabian): This is hacky and will result in false positives as soon as we implement
+        //  Java reproducers for fuzz target exits. Replace this with a more reliable signal.
+        t.printStackTrace();
+        System.exit(1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
By retransforming classes that are subject to hook instrumentation after
all hooks have been loaded, we ensure that classes don't fail to be
instrumented with hooks because they are statically referenced by hooks.
This makes it easier to write efficient and readable hooks as it removes
the need for using lazy reflection to access members of classes that
should be hooked.