### PR TITLE
Enable BuildBuddy integration

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,12 @@ run:windows --noincompatible_strict_action_env
 # Since the toolchain is conditional on OS and architecture, set it on the particular GitHub Action.
 build:toolchain --//third_party:toolchain
 
+# CI tests (not using the toolchain to test OSS-Fuzz & local compatibility)
+build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
+build:ci --bes_backend=grpcs://cloud.buildbuddy.io
+build:ci --remote_cache=grpcs://cloud.buildbuddy.io
+build:ci --remote_timeout=3600
+
 # Maven publishing (local only, requires GPG signature)
 build:maven --config=toolchain
 build:maven --stamp

--- a/.github/scripts/echoBuildBuddyConfig.sh
+++ b/.github/scripts/echoBuildBuddyConfig.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [ -n "${1}" ]; then
+  echo "BUILD_BUDDY_CONFIG=--config=ci --remote_header=x-buildbuddy-api-key=${1}";
+else
+  echo "";
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,13 @@ jobs:
         with:
           java-version: 8
 
+      - name: Set Build Buddy config
+        run: .github/scripts/echoBuildBuddyConfig.sh ${{ secrets.BUILDBUDDY_API_KEY }} >> $GITHUB_ENV
+        shell: bash
+
       - name: Build
         run: |
-          bazelisk build --java_runtime_version=local_jdk_8 ${{ matrix.bazel_args }} //agent/src/main/java/com/code_intelligence/jazzer/replay:Replayer_deploy.jar //:jazzer_release
+          bazelisk build ${{env.BUILD_BUDDY_CONFIG}} --java_runtime_version=local_jdk_8 ${{ matrix.bazel_args }} //agent/src/main/java/com/code_intelligence/jazzer/replay:Replayer_deploy.jar //:jazzer_release
           cp -L bazel-bin/agent/src/main/java/com/code_intelligence/jazzer/replay/Replayer_deploy.jar replayer.jar
           cp -L bazel-bin/jazzer_release.tar.gz release-${{ matrix.arch }}.tar.gz
 
@@ -87,4 +91,3 @@ jobs:
         with:
           name: replayer
           path: replayer.jar
-

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -49,11 +49,15 @@ jobs:
           path: ${{ matrix.cache }}
           key: bazel-disk-cache-${{ matrix.arch }}-${{ matrix.jdk }}
 
+      - name: Set Build Buddy config
+        run: .github/scripts/echoBuildBuddyConfig.sh ${{ secrets.BUILDBUDDY_API_KEY }} >> $GITHUB_ENV
+        shell: bash
+
       - name: Build
-        run: bazelisk build --java_runtime_version=local_jdk_${{ matrix.jdk }} --disk_cache=${{ matrix.cache }} ${{ matrix.bazel_args }} //...
+        run: bazelisk build ${{env.BUILD_BUDDY_CONFIG}} --java_runtime_version=local_jdk_${{ matrix.jdk }} --disk_cache=${{ matrix.cache }} ${{ matrix.bazel_args }} //...
 
       - name: Test
-        run: bazelisk test --java_runtime_version=local_jdk_${{ matrix.jdk }} --disk_cache=${{ matrix.cache }} ${{ matrix.bazel_args }} //...
+        run: bazelisk test ${{env.BUILD_BUDDY_CONFIG}} --java_runtime_version=local_jdk_${{ matrix.jdk }} --disk_cache=${{ matrix.cache }} ${{ matrix.bazel_args }} //...
 
       - name: Print JDK used
         if: matrix.os != 'windows-latest'


### PR DESCRIPTION
Enable BuildBuddy integration when the API key is available in the
workflow. Forks should still be able to execute the workflow without
piping logs to BuildBuddy.

This is done by setting the environment variable BUILD_BUDDY_CONFIG
based on the API secret. The script echoBuildBuddyConfig returns an
environment config stating the needed bazel settings if the API token is
passed in as first argument, otherwise an empty string is returned. The
return value is used to update the workflow environment settings.

The passed around secret is filtered out in the GitHub logs.

Fixes #294 