### PR TITLE
Use CallStaticVoidMethod where applicable

### DIFF
--- a/driver/coverage_tracker.cpp
+++ b/driver/coverage_tracker.cpp
@@ -132,9 +132,9 @@ void CoverageTracker::ReportCoverage(JNIEnv &env, std::string report_file) {
                         covered_edge_ids.data());
   AssertNoException(env);
   jstring report_file_str = env.NewStringUTF(report_file.c_str());
-  env.CallStaticObjectMethod(coverage_recorder,
-                             coverage_recorder_dump_coverage_report,
-                             covered_edge_ids_jni, report_file_str);
+  env.CallStaticVoidMethod(coverage_recorder,
+                           coverage_recorder_dump_coverage_report,
+                           covered_edge_ids_jni, report_file_str);
   AssertNoException(env);
 }
 
@@ -156,9 +156,9 @@ void CoverageTracker::DumpCoverage(JNIEnv &env, std::string dump_file) {
                         covered_edge_ids.data());
   AssertNoException(env);
   jstring dump_file_str = env.NewStringUTF(dump_file.c_str());
-  env.CallStaticObjectMethod(coverage_recorder,
-                             coverage_recorder_dump_jacoco_coverage,
-                             covered_edge_ids_jni, dump_file_str);
+  env.CallStaticVoidMethod(coverage_recorder,
+                           coverage_recorder_dump_jacoco_coverage,
+                           covered_edge_ids_jni, dump_file_str);
   AssertNoException(env);
 }
 }  // namespace jazzer

--- a/driver/fuzz_target_runner.cpp
+++ b/driver/fuzz_target_runner.cpp
@@ -174,7 +174,7 @@ FuzzTargetRunner::FuzzTargetRunner(
   auto on_fuzz_target_ready = jvm.GetStaticMethodID(
       jazzer_, "onFuzzTargetReady", "(Ljava/lang/String;)V", true);
   jstring fuzz_target_class = env.NewStringUTF(FLAGS_target_class.c_str());
-  env.CallStaticObjectMethod(jazzer_, on_fuzz_target_ready, fuzz_target_class);
+  env.CallStaticVoidMethod(jazzer_, on_fuzz_target_ready, fuzz_target_class);
   if (env.ExceptionCheck()) {
     env.ExceptionDescribe();
     return;
@@ -233,8 +233,7 @@ FuzzTargetRunner::FuzzTargetRunner(
       jstring str = env.NewStringUTF(fuzz_target_args_tokens[i].c_str());
       env.SetObjectArrayElement(arg_array, i, str);
     }
-    env.CallStaticObjectMethod(jclass_, fuzzer_initialize_with_args_,
-                               arg_array);
+    env.CallStaticVoidMethod(jclass_, fuzzer_initialize_with_args_, arg_array);
   } else if (fuzzer_initialize_) {
     env.CallStaticVoidMethod(jclass_, fuzzer_initialize_);
   } else {


### PR DESCRIPTION
Fix JNI warnings when running tests with openJ9 and `-Xcheck:jni`.