### PR TITLE
Fix infinite recursion in ProbeInserter patch

### DIFF
--- a/third_party/jacoco-make-probe-inserter-subclassable.patch
+++ b/third_party/jacoco-make-probe-inserter-subclassable.patch
@@ -110,7 +110,7 @@ index 0f5b99ff..80965dfe 100644
  			final TypePath typePath, final Label[] start, final Label[] end,
  			final int[] index, final String descriptor, final boolean visible) {
 +		if (getLocalVariableType() == null) {
-+			return visitLocalVariableAnnotation(typeRef, typePath, start, end, index, descriptor, visible);
++			return mv.visitLocalVariableAnnotation(typeRef, typePath, start, end, index, descriptor, visible);
 +		}
 +
  		final int[] newIndex = new int[index.length];


### PR DESCRIPTION
Speculative fix for the following externally reported issue:

```
INFO: Instrumented com....
java.lang.StackOverflowError
at org.jacoco.core.internal.instr.ProbeInserter.visitLocalVariableAnnotation(ProbeInserter.java:126)
at org.jacoco.core.internal.instr.ProbeInserter.visitLocalVariableAnnotation(ProbeInserter.java:126)
...
...
...
at org.jacoco.core.internal.instr.ProbeInserter.visitLocalVariableAnnotation(ProbeInserter.java:126)
INFO: Instrumented com....
```