### PR TITLE
Add disabled_hooks CLI argument

### DIFF
--- a/driver/jvm_tooling.cpp
+++ b/driver/jvm_tooling.cpp
@@ -51,20 +51,26 @@ DEFINE_string(agent_path, "", "location of the fuzzing instrumentation agent");
 // combined during the initialization of the JVM.
 DEFINE_string(instrumentation_includes, "",
               "list of glob patterns for classes that will be instrumented for "
-              "fuzzing. Separated by colon \":\"");
-DEFINE_string(instrumentation_excludes, "",
-              "list of glob patterns for classes that will not be instrumented "
-              "for fuzzing. Separated by colon \":\"");
+              "fuzzing (separator is ':' on Linux/macOS and ';' on Windows)");
+DEFINE_string(
+    instrumentation_excludes, "",
+    "list of glob patterns for classes that will not be instrumented "
+    "for fuzzing (separator is ':' on Linux/macOS and ';' on Windows)");
 
 DEFINE_string(custom_hook_includes, "",
               "list of glob patterns for classes that will only be "
-              "instrumented using custom hooks. Separated by colon \":\"");
-DEFINE_string(custom_hook_excludes, "",
-              "list of glob patterns for classes that will not be instrumented "
-              "using custom hooks. Separated by colon \":\"");
+              "instrumented using custom hooks (separator is ':' on "
+              "Linux/macOS and ';' on Windows)");
+DEFINE_string(
+    custom_hook_excludes, "",
+    "list of glob patterns for classes that will not be instrumented "
+    "using custom hooks (separator is ':' on Linux/macOS and ';' on Windows)");
 DEFINE_string(custom_hooks, "",
-              "list of classes containing custom instrumentation hooks. "
-              "Separated by colon \":\"");
+              "list of classes containing custom instrumentation hooks "
+              "(separator is ':' on Linux/macOS and ';' on Windows)");
+DEFINE_string(disabled_hooks, "",
+              "list of hook classes (custom or built-in) that should not be "
+              "loaded (separator is ':' on Linux/macOS and ';' on Windows)");
 DEFINE_string(
     trace, "",
     "list of instrumentation to perform separated by colon \":\". "
@@ -191,6 +197,7 @@ std::string agentArgsFromFlags() {
            {"instrumentation_includes", FLAGS_instrumentation_includes},
            {"instrumentation_excludes", FLAGS_instrumentation_excludes},
            {"custom_hooks", FLAGS_custom_hooks},
+           {"disabled_hooks", FLAGS_disabled_hooks},
            {"custom_hook_includes", FLAGS_custom_hook_includes},
            {"custom_hook_excludes", FLAGS_custom_hook_excludes},
            {"trace", FLAGS_trace},

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -162,3 +162,18 @@ JAZZER_API_TEST_CASES = {
     )
     for case, args in JAZZER_API_TEST_CASES.items()
 ]
+
+java_fuzz_target_test(
+    name = "DisabledHooksFuzzer",
+    timeout = "short",
+    srcs = ["src/test/java/com/example/DisabledHooksFuzzer.java"],
+    expect_crash = False,
+    fuzzer_args = [
+        "-runs=0",
+        "--custom_hooks=com.example.DisabledHook",
+    ] + select({
+        "@platforms//os:windows": ["--disabled_hooks=com.example.DisabledHook;com.code_intelligence.jazzer.sanitizers.RegexInjection"],
+        "//conditions:default": ["--disabled_hooks=com.example.DisabledHook:com.code_intelligence.jazzer.sanitizers.RegexInjection"],
+    }),
+    target_class = "com.example.DisabledHooksFuzzer",
+)

--- a/tests/src/test/java/com/example/DisabledHooksFuzzer.java
+++ b/tests/src/test/java/com/example/DisabledHooksFuzzer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.HookType;
+import com.code_intelligence.jazzer.api.Jazzer;
+import com.code_intelligence.jazzer.api.MethodHook;
+import java.lang.invoke.MethodHandle;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+public class DisabledHooksFuzzer {
+  public static void fuzzerTestOneInput(byte[] data) {
+    triggerCustomHook();
+    triggerBuiltinHook();
+  }
+
+  private static void triggerCustomHook() {}
+
+  private static void triggerBuiltinHook() {
+    // Trigger the built-in regex injection detector if it is enabled, but catch the exception
+    // thrown if it isn't.
+    try {
+      Pattern.compile("[");
+    } catch (PatternSyntaxException ignored) {
+    }
+  }
+}
+
+class DisabledHook {
+  @MethodHook(type = HookType.BEFORE, targetClassName = "com.example.DisabledHooksFuzzer",
+      targetMethod = "triggerCustomHook", targetMethodDescriptor = "()V")
+  public static void
+  triggerCustomHookHook(MethodHandle method, Object thisObject, Object[] arguments, int hookId) {
+    Jazzer.reportFindingFromHook(
+        new IllegalStateException("hook on triggerCustomHook should have been disabled"));
+  }
+}


### PR DESCRIPTION
The new argument can be used to selectively disable both custom and and
built-in hooks.