### PR TITLE
Add a Starlark rule for jar stripping

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -24,7 +24,7 @@ define_kt_toolchain(
 pkg_tar(
     name = "jazzer_release",
     srcs = [
-        "//agent:jazzer_agent_deploy.jar",
+        "//agent:jazzer_agent_deploy",
         "//agent:jazzer_api_deploy.jar",
         "//driver:jazzer_driver",
     ],

--- a/agent/BUILD.bazel
+++ b/agent/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl", "jar_jar")
 load("//bazel:compat.bzl", "SKIP_ON_WINDOWS")
+load("//bazel:jar.bzl", "strip_jar")
 load("//sanitizers:sanitizers.bzl", "SANITIZER_CLASSES")
 
 java_binary(
@@ -16,15 +17,12 @@ java_binary(
     ],
 )
 
-genrule(
+strip_jar(
     name = "jazzer_agent_deploy",
-    srcs = [":jazzer_agent_shaded_deploy"],
-    outs = ["jazzer_agent_deploy.jar"],
-    cmd = """
-$(execpath //bazel/tools/java:JarStripper) $(execpath :jazzer_agent_shaded_deploy) $@ \
-module-info.class
-""",
-    exec_tools = ["//bazel/tools/java:JarStripper"],
+    jar = ":jazzer_agent_shaded_deploy",
+    paths_to_strip = [
+        "module-info.class",
+    ],
     visibility = ["//visibility:public"],
 )
 
@@ -38,12 +36,10 @@ sh_test(
     name = "jazzer_agent_shading_test",
     srcs = ["verify_shading.sh"],
     args = [
-        "$(rootpath jazzer_agent_deploy.jar)",
+        "$(rootpath :jazzer_agent_deploy)",
     ],
     data = [
-        # sh_test does not correctly forward runfiles associated to targets (such as
-        # ":jazzer_agent_deploy"), so depend on a generated file instead.
-        "jazzer_agent_deploy.jar",
+        ":jazzer_agent_deploy",
         "@local_jdk//:bin/jar",
     ],
     target_compatible_with = SKIP_ON_WINDOWS,

--- a/bazel/fuzz_target.bzl
+++ b/bazel/fuzz_target.bzl
@@ -89,7 +89,7 @@ def java_fuzz_target_test(
         ] + additional_args + fuzzer_args,
         data = [
             ":%s_deploy.jar" % target_name,
-            "//agent:jazzer_agent_deploy.jar",
+            "//agent:jazzer_agent_deploy",
             "//agent:jazzer_api_deploy.jar",
             driver,
         ] + data,

--- a/bazel/jar.bzl
+++ b/bazel/jar.bzl
@@ -1,0 +1,56 @@
+# Copyright 2022 Code Intelligence GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def _strip_jar(ctx):
+    out_jar = ctx.actions.declare_file(ctx.attr.name + ".jar")
+
+    args = ctx.actions.args()
+    args.add(ctx.file.jar)
+    args.add(out_jar)
+    args.add_all(ctx.attr.paths_to_strip)
+    ctx.actions.run(
+        outputs = [out_jar],
+        inputs = [ctx.file.jar],
+        arguments = [args],
+        executable = ctx.executable._jar_stripper,
+        tools = [ctx.attr._jar_stripper[DefaultInfo].files_to_run],
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([out_jar]),
+            # Workaround for https://github.com/bazelbuild/bazel/issues/15043.
+            runfiles = ctx.runfiles(files = [out_jar]),
+        ),
+        coverage_common.instrumented_files_info(
+            ctx,
+            dependency_attributes = ["jar"],
+        ),
+    ]
+
+strip_jar = rule(
+    implementation = _strip_jar,
+    attrs = {
+        "jar": attr.label(
+            mandatory = True,
+            allow_single_file = [".jar"],
+        ),
+        "paths_to_strip": attr.string_list(),
+        "_jar_stripper": attr.label(
+            default = "//bazel/tools/java:JarStripper",
+            cfg = "exec",
+            executable = True,
+        ),
+    },
+)

--- a/docker/jazzer/Dockerfile
+++ b/docker/jazzer/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/baz
     touch /usr/bin/ld.gold && \
     BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1 \
     bazelisk build --config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux \
-      //agent:jazzer_agent_deploy.jar //driver:jazzer_driver
+      //agent:jazzer_agent_deploy //driver:jazzer_driver
 
 FROM gcr.io/distroless/java
 

--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -164,7 +164,7 @@ cc_binary(
         "sanitizer_symbols.cpp",
     ],
     data = [
-        "//agent:jazzer_agent_deploy.jar",
+        "//agent:jazzer_agent_deploy",
     ],
     linkopts = select({
         "@platforms//os:windows": [],
@@ -193,7 +193,7 @@ alias(
 cc_binary(
     name = "jazzer_driver_asan",
     data = [
-        "//agent:jazzer_agent_deploy.jar",
+        "//agent:jazzer_agent_deploy",
     ],
     linkopts = [
     ] + select({
@@ -225,7 +225,7 @@ cc_binary(
 cc_binary(
     name = "jazzer_driver_ubsan",
     data = [
-        "//agent:jazzer_agent_deploy.jar",
+        "//agent:jazzer_agent_deploy",
     ],
     linkopts = [
     ] + select({
@@ -277,7 +277,7 @@ cc_test(
         "--cp=jazzer/$(rootpath //driver/testdata:fuzz_target_mocks_deploy.jar)",
     ],
     data = [
-        "//agent:jazzer_agent_deploy.jar",
+        "//agent:jazzer_agent_deploy",
         "//driver/testdata:fuzz_target_mocks_deploy.jar",
     ],
     includes = ["."],
@@ -308,7 +308,7 @@ cc_test(
         "--cp=jazzer/$(rootpath //driver/testdata:fuzz_target_mocks_deploy.jar)",
     ],
     data = [
-        "//agent:jazzer_agent_deploy.jar",
+        "//agent:jazzer_agent_deploy",
         "//driver/testdata:fuzz_target_mocks_deploy.jar",
     ],
     includes = ["."],


### PR DESCRIPTION
This rule is easier to use (and thus potentially upstreamable) and
correctly forwards coverage information.