### PR TITLE
Prevent `ConcurrentModificationException` in `TraceCmpHooks`

### DIFF
--- a/agent/src/test/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
+++ b/agent/src/test/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
@@ -1,3 +1,5 @@
+load("//bazel:compat.bzl", "SKIP_ON_WINDOWS")
+
 java_test(
     name = "RecordingFuzzedDataProviderTest",
     srcs = [
@@ -7,6 +9,19 @@ java_test(
         "//agent/src/main/java/com/code_intelligence/jazzer/api",
         "//agent/src/main/java/com/code_intelligence/jazzer/runtime",
         "//agent/src/main/java/com/code_intelligence/jazzer/runtime:fuzzed_data_provider",
+        "@maven//:junit_junit",
+    ],
+)
+
+java_test(
+    name = "TraceCmpHooksTest",
+    srcs = [
+        "TraceCmpHooksTest.java",
+    ],
+    target_compatible_with = SKIP_ON_WINDOWS,
+    deps = [
+        "//agent/src/main/java/com/code_intelligence/jazzer/runtime",
+        "//agent/src/test/java/com/code_intelligence/jazzer:MockDriver",
         "@maven//:junit_junit",
     ],
 )

--- a/agent/src/test/java/com/code_intelligence/jazzer/runtime/TraceCmpHooksTest.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/runtime/TraceCmpHooksTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.runtime;
+
+import com.code_intelligence.jazzer.MockDriver;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TraceCmpHooksTest {
+  private static final ExecutorService ES = Executors.newFixedThreadPool(5);
+
+  @BeforeClass
+  public static void setup() {
+    MockDriver.load();
+  }
+
+  @Test
+  public void cmpHookShouldHandleConcurrentModifications() throws InterruptedException {
+    String arg = "test";
+    Map<String, Object> map = new HashMap<>();
+    map.put(arg, arg);
+
+    // Add elements to map asynchronously
+    Function<Integer, Runnable> put = (final Integer num) -> () -> {
+      map.put(String.valueOf(num), num);
+    };
+    for (int i = 0; i < 1_000_000; i++) {
+      ES.submit(put.apply(i));
+    }
+
+    // Call hook
+    for (int i = 0; i < 1_000; i++) {
+      TraceCmpHooks.mapGet(null, map, new Object[] {arg}, 1, null);
+    }
+
+    ES.shutdown();
+    // noinspection ResultOfMethodCallIgnored
+    ES.awaitTermination(5, TimeUnit.SECONDS);
+  }
+}


### PR DESCRIPTION
Applying `TraceCmpHooks::mapGet` to `LinkedHashMaps` can lead to `ConcurrentModificationExceptions`. 
As stated in its JavaDoc: 

> In access-ordered linked hash maps, merely querying the map with get is a structural modification.

This can easily cause concurrent modification exceptions as seen during startup of Spring Boot applications.
Strack trace of such on exception:
```
11:25:12.402 [main] ERROR org.springframework.boot.SpringApplication - Application run failed
java.util.ConcurrentModificationException: null
        at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:719)
        at java.util.LinkedHashMap$LinkedKeyIterator.next(LinkedHashMap.java:742)
        at com.code_intelligence.jazzer.runtime.TraceCmpHooks.mapGet(TraceCmpHooks.java:308)
        at org.springframework.boot.loader.jar.JarFileEntries.getEntry(JarFileEntries.java:312)
        at org.springframework.boot.loader.jar.JarFileEntries.getEntry(JarFileEntries.java:300)
        at org.springframework.boot.loader.jar.JarFileEntries.doGetEntry(JarFileEntries.java:288)
        at org.springframework.boot.loader.jar.JarFileEntries.getEntry(JarFileEntries.java:243)
        at org.springframework.boot.loader.jar.JarFileEntries.getEntry(JarFileEntries.java:203)
        at org.springframework.boot.loader.jar.JarFile.getEntry(JarFile.java:221)
        at org.springframework.boot.loader.LaunchedURLClassLoader.lambda$definePackage$0(LaunchedURLClassLoader.java:137)
        at java.security.AccessController.doPrivileged(Native Method)
        at org.springframework.boot.loader.LaunchedURLClassLoader.definePackage(LaunchedURLClassLoader.java:129)
        at org.springframework.boot.loader.LaunchedURLClassLoader.definePackageIfNecessary(LaunchedURLClassLoader.java:111)
        at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:80)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
[...]
```