### PR TITLE
Enable multiple hooks

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/api/HookType.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/HookType.java
@@ -17,6 +17,7 @@ package com.code_intelligence.jazzer.api;
 /**
  * The type of a {@link MethodHook}.
  */
+// Note: The order of entries is important and is used during instrumentation.
 public enum HookType {
   BEFORE,
   REPLACE,

--- a/agent/src/main/java/com/code_intelligence/jazzer/api/MethodHook.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/api/MethodHook.java
@@ -115,6 +115,13 @@ import java.lang.invoke.MethodType;
  * will be wrapped into their corresponding wrapper type (e.g. {@link Boolean}).
  * If the original method has return type {@code void}, this value will be
  * {@code null}.
+ * <p>
+ * Multiple {@link HookType#BEFORE} and {@link HookType#AFTER} hooks are
+ * allowed to reference the same target method. Exclusively one
+ * {@link HookType#REPLACE} hook may reference a target method, no other types
+ * allowed. Attention must be paid to not guide the Fuzzer in different
+ * directions via {@link Jazzer}'s {@code guideTowardsXY} methods in the
+ * different hooks.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/HookMethodVisitor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/HookMethodVisitor.kt
@@ -56,7 +56,7 @@ private class HookMethodVisitor(
         }
     }
 
-    private val hooks = hooks.associateBy { hook ->
+    private val hooks = hooks.groupBy { hook ->
         var hookKey = "${hook.hookType}#${hook.targetInternalClassName}#${hook.targetMethodName}"
         if (hook.targetMethodDescriptor != null)
             hookKey += "#${hook.targetMethodDescriptor}"
@@ -74,75 +74,22 @@ private class HookMethodVisitor(
             mv.visitMethodInsn(opcode, owner, methodName, methodDescriptor, isInterface)
             return
         }
-        handleMethodInsn(HookType.BEFORE, opcode, owner, methodName, methodDescriptor, isInterface)
-    }
-
-    /**
-     * Emits the bytecode for a method call instruction for the next applicable hook type in order (BEFORE, REPLACE,
-     * AFTER). Since the instrumented code is indistinguishable from an uninstrumented call instruction, it can be
-     * safely nested. Combining REPLACE hooks with other hooks is however not supported as these hooks already subsume
-     * the functionality of BEFORE and AFTER hooks.
-     */
-    private fun visitNextHookTypeOrCall(
-        hookType: HookType,
-        appliedHook: Boolean,
-        opcode: Int,
-        owner: String,
-        methodName: String,
-        methodDescriptor: String,
-        isInterface: Boolean,
-    ) = when (hookType) {
-        HookType.BEFORE -> {
-            val nextHookType = if (appliedHook) {
-                // After a BEFORE hook has been applied, we can safely apply an AFTER hook by replacing the actual
-                // call instruction with the full bytecode injected for the AFTER hook.
-                HookType.AFTER
-            } else {
-                // If no BEFORE hook is registered, look for a REPLACE hook next.
-                HookType.REPLACE
-            }
-            handleMethodInsn(nextHookType, opcode, owner, methodName, methodDescriptor, isInterface)
-        }
-        HookType.REPLACE -> {
-            // REPLACE hooks can't (and don't need to) be mixed with other hooks. We only cycle through them if we
-            // couldn't find a matching REPLACE hook, in which case we try an AFTER hook next.
-            require(!appliedHook)
-            handleMethodInsn(HookType.AFTER, opcode, owner, methodName, methodDescriptor, isInterface)
-        }
-        // An AFTER hook is always the last in the chain. Whether a hook has been applied or not, always emit the
-        // actual call instruction.
-        HookType.AFTER -> mv.visitMethodInsn(opcode, owner, methodName, methodDescriptor, isInterface)
+        handleMethodInsn(opcode, owner, methodName, methodDescriptor, isInterface)
     }
 
     fun handleMethodInsn(
-        hookType: HookType,
         opcode: Int,
         owner: String,
         methodName: String,
         methodDescriptor: String,
         isInterface: Boolean,
     ) {
-        val hook = findMatchingHook(hookType, owner, methodName, methodDescriptor)
-        if (hook == null) {
-            visitNextHookTypeOrCall(hookType, false, opcode, owner, methodName, methodDescriptor, isInterface)
+        val matchingHooks = findMatchingHooks(owner, methodName, methodDescriptor)
+
+        if (matchingHooks.isEmpty()) {
+            mv.visitMethodInsn(opcode, owner, methodName, methodDescriptor, isInterface)
             return
         }
-
-        if (java6Mode && hookType == HookType.REPLACE) {
-            if (showUnsupportedHookWarning.getAndSet(false)) {
-                println(
-                    """WARN: Some hooks could not be applied to class files built for Java 7 or lower.
-                      |WARN: Ensure that the fuzz target and its dependencies are compiled with
-                      |WARN: -target 8 or higher to identify as many bugs as possible.
-            """.trimMargin()
-                )
-            }
-            visitNextHookTypeOrCall(hookType, false, opcode, owner, methodName, methodDescriptor, isInterface)
-            return
-        }
-
-        // The hookId is used to identify a call site.
-        val hookId = random.nextInt()
 
         val paramDescriptors = extractParameterTypeDescriptors(methodDescriptor)
         val localObjArr = storeMethodArguments(paramDescriptors)
@@ -160,144 +107,158 @@ private class HookMethodVisitor(
         // We now removed all values for the original method call from the operand stack
         // and saved them to local variables.
 
-        // Start to build the arguments for the hook method.
-        if (methodName == "<init>") {
-            // Constructor is invoked on an uninitialized object, and that's still on the stack.
-            // In case of REPLACE pop it from the stack and replace it afterwards with the returned
-            // one from the hook.
-            if (hook.hookType == HookType.REPLACE) {
-                mv.visitInsn(Opcodes.POP)
-            }
-            // Special case for constructors:
-            // We cannot create a MethodHandle for a constructor, so we push null instead.
-            mv.visitInsn(Opcodes.ACONST_NULL) // push nullref
-            // Only pass the this object if it has been initialized by the time the hook is invoked.
-            if (hook.hookType == HookType.AFTER) {
-                mv.visitVarInsn(Opcodes.ALOAD, localOwnerObj)
-            } else {
+        val returnTypeDescriptor = extractReturnTypeDescriptor(methodDescriptor)
+        // Create a local variable to store the return value
+        val localReturnObj = lvs.newLocal(Type.getType(getWrapperTypeDescriptor(returnTypeDescriptor)))
+
+        matchingHooks.forEachIndexed { index, hook ->
+            // The hookId is used to identify a call site.
+            val hookId = random.nextInt()
+
+            // Start to build the arguments for the hook method.
+            if (methodName == "<init>") {
+                // Constructor is invoked on an uninitialized object, and that's still on the stack.
+                // In case of REPLACE pop it from the stack and replace it afterwards with the returned
+                // one from the hook.
+                if (hook.hookType == HookType.REPLACE) {
+                    mv.visitInsn(Opcodes.POP)
+                }
+                // Special case for constructors:
+                // We cannot create a MethodHandle for a constructor, so we push null instead.
                 mv.visitInsn(Opcodes.ACONST_NULL) // push nullref
-            }
-        } else {
-            // Push a MethodHandle representing the hooked method.
-            val handleOpcode = when (opcode) {
-                Opcodes.INVOKEVIRTUAL -> Opcodes.H_INVOKEVIRTUAL
-                Opcodes.INVOKEINTERFACE -> Opcodes.H_INVOKEINTERFACE
-                Opcodes.INVOKESTATIC -> Opcodes.H_INVOKESTATIC
-                Opcodes.INVOKESPECIAL -> Opcodes.H_INVOKESPECIAL
-                else -> -1
-            }
-            if (java6Mode) {
-                // MethodHandle constants (type 15) are not supported in Java 6 class files (major version 50).
-                mv.visitInsn(Opcodes.ACONST_NULL) // push nullref
-            } else {
-                mv.visitLdcInsn(
-                    Handle(
-                        handleOpcode,
-                        owner,
-                        methodName,
-                        methodDescriptor,
-                        isInterface
-                    )
-                ) // push MethodHandle
-            }
-            // Stack layout: ... | MethodHandle (objectref)
-            // Push the owner object again
-            mv.visitVarInsn(Opcodes.ALOAD, localOwnerObj)
-        }
-        // Stack layout: ... | MethodHandle (objectref) | owner (objectref)
-        // Push a reference to our object array with the saved arguments
-        mv.visitVarInsn(Opcodes.ALOAD, localObjArr)
-        // Stack layout: ... | MethodHandle (objectref) | owner (objectref) | object array (arrayref)
-        // Push the hook id
-        mv.visitLdcInsn(hookId)
-        // Stack layout: ... | MethodHandle (objectref) | owner (objectref) | object array (arrayref) | hookId (int)
-        // How we proceed depends on the type of hook we want to implement
-        when (hook.hookType) {
-            HookType.BEFORE -> {
-                // Call the hook method
-                mv.visitMethodInsn(
-                    Opcodes.INVOKESTATIC,
-                    hook.hookInternalClassName,
-                    hook.hookMethodName,
-                    hook.hookMethodDescriptor,
-                    false
-                )
-                // Stack layout: ...
-                // Push the values for the original method call onto the stack again
-                if (opcode != Opcodes.INVOKESTATIC) {
-                    mv.visitVarInsn(Opcodes.ALOAD, localOwnerObj) // push owner object
-                }
-                loadMethodArguments(paramDescriptors, localObjArr) // push all method arguments
-                // Stack layout: ... | [owner (objectref)] | arg1 (primitive/objectref) | arg2 (primitive/objectref) | ...
-                // Call the original method or the next hook in order.
-                visitNextHookTypeOrCall(hookType, true, opcode, owner, methodName, methodDescriptor, isInterface)
-            }
-            HookType.REPLACE -> {
-                // Call the hook method
-                mv.visitMethodInsn(
-                    Opcodes.INVOKESTATIC,
-                    hook.hookInternalClassName,
-                    hook.hookMethodName,
-                    hook.hookMethodDescriptor,
-                    false
-                )
-                // Stack layout: ... | [return value (primitive/objectref)]
-                // Check if we need to process the return value
-                val returnTypeDescriptor = extractReturnTypeDescriptor(methodDescriptor)
-                if (returnTypeDescriptor != "V") {
-                    val hookMethodReturnType = extractReturnTypeDescriptor(hook.hookMethodDescriptor)
-                    // if the hook method's return type is primitive we don't need to unwrap or cast it
-                    if (!isPrimitiveType(hookMethodReturnType)) {
-                        // Check if the returned object type is different than the one that should be returned
-                        // If a primitive should be returned we check it's wrapper type
-                        val expectedType = getWrapperTypeDescriptor(returnTypeDescriptor)
-                        if (expectedType != hookMethodReturnType) {
-                            // Cast object
-                            mv.visitTypeInsn(Opcodes.CHECKCAST, extractInternalClassName(expectedType))
-                        }
-                        // Check if we need to unwrap the returned object
-                        unwrapTypeIfPrimitive(returnTypeDescriptor)
-                    }
-                }
-            }
-            HookType.AFTER -> {
-                // Push the values for the original method call again onto the stack
-                if (opcode != Opcodes.INVOKESTATIC) {
-                    mv.visitVarInsn(Opcodes.ALOAD, localOwnerObj) // push owner object
-                }
-                loadMethodArguments(paramDescriptors, localObjArr) // push all method arguments
-                // Stack layout: ... | MethodHandle (objectref) | owner (objectref) | object array (arrayref) | hookId (int)
-                //                   | [owner (objectref)] | arg1 (primitive/objectref) | arg2 (primitive/objectref) | ...
-                // Call the original method or the next hook in order
-                visitNextHookTypeOrCall(hookType, true, opcode, owner, methodName, methodDescriptor, isInterface)
-                val returnTypeDescriptor = extractReturnTypeDescriptor(methodDescriptor)
-                if (returnTypeDescriptor == "V") {
-                    // If the method didn't return anything, we push a nullref as placeholder
+                // Only pass the this object if it has been initialized by the time the hook is invoked.
+                if (hook.hookType == HookType.AFTER) {
+                    mv.visitVarInsn(Opcodes.ALOAD, localOwnerObj)
+                } else {
                     mv.visitInsn(Opcodes.ACONST_NULL) // push nullref
                 }
-                // Wrap return value if it is a primitive type
-                wrapTypeIfPrimitive(returnTypeDescriptor)
-                // Stack layout: ... | MethodHandle (objectref) | owner (objectref) | object array (arrayref) | hookId (int)
-                //                   | return value (objectref)
-                // Store the result value in a local variable (but keep it on the stack)
-                val localReturnObj = lvs.newLocal(Type.getType(getWrapperTypeDescriptor(returnTypeDescriptor)))
-                mv.visitVarInsn(Opcodes.ASTORE, localReturnObj) // consume objectref
-                mv.visitVarInsn(Opcodes.ALOAD, localReturnObj) // push objectref
-                // Call the hook method
-                mv.visitMethodInsn(
-                    Opcodes.INVOKESTATIC,
-                    hook.hookInternalClassName,
-                    hook.hookMethodName,
-                    hook.hookMethodDescriptor,
-                    false
-                )
-                // Stack layout: ...
-                if (returnTypeDescriptor != "V") {
-                    // Push the return value again
+            } else {
+                // Push a MethodHandle representing the hooked method.
+                val handleOpcode = when (opcode) {
+                    Opcodes.INVOKEVIRTUAL -> Opcodes.H_INVOKEVIRTUAL
+                    Opcodes.INVOKEINTERFACE -> Opcodes.H_INVOKEINTERFACE
+                    Opcodes.INVOKESTATIC -> Opcodes.H_INVOKESTATIC
+                    Opcodes.INVOKESPECIAL -> Opcodes.H_INVOKESPECIAL
+                    else -> -1
+                }
+                if (java6Mode) {
+                    // MethodHandle constants (type 15) are not supported in Java 6 class files (major version 50).
+                    mv.visitInsn(Opcodes.ACONST_NULL) // push nullref
+                } else {
+                    mv.visitLdcInsn(
+                        Handle(
+                            handleOpcode,
+                            owner,
+                            methodName,
+                            methodDescriptor,
+                            isInterface
+                        )
+                    ) // push MethodHandle
+                }
+                // Stack layout: ... | MethodHandle (objectref)
+                // Push the owner object again
+                mv.visitVarInsn(Opcodes.ALOAD, localOwnerObj)
+            }
+            // Stack layout: ... | MethodHandle (objectref) | owner (objectref)
+            // Push a reference to our object array with the saved arguments
+            mv.visitVarInsn(Opcodes.ALOAD, localObjArr)
+            // Stack layout: ... | MethodHandle (objectref) | owner (objectref) | object array (arrayref)
+            // Push the hook id
+            mv.visitLdcInsn(hookId)
+            // Stack layout: ... | MethodHandle (objectref) | owner (objectref) | object array (arrayref) | hookId (int)
+            // How we proceed depends on the type of hook we want to implement
+            when (hook.hookType) {
+                HookType.BEFORE -> {
+                    // Call the hook method
+                    mv.visitMethodInsn(
+                        Opcodes.INVOKESTATIC,
+                        hook.hookInternalClassName,
+                        hook.hookMethodName,
+                        hook.hookMethodDescriptor,
+                        false
+                    )
+
+                    // Call the original method if this is the last BEFORE hook. If not, the original method will be
+                    // called by the next AFTER hook.
+                    if (index == matchingHooks.lastIndex) {
+                        // Stack layout: ...
+                        // Push the values for the original method call onto the stack again
+                        if (opcode != Opcodes.INVOKESTATIC) {
+                            mv.visitVarInsn(Opcodes.ALOAD, localOwnerObj) // push owner object
+                        }
+                        loadMethodArguments(paramDescriptors, localObjArr) // push all method arguments
+                        // Stack layout: ... | [owner (objectref)] | arg1 (primitive/objectref) | arg2 (primitive/objectref) | ...
+                        mv.visitMethodInsn(opcode, owner, methodName, methodDescriptor, isInterface)
+                    }
+                }
+                HookType.REPLACE -> {
+                    // Call the hook method
+                    mv.visitMethodInsn(
+                        Opcodes.INVOKESTATIC,
+                        hook.hookInternalClassName,
+                        hook.hookMethodName,
+                        hook.hookMethodDescriptor,
+                        false
+                    )
+                    // Stack layout: ... | [return value (primitive/objectref)]
+                    // Check if we need to process the return value
+                    if (returnTypeDescriptor != "V") {
+                        val hookMethodReturnType = extractReturnTypeDescriptor(hook.hookMethodDescriptor)
+                        // if the hook method's return type is primitive we don't need to unwrap or cast it
+                        if (!isPrimitiveType(hookMethodReturnType)) {
+                            // Check if the returned object type is different than the one that should be returned
+                            // If a primitive should be returned we check it's wrapper type
+                            val expectedType = getWrapperTypeDescriptor(returnTypeDescriptor)
+                            if (expectedType != hookMethodReturnType) {
+                                // Cast object
+                                mv.visitTypeInsn(Opcodes.CHECKCAST, extractInternalClassName(expectedType))
+                            }
+                            // Check if we need to unwrap the returned object
+                            unwrapTypeIfPrimitive(returnTypeDescriptor)
+                        }
+                    }
+                }
+                HookType.AFTER -> {
+                    // Call the original method before the first AFTER hook
+                    if (index == 0 || matchingHooks[index - 1].hookType != HookType.AFTER) {
+                        // Push the values for the original method call again onto the stack
+                        if (opcode != Opcodes.INVOKESTATIC) {
+                            mv.visitVarInsn(Opcodes.ALOAD, localOwnerObj) // push owner object
+                        }
+                        loadMethodArguments(paramDescriptors, localObjArr) // push all method arguments
+                        // Stack layout: ... | MethodHandle (objectref) | owner (objectref) | object array (arrayref) | hookId (int)
+                        //                   | [owner (objectref)] | arg1 (primitive/objectref) | arg2 (primitive/objectref) | ...
+                        mv.visitMethodInsn(opcode, owner, methodName, methodDescriptor, isInterface)
+                        if (returnTypeDescriptor == "V") {
+                            // If the method didn't return anything, we push a nullref as placeholder
+                            mv.visitInsn(Opcodes.ACONST_NULL) // push nullref
+                        }
+                        // Wrap return value if it is a primitive type
+                        wrapTypeIfPrimitive(returnTypeDescriptor)
+                        mv.visitVarInsn(Opcodes.ASTORE, localReturnObj) // consume objectref
+                    }
                     mv.visitVarInsn(Opcodes.ALOAD, localReturnObj) // push objectref
-                    // Unwrap it, if it was a primitive value
-                    unwrapTypeIfPrimitive(returnTypeDescriptor)
-                    // Stack layout: ... | return value (primitive/objectref)
+
+                    // Stack layout: ... | MethodHandle (objectref) | owner (objectref) | object array (arrayref) | hookId (int)
+                    //                   | return value (objectref)
+                    // Store the result value in a local variable (but keep it on the stack)
+                    // Call the hook method
+                    mv.visitMethodInsn(
+                        Opcodes.INVOKESTATIC,
+                        hook.hookInternalClassName,
+                        hook.hookMethodName,
+                        hook.hookMethodDescriptor,
+                        false
+                    )
+                    // Stack layout: ...
+                    // Push the return value on the stack after the last AFTER hook if the original method returns a value
+                    if (index == matchingHooks.size - 1 && returnTypeDescriptor != "V") {
+                        // Push the return value again
+                        mv.visitVarInsn(Opcodes.ALOAD, localReturnObj) // push objectref
+                        // Unwrap it, if it was a primitive value
+                        unwrapTypeIfPrimitive(returnTypeDescriptor)
+                        // Stack layout: ... | return value (primitive/objectref)
+                    }
                 }
             }
         }
@@ -310,10 +271,36 @@ private class HookMethodVisitor(
         Opcodes.INVOKESPECIAL
     )
 
-    private fun findMatchingHook(hookType: HookType, owner: String, name: String, descriptor: String): Hook? {
-        val withoutDescriptorKey = "$hookType#$owner#$name"
-        val withDescriptorKey = "$withoutDescriptorKey#$descriptor"
-        return hooks[withDescriptorKey] ?: hooks[withoutDescriptorKey]
+    private fun findMatchingHooks(owner: String, name: String, descriptor: String): List<Hook> {
+        val result = HookType.values().flatMap { hookType ->
+            val withoutDescriptorKey = "$hookType#$owner#$name"
+            val withDescriptorKey = "$withoutDescriptorKey#$descriptor"
+            hooks[withDescriptorKey].orEmpty() + hooks[withoutDescriptorKey].orEmpty()
+        }.sortedBy { it.hookType }
+        check(
+            result.isEmpty() ||
+                result.count { it.hookType != HookType.REPLACE } == result.size ||
+                result.count { it.hookType == HookType.REPLACE } == 1
+        ) {
+            "For a given method, You can either have a single REPLACE hook or BEFORE/AFTER hooks. Found:\n $result"
+        }
+
+        return result.filter { !isReplaceHookInJava6mode(it) }
+    }
+
+    private fun isReplaceHookInJava6mode(hook: Hook): Boolean {
+        if (java6Mode && hook.hookType == HookType.REPLACE) {
+            if (showUnsupportedHookWarning.getAndSet(false)) {
+                println(
+                    """WARN: Some hooks could not be applied to class files built for Java 7 or lower.
+                      |WARN: Ensure that the fuzz target and its dependencies are compiled with
+                      |WARN: -target 8 or higher to identify as many bugs as possible.
+            """.trimMargin()
+                )
+            }
+            return true
+        }
+        return false
     }
 
     // Stores all arguments for a method call in a local object array.
@@ -374,7 +361,7 @@ private class HookMethodVisitor(
     }
 
     // Removes a primitive value from the top of the operand stack
-    // and pushes it enclosed in it's wrapper type (e.g. removes int, pushes Integer).
+    // and pushes it enclosed in its wrapper type (e.g. removes int, pushes Integer).
     // This is done by calling .valueOf(...) on the wrapper class.
     private fun wrapTypeIfPrimitive(unwrappedTypeDescriptor: String) {
         if (!isPrimitiveType(unwrappedTypeDescriptor) || unwrappedTypeDescriptor == "V") return

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/HookMethodVisitor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/HookMethodVisitor.kt
@@ -277,15 +277,17 @@ private class HookMethodVisitor(
             val withDescriptorKey = "$withoutDescriptorKey#$descriptor"
             hooks[withDescriptorKey].orEmpty() + hooks[withoutDescriptorKey].orEmpty()
         }.sortedBy { it.hookType }
+        val replaceHookCount = result.count { it.hookType == HookType.REPLACE }
         check(
-            result.isEmpty() ||
-                result.count { it.hookType != HookType.REPLACE } == result.size ||
-                result.count { it.hookType == HookType.REPLACE } == 1
+            replaceHookCount == 0 ||
+                (replaceHookCount == 1 && result.size == 1)
         ) {
             "For a given method, You can either have a single REPLACE hook or BEFORE/AFTER hooks. Found:\n $result"
         }
 
-        return result.filter { !isReplaceHookInJava6mode(it) }
+        return result
+            .filter { !isReplaceHookInJava6mode(it) }
+            .sortedByDescending { it.toString() }
     }
 
     private fun isReplaceHookInJava6mode(hook: Hook): Boolean {

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/Utils.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/Utils.kt
@@ -21,6 +21,7 @@ import java.io.InputStream
  * jaz.Zer is a honeypot class: All of its methods report a finding when called.
  */
 const val HONEYPOT_CLASS_NAME = "jaz.Zer"
+const val HONEYPOT_LIBRARY_NAME = "jazzer_honeypot"
 
 internal fun Short.toBytes(): ByteArray {
     return byteArrayOf(

--- a/sanitizers/src/test/java/com/example/BUILD.bazel
+++ b/sanitizers/src/test/java/com/example/BUILD.bazel
@@ -1,4 +1,5 @@
 load("//bazel:fuzz_target.bzl", "java_fuzz_target_test")
+load("//bazel:compat.bzl", "SKIP_ON_MACOS")
 
 java_fuzz_target_test(
     name = "ObjectInputStreamDeserialization",
@@ -14,6 +15,17 @@ java_fuzz_target_test(
         "ReflectiveCall.java",
     ],
     target_class = "com.example.ReflectiveCall",
+)
+
+java_fuzz_target_test(
+    name = "LibraryLoad",
+    srcs = [
+        "LibraryLoad.java",
+    ],
+    target_class = "com.example.LibraryLoad",
+    # loading of native libraries is very slow on macos,
+    # especially using Java 17
+    target_compatible_with = SKIP_ON_MACOS,
 )
 
 java_fuzz_target_test(

--- a/sanitizers/src/test/java/com/example/LibraryLoad.java
+++ b/sanitizers/src/test/java/com/example/LibraryLoad.java
@@ -1,0 +1,29 @@
+// Copyright 2021 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+public class LibraryLoad {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    String input = data.consumeRemainingAsAsciiString();
+
+    try {
+      System.loadLibrary(input);
+    } catch (SecurityException | UnsatisfiedLinkError | NullPointerException
+        | IllegalArgumentException ignored) {
+    }
+  }
+}


### PR DESCRIPTION
Since we are going to start with a blog post describing jazzer's hooking framework. We enable having multiple BEFORE and AFTER hooks for the same method. Otherwise, users might have hard to debug problems when developing bug detectors.