### PR TITLE
Export JaCoCo coverage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,33 @@ With the flag `--keep_going=N` Jazzer continues fuzzing until `N` unique stack t
 Particular stack traces can also be ignored based on their `DEDUP_TOKEN` by passing a comma-separated list of tokens
 via `--ignore=<token_1>,<token2>`.
 
+### Export coverage information
+
+The internally gathered JaCoCo coverage information can be exported in a human-readable and the JaCoCo dump format.
+These can help identify code areas that can not be reached through fuzzing and perhaps need changes to make them more
+accessible for the fuzzer.
+
+The human-readable report contains coverage information, like branch and line coverage, on file level. It's useful to 
+get a quick overview about the overall coverage. The flag `--coverage_report=<file>` can be used to generate the report. 
+
+Similar to the JaCoCo `dump` command the flag `--coverage_dump=<file>` specifies the coverage dump file, often called
+`coverage.exec`, that should be generated after the fuzzing run. It contains a binary representation of the gathered
+coverage data in the JaCoCo format.
+
+The JaCoCo `report` command can be used to generate reports based on the coverage dump. For example the
+following command generates an HTML report in the folder `./report/` containing all classes available in `classes.jar`
+and their coverage as captured in the export `coverage.exec`.
+```shell
+java -jar jacococli.jar report coverage.exec \
+  --classfiles classes.jar \
+  --sourcefiles some/path/to/sources \
+  --html ./report/ \
+  --name FuzzCoverageReport
+```
+
+More information about coverage report generation is available on the JaCoCo
+[CLI documentation](https://www.eclemma.org/jacoco/trunk/doc/cli.html) page.
+
 ## Advanced fuzz targets
 
 ### Fuzzing with Native Libraries

--- a/README.md
+++ b/README.md
@@ -473,30 +473,44 @@ via `--ignore=<token_1>,<token2>`.
 
 ### Export coverage information
 
-The internally gathered JaCoCo coverage information can be exported in a human-readable and the JaCoCo dump format.
-These can help identify code areas that can not be reached through fuzzing and perhaps need changes to make them more
-accessible for the fuzzer.
+The internally gathered JaCoCo coverage information can be exported in human-readable and JaCoCo execution data format
+(`.exec`). These can help identify code areas that have not been covered by the fuzzer and thus may require more
+comprehensive fuzz targets or a more extensive initial corpus to reach.
 
 The human-readable report contains coverage information, like branch and line coverage, on file level. It's useful to 
-get a quick overview about the overall coverage. The flag `--coverage_report=<file>` can be used to generate the report. 
+get a quick overview about the overall coverage. The flag `--coverage_report=<file>` can be used to generate it.
 
-Similar to the JaCoCo `dump` command the flag `--coverage_dump=<file>` specifies the coverage dump file, often called
-`coverage.exec`, that should be generated after the fuzzing run. It contains a binary representation of the gathered
-coverage data in the JaCoCo format.
+Similar to the JaCoCo `dump` command, the flag `--coverage_dump=<file>` specifies a coverage dump file, often called
+`jacoco.exec`, that is generated after the fuzzing run. It contains a binary representation of the gathered coverage 
+data in the JaCoCo format.
 
-The JaCoCo `report` command can be used to generate reports based on the coverage dump. For example the
-following command generates an HTML report in the folder `./report/` containing all classes available in `classes.jar`
-and their coverage as captured in the export `coverage.exec`.
+The JaCoCo `report` command can be used to generate reports based on this coverage dump. **Note:** The version of the
+JaCoCo agent used by Jazzer internally differs slightly from the official one. As a result, a similarly modified version
+of the JaCoCo CLI tool has to be used to generate correct reports. The correct version is available at its
+[release page](https://github.com/CodeIntelligenceTesting/jacoco/releases) as `zip` file. The report tool is located in 
+the `lib` folder and can be used as described in the JaCoCo 
+[CLI documentation](https://www.eclemma.org/jacoco/trunk/doc/cli.html). For example the following command generates an 
+HTML report in the folder `report` containing all classes available in `classes.jar` and their coverage as captured in 
+the export `coverage.exec`. Source code to include in the report is searched for in `some/path/to/sources`. 
+After execution the `index.html` file in the output folder can be opened in a browser.
 ```shell
-java -jar jacococli.jar report coverage.exec \
+java -jar path/to/jacococli.jar report coverage.exec \
   --classfiles classes.jar \
   --sourcefiles some/path/to/sources \
-  --html ./report/ \
+  --html report \
   --name FuzzCoverageReport
 ```
 
-More information about coverage report generation is available on the JaCoCo
-[CLI documentation](https://www.eclemma.org/jacoco/trunk/doc/cli.html) page.
+Furthermore, it's also possible to directly use the CLI tools of the internal JaCoCo version via Bazel with the target
+`@jazzer_jacoco//:jacoco_cli`. The following command builds an HTML report similar to the one mentioned above:
+```shell
+bazel run @jazzer_jacoco//:jacoco_cli -- \
+  report /coverage.exec \
+  --classfiles /classes.jar \
+  --sourcefiles /some/path/to/sources \
+  --html /tmp/report/ \
+  --name FuzzCoverageReport
+```
 
 ## Advanced fuzz targets
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,6 +1,6 @@
 workspace(name = "jazzer")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 load("//:repositories.bzl", "jazzer_dependencies")
 
 jazzer_dependencies()
@@ -62,6 +62,12 @@ http_archive(
     sha256 = "6a965adb02ad898b2ae48214244618fe342baea79db97157fdc70d8844ac6f09",
     strip_prefix = "libjpeg-turbo-2.0.90",
     url = "https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/2.0.90.tar.gz",
+)
+
+http_jar(
+    name = "org_kohsuke_args4j_args4j",
+    sha256 = "91ddeaba0b24adce72291c618c00bbdce1c884755f6c4dba9c5c46e871c69ed6",
+    url = "https://repo1.maven.org/maven2/args4j/args4j/2.33/args4j-2.33.jar",
 )
 
 load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -168,7 +168,7 @@ internal class RuntimeInstrumentor(
                             internalClassName,
                             bytecode,
                             firstId,
-                            firstId + actualNumEdgeIds
+                            actualNumEdgeIds
                         )
                     }
                 }

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/CoverageRecorder.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/CoverageRecorder.kt
@@ -19,14 +19,13 @@ import com.code_intelligence.jazzer.utils.ClassNameGlobber
 import io.github.classgraph.ClassGraph
 import org.jacoco.core.analysis.CoverageBuilder
 import org.jacoco.core.data.ExecutionData
-import org.jacoco.core.data.ExecutionDataReader
 import org.jacoco.core.data.ExecutionDataStore
 import org.jacoco.core.data.ExecutionDataWriter
 import org.jacoco.core.data.SessionInfo
-import org.jacoco.core.data.SessionInfoStore
 import org.jacoco.core.internal.data.CRC64
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
 import java.time.Instant
 import java.util.UUID
 
@@ -65,8 +64,18 @@ object CoverageRecorder {
         CoverageMap.replayCoveredIds(additionalCoverage)
     }
 
+    /**
+     * [dumpCoverageReport] dumps a human-readable coverage report of files using any [coveredIds] to [dumpFileName].
+     */
     @JvmStatic
-    fun computeFileCoverage(coveredIds: IntArray): String {
+    fun dumpCoverageReport(coveredIds: IntArray, dumpFileName: String) {
+        File(dumpFileName).bufferedWriter().use { writer ->
+            writer.write(computeFileCoverage(coveredIds))
+        }
+    }
+
+    private fun computeFileCoverage(coveredIds: IntArray): String {
+        fun Double.format(digits: Int) = "%.${digits}f".format(this)
         val coverage = analyzeCoverage(coveredIds.toSet()) ?: return "No classes were instrumented"
         return coverage.sourceFiles.joinToString(
             "\n",
@@ -104,21 +113,42 @@ object CoverageRecorder {
         }
     }
 
-    private fun Double.format(digits: Int) = "%.${digits}f".format(this)
+    /**
+     * [dumpJacocoCoverage] dumps the JaCoCo coverage of files using any [coveredIds] to [dumpFileName].
+     * JaCoCo only exports coverage for files containing at least one coverage data point. The dump
+     * can be used by the JaCoCo report command to create reports also including not covered files.
+     */
+    @JvmStatic
+    fun dumpJacocoCoverage(coveredIds: IntArray, dumpFileName: String) {
+        FileOutputStream(dumpFileName).use { outStream ->
+            dumpJacocoCoverage(coveredIds, outStream)
+        }
+    }
 
-    fun dumpJacocoCoverage(coveredIds: Set<Int>): ByteArray? {
+    /**
+     * [dumpJacocoCoverage] dumps the JaCoCo coverage of files using any [coveredIds] to [outStream].
+     */
+    @JvmStatic
+    fun dumpJacocoCoverage(coveredIds: IntArray, outStream: OutputStream) {
+        // Return if no class has been instrumented.
+        val startTimestamp = startTimestamp ?: return
+
         // Update the list of covered IDs with the coverage information for the current run.
         updateCoveredIdsWithCoverageMap()
 
         val dumpTimestamp = Instant.now()
-        val outStream = ByteArrayOutputStream()
         val outWriter = ExecutionDataWriter(outStream)
-        // Return null if no class has been instrumented.
-        val startTimestamp = startTimestamp ?: return null
         outWriter.visitSessionInfo(
             SessionInfo(UUID.randomUUID().toString(), startTimestamp.epochSecond, dumpTimestamp.epochSecond)
         )
+        analyzeJacocoCoverage(coveredIds.toSet()).accept(outWriter)
+    }
 
+    /**
+     * Build up a JaCoCo [ExecutionDataStore] based on [coveredIds] containing the internally gathered coverage information.
+     */
+    private fun analyzeJacocoCoverage(coveredIds: Set<Int>): ExecutionDataStore {
+        val executionDataStore = ExecutionDataStore()
         val sortedCoveredIds = (additionalCoverage + coveredIds).sorted().toIntArray()
         for ((internalClassName, info) in instrumentedClassInfo) {
             // Determine the subarray of coverage IDs in sortedCoveredIds that contains the IDs generated while
@@ -148,25 +178,19 @@ object CoverageRecorder {
                 .forEach { classLocalEdgeId ->
                     probes[classLocalEdgeId] = true
                 }
-            outWriter.visitClassExecution(ExecutionData(info.classId, internalClassName, probes))
+            executionDataStore.visitClassExecution(ExecutionData(info.classId, internalClassName, probes))
         }
-        return outStream.toByteArray()
+        return executionDataStore
     }
 
+    /**
+     * Create a [CoverageBuilder] containing all classes matching the include/exclude pattern and their coverage statistics.
+     */
     fun analyzeCoverage(coveredIds: Set<Int>): CoverageBuilder? {
         return try {
             val coverage = CoverageBuilder()
             analyzeAllUncoveredClasses(coverage)
-            val rawExecutionData = dumpJacocoCoverage(coveredIds) ?: return null
-            val executionDataStore = ExecutionDataStore()
-            val sessionInfoStore = SessionInfoStore()
-            ByteArrayInputStream(rawExecutionData).use { stream ->
-                ExecutionDataReader(stream).run {
-                    setExecutionDataVisitor(executionDataStore)
-                    setSessionInfoVisitor(sessionInfoStore)
-                    read()
-                }
-            }
+            val executionDataStore = analyzeJacocoCoverage(coveredIds)
             for ((internalClassName, info) in instrumentedClassInfo) {
                 EdgeCoverageInstrumentor(ClassInstrumentor.defaultEdgeCoverageStrategy, ClassInstrumentor.defaultCoverageMap, 0)
                     .analyze(
@@ -194,7 +218,6 @@ object CoverageRecorder {
             .asSequence()
             .map { it.replace('/', '.') }
             .toSet()
-        val emptyExecutionDataStore = ExecutionDataStore()
         ClassGraph()
             .enableClassInfo()
             .ignoreClassVisibility()
@@ -205,6 +228,9 @@ object CoverageRecorder {
                 "jaz",
             )
             .scan().use { result ->
+                // ExecutionDataStore is used to look up existing coverage during analysis of the class files,
+                // no entries are added during that. Passing in an empty store is fine for uncovered files.
+                val emptyExecutionDataStore = ExecutionDataStore()
                 result.allClasses
                     .asSequence()
                     .filter { classInfo -> classNameGlobber.includes(classInfo.name) }

--- a/driver/coverage_tracker.h
+++ b/driver/coverage_tracker.h
@@ -44,6 +44,7 @@ class CoverageTracker {
 
   static void RecordInitialCoverage(JNIEnv &env);
   static void ReplayInitialCoverage(JNIEnv &env);
-  static std::string ComputeCoverage(JNIEnv &env);
+  static void ReportCoverage(JNIEnv &env, std::string);
+  static void DumpCoverage(JNIEnv &env, std::string);
 };
 }  // namespace jazzer

--- a/driver/libfuzzer_driver.cpp
+++ b/driver/libfuzzer_driver.cpp
@@ -45,6 +45,9 @@ DECLARE_string(id_sync_file);
 // Defined in fuzz_target_runner.cpp
 DECLARE_string(coverage_report);
 
+// Defined in fuzz_target_runner.cpp
+DECLARE_string(coverage_dump);
+
 // This symbol is defined by sanitizers if linked into Jazzer or in
 // sanitizer_symbols.cpp if no sanitizer is used.
 extern "C" void __sanitizer_set_death_callback(void (*)());
@@ -128,6 +131,11 @@ AbstractLibfuzzerDriver::AbstractLibfuzzerDriver(
       LOG(WARNING) << "WARN: --coverage_report does not support parallel "
                       "fuzzing and has been disabled";
       FLAGS_coverage_report = "";
+    }
+    if (!FLAGS_coverage_dump.empty()) {
+      LOG(WARNING) << "WARN: --coverage_dump does not support parallel "
+                      "fuzzing and has been disabled";
+      FLAGS_coverage_dump = "";
     }
     if (FLAGS_id_sync_file.empty()) {
       // Create an empty temporary file used for coverage ID synchronization and

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -71,3 +71,19 @@ java_fuzz_target_test(
     # The exit codes of the forked libFuzzer processes are not picked up correctly.
     target_compatible_with = SKIP_ON_MACOS,
 )
+
+java_fuzz_target_test(
+    name = "CoverageFuzzer",
+    srcs = [
+        "src/test/java/com/example/CoverageFuzzer.java",
+    ],
+    fuzzer_args = [
+        "-use_value_profile=1",
+        "--coverage_report=coverage.exec",
+    ],
+    target_class = "com.example.CoverageFuzzer",
+    verify_crash_input = False,
+    deps = [
+        "@jazzer_jacoco//:jacoco_internal",
+    ],
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -77,12 +77,19 @@ java_fuzz_target_test(
     srcs = [
         "src/test/java/com/example/CoverageFuzzer.java",
     ],
+    env = {
+        "COVERAGE_REPORT_FILE": "coverage.txt",
+        "COVERAGE_DUMP_FILE": "coverage.exec",
+    },
     fuzzer_args = [
         "-use_value_profile=1",
-        "--coverage_report=coverage.exec",
+        "--coverage_report=coverage.txt",
+        "--coverage_dump=coverage.exec",
+        "--instrumentation_includes=com.example.**",
     ],
     target_class = "com.example.CoverageFuzzer",
     verify_crash_input = False,
+    verify_crash_reproducer = False,
     deps = [
         "@jazzer_jacoco//:jacoco_internal",
     ],

--- a/tests/src/test/java/com/example/CoverageFuzzer.java
+++ b/tests/src/test/java/com/example/CoverageFuzzer.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueLow;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+@SuppressWarnings({"unused", "UnusedReturnValue"})
+public final class CoverageFuzzer {
+  public static class ClassToCover {
+    private final int i;
+
+    public ClassToCover(int i) {
+      if (i < 0 || i > 1000) {
+        throw new IllegalArgumentException(String.format("Invalid repeat number \"%d\"", i));
+      }
+      this.i = i;
+    }
+
+    public String repeat(String str) {
+      if (str != null && str.length() >= 3 && str.length() <= 10) {
+        return IntStream.range(0, i).mapToObj(i -> str).collect(Collectors.joining());
+      }
+      throw new IllegalArgumentException(String.format("Invalid str \"%s\"", str));
+    }
+  }
+
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    try {
+      ClassToCover classToCover = new ClassToCover(data.consumeInt());
+      String repeated = classToCover.repeat(data.consumeRemainingAsAsciiString());
+      if (repeated.equals("foofoofoo")) {
+        throw new FuzzerSecurityIssueLow("Finished coverage fuzzer test");
+      }
+    } catch (IllegalArgumentException ignored) {
+    }
+  }
+
+  public static void fuzzerTearDown() throws IOException {
+    List<String> coverage = Files.readAllLines(Paths.get("./coverage.exec"));
+    assertEquals(871, coverage.size());
+
+    List<List<String>> sections = new ArrayList<>(4);
+    sections.add(new ArrayList<>());
+    coverage.forEach(l -> {
+      if (l.isEmpty()) {
+        sections.add(new ArrayList<>());
+      }
+      sections.get(sections.size() - 1).add(l);
+    });
+
+    List<String> branchCoverage = sections.get(0);
+    assertEquals(217, branchCoverage.size());
+    List<String> lineCoverage = sections.get(1);
+    assertEquals(218, lineCoverage.size());
+    List<String> incompleteCoverage = sections.get(2);
+    assertEquals(218, incompleteCoverage.size());
+    List<String> missedCoverage = sections.get(3);
+    assertEquals(218, missedCoverage.size());
+
+    String branch =
+        branchCoverage.stream()
+            .filter(l -> l.startsWith(CoverageFuzzer.class.getSimpleName()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Could not find branch coverage"));
+    //    assertEquals("CoverageFuzzer.java: 11/16 (68.75%)", branch);
+
+    String line = lineCoverage.stream()
+                      .filter(l -> l.startsWith(CoverageFuzzer.class.getSimpleName()))
+                      .findFirst()
+                      .orElseThrow(() -> new IllegalStateException("Could not find line coverage"));
+    assertEquals("CoverageFuzzer.java: 15/61 (24.59%)", line);
+
+    String incomplete =
+        incompleteCoverage.stream()
+            .filter(l -> l.startsWith(CoverageFuzzer.class.getSimpleName()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Could not find incomplete coverage"));
+    assertEquals("CoverageFuzzer.java: []", incomplete);
+
+    String missed =
+        missedCoverage.stream()
+            .filter(l -> l.startsWith(CoverageFuzzer.class.getSimpleName()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Could not find missed coverage"));
+    if (IntStream.rangeClosed(15, 44).anyMatch(i -> missed.contains(String.valueOf(i)))) {
+      throw new IllegalStateException("No coverage collected for ClassToCover");
+    }
+
+    // TODO switch to JaCoCo coverage report format
+    //    CoverageBuilder coverage = new CoverageBuilder();
+    //    ExecutionDataStore executionDataStore = new ExecutionDataStore();
+    //    SessionInfoStore sessionInfoStore = new SessionInfoStore();
+    //    try (FileInputStream bais = new FileInputStream("./coverage.exec")) {
+    //      ExecutionDataReader reader = new ExecutionDataReader(bais);
+    //      reader.setExecutionDataVisitor(executionDataStore);
+    //      reader.setSessionInfoVisitor(sessionInfoStore);
+    //      reader.read();
+    //    }
+    //    System.out.println(coverage.getClasses());
+  }
+
+  private static <T> void assertEquals(T expected, T actual) {
+    if (!expected.equals(actual)) {
+      throw new IllegalStateException(
+          String.format("Expected \"%s\", got \"%s\"", expected, actual));
+    }
+  }
+}

--- a/third_party/jacoco_internal.BUILD
+++ b/third_party/jacoco_internal.BUILD
@@ -4,12 +4,35 @@ java_library(
         "org.jacoco.core/src/org/jacoco/core/**/*.java",
     ]),
     resources = glob([
+        "org.jacoco.core/src/org/jacoco/core/**/*.properties",
         "org.jacoco.core/src/org/jacoco/core/internal/flow/java_no_throw_methods_list.dat",
     ]),
     javacopts = [
         "-Xep:EqualsHashCode:OFF",
     ],
     deps = [
+        "@org_ow2_asm_asm//jar",
+        "@org_ow2_asm_asm_commons//jar",
+        "@org_ow2_asm_asm_tree//jar",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+java_binary(
+    name = "jacoco_cli",
+    srcs = glob([
+        "org.jacoco.cli/src/org/jacoco/cli/**/*.java",
+        "org.jacoco.report/src/org/jacoco/report/**/*.java",
+    ]),
+    resources = glob([
+        "org.jacoco.report/src/org/jacoco/report/**/*.css",
+        "org.jacoco.report/src/org/jacoco/report/**/*.gif",
+        "org.jacoco.report/src/org/jacoco/report/**/*.js",
+    ]),
+    main_class = "org.jacoco.cli.internal.Main",
+    deps = [
+        "//:jacoco_internal",
+        "@org_kohsuke_args4j_args4j//jar",
         "@org_ow2_asm_asm//jar",
         "@org_ow2_asm_asm_commons//jar",
         "@org_ow2_asm_asm_tree//jar",


### PR DESCRIPTION
JaCoCo coverage can be used to create reports helping to identify fuzz blockers. 
The `--coverage_dump` flag can now specify a file containing coverage information that should be created after the fuzz run.