### PR TITLE
Fix regex injection hook invocation for String functions

### DIFF
--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/RegexInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/RegexInjection.kt
@@ -29,7 +29,7 @@ object RegexInjection {
      * Part of an OOM "exploit" for [java.util.regex.Pattern.compile] with the
      * [java.util.regex.Pattern.CANON_EQ] flag, formed by three consecutive combining marks, in this
      * case grave accents: ◌̀.
-     * See [patternCompileWithFlagsHook] for details.
+     * See [compileWithFlagsHook] for details.
      */
     private const val CANON_EQ_ALMOST_EXPLOIT = "\u0300\u0300\u0300"
 
@@ -49,7 +49,7 @@ object RegexInjection {
     fun compileWithFlagsHook(method: MethodHandle, alwaysNull: Any?, args: Array<Any?>, hookId: Int): Any? {
         val pattern = args[0] as String?
         val hasCanonEqFlag = ((args[1] as Int) and Pattern.CANON_EQ) != 0
-        return hookInternal(method, pattern, hasCanonEqFlag, args, hookId)
+        return hookInternal(method, pattern, hasCanonEqFlag, hookId, *args)
     }
 
     @MethodHooks(
@@ -65,6 +65,13 @@ object RegexInjection {
             targetMethod = "matches",
             targetMethodDescriptor = "(Ljava/lang/String;Ljava/lang/CharSequence;)Z"
         ),
+    )
+    @JvmStatic
+    fun patternHook(method: MethodHandle, alwaysNull: Any?, args: Array<Any?>, hookId: Int): Any? {
+        return hookInternal(method, args[0] as String?, false, hookId, *args)
+    }
+
+    @MethodHooks(
         MethodHook(
             type = HookType.REPLACE,
             targetClassName = "java.lang.String",
@@ -97,11 +104,17 @@ object RegexInjection {
         ),
     )
     @JvmStatic
-    fun patternHook(method: MethodHandle, alwaysNull: Any?, args: Array<Any?>, hookId: Int): Any? {
-        return hookInternal(method, args[0] as String?, false, args, hookId)
+    fun stringHook(method: MethodHandle, thisObject: Any?, args: Array<Any?>, hookId: Int): Any? {
+        return hookInternal(method, args[0] as String?, false, hookId, thisObject, *args)
     }
 
-    private fun hookInternal(method: MethodHandle, pattern: String?, hasCanonEqFlag: Boolean, args: Array<Any?>, hookId: Int): Any? {
+    private fun hookInternal(
+        method: MethodHandle,
+        pattern: String?,
+        hasCanonEqFlag: Boolean,
+        hookId: Int,
+        vararg args: Any?
+    ): Any? {
         if (hasCanonEqFlag && pattern != null) {
             // With CANON_EQ enabled, Pattern.compile allocates an array with a size that is
             // (super-)exponential in the number of consecutive Unicode combining marks. We use a mild case


### PR DESCRIPTION
Fixes the incorrect invocation of the MethodHandle in the case where the
regex injection hook is applied to a String function, which do require
passing in the this object:

== Java Exception: java.lang.invoke.WrongMethodTypeException: cannot convert MethodHandle(String,String,String)String to (Object,Object)Object
 at java.base/java.lang.invoke.MethodHandle.asTypeUncached(MethodHandle.java:881)
 at java.base/java.lang.invoke.MethodHandle.asType(MethodHandle.java:866)
 at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:729)
 at com.code_intelligence.jazzer.sanitizers.RegexInjection.hookInternal(RegexInjection.kt:126)
 at com.code_intelligence.jazzer.sanitizers.RegexInjection.patternHook(RegexInjection.kt:101)
 ...

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=45246