### PR TITLE
Exclude OpenJ9 internal classes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,13 @@ jobs:
         run: cat $(bazel info execution_root)/external/local_jdk/BUILD.bazel | grep java_home
 
       - name: Upload replayer
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: replayer_${{ matrix.arch }}
           path: replayer.jar
 
       - name: Upload release tar
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: jazzer_releases
           path: release-${{ matrix.arch}}.tar.gz
@@ -61,19 +61,19 @@ jobs:
 
     steps:
       - name: Download macOS jar
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: replayer_darwin
           path: replayer_darwin
 
       - name: Download Linux jar
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: replayer_linux
           path: replayer_linux
 
       - name: Download Windows jar
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: replayer_windows
           path: replayer_windows
@@ -87,7 +87,7 @@ jobs:
           jar cvmf merged/META-INF/MANIFEST.MF replayer.jar -C merged .
 
       - name: Upload merged jar
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: replayer
           path: replayer.jar

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: testlogs-${{ matrix.arch }}-${{ matrix.jdk }}
           # https://github.com/actions/upload-artifact/issues/92#issuecomment-711107236

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ After unpacking the archive, run Jazzer via
 If this leads to an error message saying that `libjvm.so` has not been found, the path to the local JRE needs to be
 specified in the `JAVA_HOME` environment variable.
 
+JDK distributions based on [OpenJDK](https://openjdk.java.net/) are supported. [OpenJ9](https://www.eclipse.org/openj9/) is not supported due to random crashes.
+
 ## Examples
 
 Multiple examples for instructive and real-world Jazzer fuzz targets can be found in the `examples/` directory.

--- a/agent/src/main/java/com/code_intelligence/jazzer/utils/ClassNameGlobber.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/utils/ClassNameGlobber.kt
@@ -21,16 +21,27 @@ private val BASE_INCLUDED_CLASS_NAME_GLOBS = listOf(
 )
 
 private val BASE_EXCLUDED_CLASS_NAME_GLOBS = listOf(
+    // jdk excludes
     "\\[**", // array types
-    "com.code_intelligence.jazzer.**",
     "com.sun.**", // package for Proxy objects
     "java.**",
     "javax.**",
+    "jdk.**",
+    "sun.**",
+    // openJ9 excludes
+    "com.ibm.java.**",
+    "com.ibm.jvm.**",
+    "com.ibm.lang.**",
+    "com.ibm.oti.**",
+    "com.ibm.sharedclasses.**",
+    "com.ibm.virtualization.**",
+    "openj9.**",
+    // kotlin internals
+    "kotlin.**",
+    // jazzer internals
+    "com.code_intelligence.jazzer.**",
     "jaz.Ter", // safe companion of the honeypot class used by sanitizers
     "jaz.Zer", // honeypot class used by sanitizers
-    "jdk.**",
-    "kotlin.**",
-    "sun.**",
 )
 
 class ClassNameGlobber(includes: List<String>, excludes: List<String>) {


### PR DESCRIPTION
OpenJ9 was not mentioned in the documentation. Using version 11 and 17 to execute the `examples` causes random JVM seg-faults, though.

Nevertheless, the hook instrumentation should exclude OpenJ9 internal classes, analogous to Sun/Oracle internals.