### PR TITLE
Make OsCommandInjection tests safer

### DIFF
--- a/sanitizers/src/test/java/com/example/OsCommandInjectionProcessBuilder.java
+++ b/sanitizers/src/test/java/com/example/OsCommandInjectionProcessBuilder.java
@@ -15,14 +15,15 @@
 package com.example;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 public class OsCommandInjectionProcessBuilder {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String input = data.consumeRemainingAsAsciiString();
     try {
-      Process process = new ProcessBuilder(input).start();
+      ProcessBuilder processBuilder = new ProcessBuilder(input);
+      processBuilder.environment().clear();
+      Process process = processBuilder.start();
       // This should be way faster, but we have to wait until the call is done
       if (!process.waitFor(10, TimeUnit.MILLISECONDS)) {
         process.destroyForcibly();

--- a/sanitizers/src/test/java/com/example/OsCommandInjectionRuntimeExec.java
+++ b/sanitizers/src/test/java/com/example/OsCommandInjectionRuntimeExec.java
@@ -17,14 +17,13 @@ package com.example;
 import static java.lang.Runtime.getRuntime;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
 public class OsCommandInjectionRuntimeExec {
   public static void fuzzerTestOneInput(FuzzedDataProvider data) {
     String input = data.consumeRemainingAsAsciiString();
     try {
-      Process process = getRuntime().exec(input);
+      Process process = getRuntime().exec(input, new String[] {});
       // This should be way faster, but we have to wait until the call is done
       if (!process.waitFor(10, TimeUnit.MILLISECONDS)) {
         process.destroyForcibly();


### PR DESCRIPTION
By clearing out the environment, especially PATH, it should become
extremely unlikely that the fuzzer ever executes a valid command.

Installing a SecurityManager would be even safer, but it's terminally
deprecated and incompatible with the Bazel test runner, which itself
uses a SecurityManager.