### PR TITLE
Remove redundant -ldl linkopt

### DIFF
--- a/driver/BUILD.bazel
+++ b/driver/BUILD.bazel
@@ -125,10 +125,6 @@ cc_library(
         "jvm_tooling.h",
         "libfuzzer_driver.h",
     ],
-    linkopts = select({
-        "@platforms//os:windows": [],
-        "//conditions:default": ["-ldl"],
-    }),
     # Needs to be linked statically for JNI_OnLoad_jazzer_initialize to be found
     # by the JVM.
     linkstatic = True,


### PR DESCRIPTION
We no longer use dlsym in the driver and thus don't have to link with
-ldl.