### PR TITLE
Simplify jazzer-autofuzz entrypoint

### DIFF
--- a/docker/jazzer-autofuzz/entrypoint.sh
+++ b/docker/jazzer-autofuzz/entrypoint.sh
@@ -17,8 +17,6 @@ set -e
 
 CP="$(/app/coursier.jar fetch --classpath "$1")"
 /app/jazzer_driver \
-  -artifact_prefix=/fuzzing/ \
-  --reproducer_path=/fuzzing \
   --cp="$CP" \
   --autofuzz="$2" \
   "${@:3}"


### PR DESCRIPTION
Setting the prefixes explicitly is not necessary due to the WORKDIR
directive. Dropping them has the additional benefit that printed paths
will resolve on the host when mounting $(pwd).