### PR TITLE
Update windows runner in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,11 @@ on:
   workflow_dispatch:
 
 jobs:
-
   build_release:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-10.15, windows-2016]
+        os: [ubuntu-latest, macos-10.15, windows-2019]
         include:
           - os: ubuntu-latest
             arch: "linux"
@@ -17,7 +16,7 @@ jobs:
           - os: macos-10.15
             arch: "macos-x86_64"
             bazel_args: "--config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-darwin --xcode_version_config=//.github:host_xcodes"
-          - os: windows-2016
+          - os: windows-2019
             arch: "windows"
             bazel_args: ""
 


### PR DESCRIPTION
`windows-2016` runners were removed (https://github.com/actions/virtual-environments/issues/4312).