### PR TITLE
Support hooks on interfaces

### DIFF
--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -69,4 +69,6 @@ jobs:
         with:
           name: testlogs-${{ matrix.arch }}-${{ matrix.jdk }}
           # https://github.com/actions/upload-artifact/issues/92#issuecomment-711107236
-          path: bazel-testlogs*/**/test.log
+          path: |
+            bazel-testlogs*/**/test.log
+            bazel-out*/**/hs_err_pid*.log

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/MethodHook.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/MethodHook.java
@@ -143,6 +143,11 @@ public @interface MethodHook {
    * The name of the class that contains the method that should be hooked,
    * as returned by {@link Class#getName()}.
    * <p>
+   * If an interface or abstract class is specified, also calls to all
+   * implementations and subclasses available on the classpath during startup
+   * are hooked, respectively. Interfaces and subclasses are not taken into
+   * account for concrete classes.
+   * <p>
    * Examples:
    * <p><ul>
    * <li>{@link String}: {@code "java.lang.String"}

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
@@ -12,6 +12,7 @@ kt_jvm_library(
         "Hook.kt",
         "HookInstrumentor.kt",
         "HookMethodVisitor.kt",
+        "Hooks.kt",
         "Instrumentor.kt",
         "StaticMethodStrategy.java",
         "TraceDataFlowInstrumentor.kt",

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Hooks.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Hooks.kt
@@ -1,0 +1,111 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.instrumentor
+
+import com.code_intelligence.jazzer.api.MethodHook
+import com.code_intelligence.jazzer.api.MethodHooks
+import com.code_intelligence.jazzer.utils.ClassNameGlobber
+import io.github.classgraph.ClassGraph
+import io.github.classgraph.ScanResult
+import java.lang.reflect.Method
+
+data class Hooks(
+    val hooks: List<Hook>,
+    val hookClasses: Set<Class<*>>,
+    val additionalHookClassNameGlobber: ClassNameGlobber
+) {
+
+    companion object {
+        fun loadHooks(vararg hookClassNames: Set<String>): List<Hooks> {
+            return ClassGraph()
+                .enableClassInfo()
+                .enableSystemJarsAndModules()
+                .rejectPackages("jaz.*", "com.code_intelligence.jazzer.*")
+                .scan()
+                .use { scanResult ->
+                    // Capture scanResult in HooksLoader field to not pass it through
+                    // all internal hook loading methods.
+                    val loader = HooksLoader(scanResult)
+                    hookClassNames.map(loader::load)
+                }
+        }
+
+        private class HooksLoader(private val scanResult: ScanResult) {
+            fun load(hookClassNames: Set<String>): Hooks {
+                val hooksWithHookClasses = hookClassNames.flatMap(::loadHooks)
+                val hooks = hooksWithHookClasses.map { it.first }
+                val hookClasses = hooksWithHookClasses.map { it.second }.toSet()
+                val additionalHookClassNameGlobber = ClassNameGlobber(
+                    hooks.flatMap(Hook::additionalClassesToHook),
+                    emptyList()
+                )
+                return Hooks(hooks, hookClasses, additionalHookClassNameGlobber)
+            }
+
+            private fun loadHooks(hookClassName: String): List<Pair<Hook, Class<*>>> {
+                return try {
+                    // Custom hook classes outside the agent jar can not be found by bootstrap
+                    // class loader, so use the system class loader as that will be the main application
+                    // class loader and can access jars on the classpath.
+                    // Also, don't initialize the hook class to defer further class loading.
+                    val hookClass = Class.forName(hookClassName, false, ClassLoader.getSystemClassLoader())
+                    loadHooks(hookClass).also {
+                        println("INFO: Loaded ${it.size} hooks from $hookClassName")
+                    }.map {
+                        it to hookClass
+                    }
+                } catch (e: ClassNotFoundException) {
+                    println("WARN: Failed to load hooks from $hookClassName: ${e.printStackTrace()}")
+                    emptyList()
+                }
+            }
+
+            private fun loadHooks(hookClass: Class<*>): List<Hook> {
+                val hooks = mutableListOf<Hook>()
+                for (method in hookClass.methods) {
+                    method.getAnnotation(MethodHook::class.java)?.let {
+                        hooks.addAll(verifyAndGetHooks(method, it))
+                    }
+                    method.getAnnotation(MethodHooks::class.java)?.let {
+                        it.value.forEach { hookAnnotation ->
+                            hooks.addAll(verifyAndGetHooks(method, hookAnnotation))
+                        }
+                    }
+                }
+                return hooks
+            }
+
+            private fun verifyAndGetHooks(hookMethod: Method, hookData: MethodHook): List<Hook> {
+                return lookupClassesToHook(hookData.targetClassName)
+                    .map { className ->
+                        Hook.createAndVerifyHook(hookMethod, hookData, className)
+                    }
+            }
+
+            private fun lookupClassesToHook(annotationTargetClassName: String): List<String> {
+                // Allowing arbitrary exterior whitespace in the target class name allows for an easy workaround
+                // for mangled hooks due to shading applied to hooks.
+                val targetClassName = annotationTargetClassName.trim()
+                val targetClassInfo = scanResult.getClassInfo(targetClassName) ?: return listOf(targetClassName)
+                val additionalTargetClasses = when {
+                    targetClassInfo.isInterface -> scanResult.getClassesImplementing(targetClassName)
+                    targetClassInfo.isAbstract -> scanResult.getSubclasses(targetClassName)
+                    else -> emptyList()
+                }
+                return listOf(targetClassName) + additionalTargetClasses.map { it.name }
+            }
+        }
+    }
+}

--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
@@ -84,10 +84,6 @@ final public class TraceCmpHooks {
   @MethodHook(
       type = HookType.AFTER, targetClassName = "java.lang.CharSequence", targetMethod = "equals")
   @MethodHook(type = HookType.AFTER, targetClassName = "java.lang.Number", targetMethod = "equals")
-  @MethodHook(type = HookType.AFTER, targetClassName = "java.lang.Byte", targetMethod = "equals")
-  @MethodHook(type = HookType.AFTER, targetClassName = "java.lang.Integer", targetMethod = "equals")
-  @MethodHook(type = HookType.AFTER, targetClassName = "java.lang.Short", targetMethod = "equals")
-  @MethodHook(type = HookType.AFTER, targetClassName = "java.lang.Long", targetMethod = "equals")
   public static void
   genericEquals(
       MethodHandle method, Object thisObject, Object[] arguments, int hookId, Boolean returnValue) {
@@ -277,21 +273,8 @@ final public class TraceCmpHooks {
   private static final int MAX_NUM_KEYS_TO_ENUMERATE = 100;
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  @MethodHook(type = HookType.AFTER, targetClassName = "com.google.common.collect.ImmutableMap",
-      targetMethod = "get")
-  @MethodHook(
-      type = HookType.AFTER, targetClassName = "java.util.AbstractMap", targetMethod = "get")
-  @MethodHook(type = HookType.AFTER, targetClassName = "java.util.EnumMap", targetMethod = "get")
-  @MethodHook(type = HookType.AFTER, targetClassName = "java.util.HashMap", targetMethod = "get")
-  @MethodHook(
-      type = HookType.AFTER, targetClassName = "java.util.LinkedHashMap", targetMethod = "get")
   @MethodHook(type = HookType.AFTER, targetClassName = "java.util.Map", targetMethod = "get")
-  @MethodHook(type = HookType.AFTER, targetClassName = "java.util.SortedMap", targetMethod = "get")
-  @MethodHook(type = HookType.AFTER, targetClassName = "java.util.TreeMap", targetMethod = "get")
-  @MethodHook(type = HookType.AFTER, targetClassName = "java.util.concurrent.ConcurrentMap",
-      targetMethod = "get")
-  public static void
-  mapGet(
+  public static void mapGet(
       MethodHandle method, Object thisObject, Object[] arguments, int hookId, Object returnValue) {
     if (returnValue != null)
       return;

--- a/agent/src/main/java/com/code_intelligence/jazzer/utils/ClassNameGlobber.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/utils/ClassNameGlobber.kt
@@ -33,9 +33,9 @@ private val BASE_EXCLUDED_CLASS_NAME_GLOBS = listOf(
     "sun.**",
 )
 
-class ClassNameGlobber(private val includes: List<String>, private val excludes: List<String>) {
+class ClassNameGlobber(includes: List<String>, excludes: List<String>) {
     // If no include globs are provided, start with all classes.
-    private val includeMatchers = (if (includes.isEmpty()) BASE_INCLUDED_CLASS_NAME_GLOBS else includes)
+    private val includeMatchers = includes.ifEmpty { BASE_INCLUDED_CLASS_NAME_GLOBS }
         .map(::SimpleGlobMatcher)
 
     // If no include globs are provided, additionally exclude stdlib classes as well as our own classes.
@@ -45,9 +45,6 @@ class ClassNameGlobber(private val includes: List<String>, private val excludes:
     fun includes(className: String): Boolean {
         return includeMatchers.any { it.matches(className) } && excludeMatchers.none { it.matches(className) }
     }
-
-    fun withAdditionalIncludes(includes: List<String>): ClassNameGlobber =
-        ClassNameGlobber(this.includes + includes, excludes)
 }
 
 class SimpleGlobMatcher(val glob: String) {

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooksPatchTest.kt
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooksPatchTest.kt
@@ -18,7 +18,8 @@ import org.junit.Test
 import java.io.File
 
 private fun applyAfterHooks(bytecode: ByteArray): ByteArray {
-    return HookInstrumentor(loadHooks(AfterHooks::class.java), false).instrument(bytecode)
+    val hooks = Hooks.loadHooks(setOf(AfterHooks::class.java.name)).first().hooks
+    return HookInstrumentor(hooks, false).instrument(bytecode)
 }
 
 private fun getOriginalAfterHooksTargetInstance(): AfterHooksTargetContract {

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/BeforeHooksPatchTest.kt
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/BeforeHooksPatchTest.kt
@@ -18,7 +18,8 @@ import org.junit.Test
 import java.io.File
 
 private fun applyBeforeHooks(bytecode: ByteArray): ByteArray {
-    return HookInstrumentor(loadHooks(BeforeHooks::class.java), false).instrument(bytecode)
+    val hooks = Hooks.loadHooks(setOf(BeforeHooks::class.java.name)).first().hooks
+    return HookInstrumentor(hooks, false).instrument(bytecode)
 }
 
 private fun getOriginalBeforeHooksTargetInstance(): BeforeHooksTargetContract {

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/HookValidationTest.kt
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/HookValidationTest.kt
@@ -22,7 +22,8 @@ import kotlin.test.assertFailsWith
 class HookValidationTest {
     @Test
     fun testValidHooks() {
-        assertEquals(6, loadHooks(ValidHookMocks::class.java).size)
+        val hooks = Hooks.loadHooks(setOf(ValidHookMocks::class.java.name)).first().hooks
+        assertEquals(6, hooks.size)
     }
 
     @Test
@@ -30,7 +31,8 @@ class HookValidationTest {
         for (method in InvalidHookMocks::class.java.methods) {
             if (method.isAnnotationPresent(MethodHook::class.java)) {
                 assertFailsWith<IllegalArgumentException>("Expected ${method.name} to be an invalid hook") {
-                    Hook.verifyAndGetHook(method, method.declaredAnnotations.first() as MethodHook)
+                    val methodHook = method.declaredAnnotations.first() as MethodHook
+                    Hook.createAndVerifyHook(method, methodHook, methodHook.targetClassName)
                 }
             }
         }

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/ReplaceHooks.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/ReplaceHooks.java
@@ -108,6 +108,13 @@ public class ReplaceHooks {
     return true;
   }
 
+  @MethodHook(type = HookType.REPLACE, targetClassName = "java.util.Set", targetMethod = "contains",
+      targetMethodDescriptor = "(Ljava/lang/Object;)Z")
+  public static boolean
+  patchSetGet(MethodHandle method, Object thisObject, Object[] arguments, int hookId) {
+    return true;
+  }
+
   @MethodHook(type = HookType.REPLACE,
       targetClassName = "com.code_intelligence.jazzer.instrumentor.ReplaceHooksInit",
       targetMethod = "<init>", targetMethodDescriptor = "()V")

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/ReplaceHooksPatchTest.kt
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/ReplaceHooksPatchTest.kt
@@ -18,7 +18,8 @@ import org.junit.Test
 import java.io.File
 
 private fun applyReplaceHooks(bytecode: ByteArray): ByteArray {
-    return HookInstrumentor(loadHooks(ReplaceHooks::class.java), false).instrument(bytecode)
+    val hooks = Hooks.loadHooks(setOf(ReplaceHooks::class.java.name)).first().hooks
+    return HookInstrumentor(hooks, false).instrument(bytecode)
 }
 
 private fun getOriginalReplaceHooksTargetInstance(): ReplaceHooksTargetContract {

--- a/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/ReplaceHooksTarget.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/instrumentor/ReplaceHooksTarget.java
@@ -15,9 +15,9 @@
 package com.code_intelligence.jazzer.instrumentor;
 
 import java.security.SecureRandom;
-import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 // selfCheck() only passes with the hooks in ReplaceHooks.java applied.
@@ -56,9 +56,12 @@ public class ReplaceHooksTarget implements ReplaceHooksTargetContract {
       shouldCallPass();
     }
 
-    AbstractList<Boolean> boolList = new ArrayList<>();
+    ArrayList<Boolean> boolList = new ArrayList<>();
     boolList.add(false);
     results.put("arrayListGet", boolList.get(0));
+
+    HashSet<Boolean> boolSet = new HashSet<>();
+    results.put("stringSetGet", boolSet.contains(Boolean.TRUE));
 
     results.put("shouldInitialize", new ReplaceHooksInit().initialized);
     results.put("shouldInitializeWithParams", new ReplaceHooksInit(false, "foo").initialized);

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -145,7 +145,7 @@ java_fuzz_target_test(
         "JAVA_OPTS": "-Dfoo=not_foo -Djava_opts=1",
     },
     fuzzer_args = [
-        "-fork=5",
+        "-fork=3",
         "--additional_jvm_args=-Dbaz=baz",
     ] + select({
         # \\\\ becomes \\ when evaluated as a Starlark string literal, then \ in

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/NamingContextLookup.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/NamingContextLookup.kt
@@ -42,43 +42,7 @@ object NamingContextLookup {
         ),
         MethodHook(
             type = HookType.REPLACE,
-            targetClassName = "javax.naming.InitialContext",
-            targetMethod = "lookup",
-            targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Object;",
-        ),
-        MethodHook(
-            type = HookType.REPLACE,
-            targetClassName = "javax.naming.InitialDirContext",
-            targetMethod = "lookup",
-            targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Object;",
-        ),
-        MethodHook(
-            type = HookType.REPLACE,
-            targetClassName = "javax.naming.InitialLdapContext",
-            targetMethod = "lookup",
-            targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Object;",
-        ),
-        MethodHook(
-            type = HookType.REPLACE,
             targetClassName = "javax.naming.Context",
-            targetMethod = "lookupLink",
-            targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Object;",
-        ),
-        MethodHook(
-            type = HookType.REPLACE,
-            targetClassName = "javax.naming.InitialContext",
-            targetMethod = "lookupLink",
-            targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Object;",
-        ),
-        MethodHook(
-            type = HookType.REPLACE,
-            targetClassName = "javax.naming.InitialDirContext",
-            targetMethod = "lookupLink",
-            targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Object;",
-        ),
-        MethodHook(
-            type = HookType.REPLACE,
-            targetClassName = "javax.naming.InitialLdapContext",
             targetMethod = "lookupLink",
             targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Object;",
         ),


### PR DESCRIPTION
If the target type of a hook is abstract or an interface, it is applied on all its implementations.