### PR TITLE
Hierarchically budget fuzzer bytes with Autofuzz 

### DIFF
--- a/agent/BUILD.bazel
+++ b/agent/BUILD.bazel
@@ -22,7 +22,9 @@ strip_jar(
     out = "jazzer_agent_deploy.jar",
     jar = ":jazzer_agent_shaded_deploy",
     paths_to_strip = [
+        "LICENSE",
         "module-info.class",
+        "THIRD-PARTY",
     ],
     visibility = ["//visibility:public"],
 )

--- a/agent/agent_shade_rules
+++ b/agent/agent_shade_rules
@@ -4,3 +4,4 @@ rule kotlin.** com.code_intelligence.jazzer.third_party.@0
 rule net.jodah.** com.code_intelligence.jazzer.third_party.@0
 rule nonapi.** com.code_intelligence.jazzer.third_party.@0
 rule org.objectweb.** com.code_intelligence.jazzer.third_party.@0
+rule org.openjdk.** com.code_intelligence.jazzer.third_party.@0

--- a/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/AutofuzzCodegenVisitor.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/AutofuzzCodegenVisitor.java
@@ -37,6 +37,23 @@ public class AutofuzzCodegenVisitor {
     groups.peek().push(element);
   }
 
+  // Reorders the elements of the top-most group according to the provided permutation.
+  // After the call, the element at position i will be the element that previously was at position
+  // permutation[i].
+  public void permuteGroup(int[] permutation) {
+    Stack<String> elements = groups.peek().elements;
+    if (elements.size() != permutation.length) {
+      throw new AutofuzzError("permuteGroup called with a permutation on " + permutation.length
+          + " elements, expected " + elements.size() + ": " + toDebugString());
+    }
+    Stack<String> newGroup = new Stack<>();
+    for (int i : permutation) {
+      newGroup.push(elements.get(i));
+    }
+    elements.clear();
+    elements.addAll(newGroup);
+  }
+
   public void popElement() {
     groups.peek().pop();
   }

--- a/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/BUILD.bazel
@@ -13,5 +13,6 @@ java_library(
         "//agent/src/main/java/com/code_intelligence/jazzer/utils",
         "@com_github_classgraph_classgraph//:classgraph",
         "@com_github_jhalterman_typetools//:typetools",
+        "@org_openjdk_jol_jol_core//jar",
     ],
 )

