### PR TITLE
Report simple GC stats on timeouts

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/ExceptionUtils.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/ExceptionUtils.kt
@@ -163,4 +163,10 @@ fun dumpAllStackTraces() {
             }
         System.err.println()
     }
+    System.err.println("Garbage collector stats:")
+    System.err.println(
+        ManagementFactory.getGarbageCollectorMXBeans().joinToString("\n", "\n", "\n") {
+            "${it.name}: ${it.collectionCount} collections took ${it.collectionTime}ms"
+        }
+    )
 }


### PR DESCRIPTION
Timeouts can be caused by extreme GC stalls, in which case these rough
statistics can provide a first indication.