### PR TITLE
Use go install instead of go get in format CI job

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -28,8 +28,8 @@ jobs:
           sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
           sudo apt-get install clang-format-13
           curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.42.1/ktlint && chmod a+x ktlint && sudo mv ktlint /usr/bin/ktlint
-          go get -u github.com/google/addlicense
-          go get github.com/bazelbuild/buildtools/buildifier
+          go install github.com/google/addlicense@latest
+          go install github.com/bazelbuild/buildtools/buildifier@latest
 
       - name: Run format.sh and print changes
         run: |


### PR DESCRIPTION
go get for binaries is no longer supported with Go 1.18.