--- a/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/FuzzTarget.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/FuzzTarget.java
@@ -242,10 +242,12 @@ public final class FuzzTarget {
     }
     Object returnValue = null;
     try {
+      // We know that we are calling autofuzz only ones per execution and can thus let the single
+      // call consume all fuzzer input bytes, i.e., use a single bucket.
       if (targetExecutable instanceof Method) {
-        returnValue = Meta.autofuzz(data, (Method) targetExecutable, codegenVisitor);
+        returnValue = Meta.autofuzz(data, (Method) targetExecutable, 0, 1, codegenVisitor);
       } else {
-        returnValue = Meta.autofuzz(data, (Constructor<?>) targetExecutable, codegenVisitor);
+        returnValue = Meta.autofuzz(data, (Constructor<?>) targetExecutable, 0, 1, codegenVisitor);
       }
       executionsSinceLastInvocation = 0;
     } catch (AutofuzzConstructionException e) {

--- a/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/FuzzTarget.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/FuzzTarget.java
@@ -245,9 +245,9 @@ public final class FuzzTarget {
       // We know that we are calling autofuzz only ones per execution and can thus let the single
       // call consume all fuzzer input bytes, i.e., use a single bucket.
       if (targetExecutable instanceof Method) {
-        returnValue = Meta.autofuzz(data, (Method) targetExecutable, 0, 1, codegenVisitor);
+        returnValue = Meta.autofuzz(data, (Method) targetExecutable, 1, codegenVisitor);
       } else {
-        returnValue = Meta.autofuzz(data, (Constructor<?>) targetExecutable, 0, 1, codegenVisitor);
+        returnValue = Meta.autofuzz(data, (Constructor<?>) targetExecutable, 1, codegenVisitor);
       }
       executionsSinceLastInvocation = 0;
     } catch (AutofuzzConstructionException e) {

--- a/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
@@ -51,11 +51,14 @@ import net.jodah.typetools.TypeResolver;
 import net.jodah.typetools.TypeResolver.Unknown;
 
 public class Meta {
-  static WeakHashMap<Class<?>, List<Class<?>>> implementingClassesCache = new WeakHashMap<>();
-  static WeakHashMap<Class<?>, List<Class<?>>> nestedBuilderClassesCache = new WeakHashMap<>();
-  static WeakHashMap<Class<?>, List<Method>> originalObjectCreationMethodsCache =
+  private static final WeakHashMap<Class<?>, List<Class<?>>> implementingClassesCache =
       new WeakHashMap<>();
-  static WeakHashMap<Class<?>, List<Method>> cascadingBuilderMethodsCache = new WeakHashMap<>();
+  private static final WeakHashMap<Class<?>, List<Class<?>>> nestedBuilderClassesCache =
+      new WeakHashMap<>();
+  private static final WeakHashMap<Class<?>, List<Method>> originalObjectCreationMethodsCache =
+      new WeakHashMap<>();
+  private static final WeakHashMap<Class<?>, List<Method>> cascadingBuilderMethodsCache =
+      new WeakHashMap<>();
 
   public static Object autofuzz(FuzzedDataProvider data, Method method) {
     return autofuzz(data, method, null);

--- a/agent/src/test/java/com/code_intelligence/jazzer/api/AutofuzzTest.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/api/AutofuzzTest.java
@@ -91,17 +91,18 @@ public class AutofuzzTest {
 
   @Test
   public void testAutofuzzConsumer() {
-    FuzzedDataProvider data = CannedFuzzedDataProvider.create(
-        Arrays.asList((byte) 1 /* do not return null */, 6 /* string length */, "foobar", 42,
-            (byte) 5, (byte) 1 /* do not return null */, 0 /* first class on the classpath */,
+    FuzzedDataProvider data =
+        CannedFuzzedDataProvider.create(Arrays.asList((byte) 1 /* do not return null */,
+            12 /* remaining bytes */, 6 /* string length */, "foobar", 42, (byte) 5,
+            (byte) 1 /* do not return null */, 0 /* first class on the classpath */,
             (byte) 1 /* do not return null */, 0 /* first constructor */));
     Jazzer.autofuzz(data, AutofuzzTest::checkAllTheArguments);
   }
 
   @Test
   public void testAutofuzzConsumerThrowsException() {
-    FuzzedDataProvider data =
-        CannedFuzzedDataProvider.create(Arrays.asList((byte) 1 /* do not return null */,
+    FuzzedDataProvider data = CannedFuzzedDataProvider.create(
+        Arrays.asList((byte) 1 /* do not return null */, 12 /* remaining bytes */,
             6 /* string length */, "foobar", 42, (byte) 5, (byte) 0 /* *do* return null */));
     try {
       Jazzer.autofuzz(data, AutofuzzTest::checkAllTheArguments);

--- a/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/BuilderPatternTest.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/BuilderPatternTest.java
@@ -90,13 +90,16 @@ public class BuilderPatternTest {
             0, // pick the first build method
             (byte) 1, // do not return null
             6, // remaining bytes
+            3, // string length
             "foo", // firstName
             (byte) 1, // do not return null
             6, // remaining bytes
+            3, // string length
             "bar", // lastName
             20, // age
             (byte) 1, // do not return null
             6, // remaining bytes
+            3, // string length
             "baz" // jobTitle
             ));
   }

--- a/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/InterfaceCreationTest.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/InterfaceCreationTest.java
@@ -105,6 +105,7 @@ public class InterfaceCreationTest {
             0, // pick first constructor
             (byte) 1, // do not return null
             8, // remaining bytes
+            4, // string length
             "test" // arg for ClassB2 constructor
             ));
   }

--- a/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/SettersTest.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/SettersTest.java
@@ -36,6 +36,7 @@ public class SettersTest {
             0, // pick first setter
             (byte) 1, // do not return null for String
             6, // remaining bytes
+            3, // string length
             "foo", // setFirstName
             26 // setAge
             ));

--- a/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/TestHelpers.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/TestHelpers.java
@@ -16,7 +16,6 @@ package com.code_intelligence.jazzer.autofuzz;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import com.code_intelligence.jazzer.api.CannedFuzzedDataProvider;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -70,9 +69,10 @@ class TestHelpers {
     AutofuzzCodegenVisitor visitor = new AutofuzzCodegenVisitor();
     FuzzedDataProvider data = CannedFuzzedDataProvider.create(cannedData);
     if (func instanceof Method) {
-      assertGeneralEquals(expectedResult, Meta.autofuzz(data, (Method) func, visitor));
+      assertGeneralEquals(expectedResult, Meta.autofuzz(data, (Method) func, 0, 2, visitor));
     } else {
-      assertGeneralEquals(expectedResult, Meta.autofuzz(data, (Constructor<?>) func, visitor));
+      assertGeneralEquals(
+          expectedResult, Meta.autofuzz(data, (Constructor<?>) func, 0, 2, visitor));
     }
     assertEquals(expectedResultString, visitor.generate());
   }

--- a/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/TestHelpers.java
+++ b/agent/src/test/java/com/code_intelligence/jazzer/autofuzz/TestHelpers.java
@@ -69,10 +69,9 @@ class TestHelpers {
     AutofuzzCodegenVisitor visitor = new AutofuzzCodegenVisitor();
     FuzzedDataProvider data = CannedFuzzedDataProvider.create(cannedData);
     if (func instanceof Method) {
-      assertGeneralEquals(expectedResult, Meta.autofuzz(data, (Method) func, 0, 2, visitor));
+      assertGeneralEquals(expectedResult, Meta.autofuzz(data, (Method) func, 2, visitor));
     } else {
-      assertGeneralEquals(
-          expectedResult, Meta.autofuzz(data, (Constructor<?>) func, 0, 2, visitor));
+      assertGeneralEquals(expectedResult, Meta.autofuzz(data, (Constructor<?>) func, 2, visitor));
     }
     assertEquals(expectedResultString, visitor.generate());
   }

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -118,6 +118,13 @@ def jazzer_dependencies():
     )
 
     maybe(
+        http_jar,
+        name = "org_openjdk_jol_jol_core",
+        sha256 = "7ba48c1dbcd8b6ce5ca722cabc4a59f5a3fac8e87bddc02e7a5cd9b63d52eb55",
+        url = "https://repo1.maven.org/maven2/org/openjdk/jol/jol-core/0.16/jol-core-0.16.jar",
+    )
+
+    maybe(
         http_archive,
         name = "jazzer_com_github_gflags_gflags",
         patches = [

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -61,6 +61,20 @@ java_fuzz_target_test(
 )
 
 java_fuzz_target_test(
+    name = "AutofuzzWithSingleString",
+    expected_findings = ["java.lang.IndexOutOfBoundsException"],
+    fuzzer_args = [
+        "--autofuzz=com.google.json.JsonSanitizer::sanitize",
+        "--autofuzz_ignore=java.lang.ArrayIndexOutOfBoundsException",
+        # Exit after the first finding for testing purposes.
+        "--keep_going=1",
+    ],
+    runtime_deps = [
+        "@maven//:com_mikesamuel_json_sanitizer",
+    ],
+)
+
+java_fuzz_target_test(
     name = "ForkModeFuzzer",
     size = "enormous",
     srcs = [


### PR DESCRIPTION
Currently, whenever Autofuzz needs to decide how many bytes from the
fuzzer input to spend on the construction of an object, it uses half of
the remaining bytes. While this ensures that primitives with non-trivial
values can be generated with arbitrarily many nested object
constructions, this strategy does not make good use of the fuzzer input
in the case of flat call graphs (e.g. a foo(String, int) method).
Experiments show that ignoring half of the fuzzer input hurts efficiency
quite a bit.

This commit switches to a new strategy that hierarchically assigns a
"budget" for every consume or autofuzz call:

1. Every call to consume or autofuzz is allocated a fraction of the
   remaining bytes and assigns equal parts of this budget to the
   recursive invocations it makes.
2. By constructing the objects that consume a bounded number of bytes
   first in autofuzz, the remaining budget for an autofuzz invocation
   can be evenly distributed among the variable-length objects without
   risking that primitive arguments are forced to trivial values.