### PR TITLE
Catch exception if fuzz target class not found

### DIFF
--- a/driver/fuzz_target_runner.cpp
+++ b/driver/fuzz_target_runner.cpp
@@ -181,7 +181,12 @@ FuzzTargetRunner::FuzzTargetRunner(
   }
   env.DeleteLocalRef(fuzz_target_class);
 
-  jclass_ = jvm.FindClass(FLAGS_target_class);
+  try {
+    jclass_ = jvm.FindClass(FLAGS_target_class);
+  } catch (const std::runtime_error &error) {
+    std::cerr << "ERROR: " << error.what() << std::endl;
+    exit(1);
+  }
   // one of the following functions is required:
   //    public static void fuzzerTestOneInput(byte[] input)
   //    public static void fuzzerTestOneInput(FuzzedDataProvider data)


### PR DESCRIPTION
Previously, if the fuzz target class could not be found, Jazzer would
throw an uncaught exception, which results in a c++abi terminate message
as well as a JVM native stack trace.

Now, a simple error message is shown followed by a graceful exit.