### PR TITLE
driver: Fix memory leak for byte[] targets

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -181,3 +181,19 @@ java_fuzz_target_test(
     }),
     target_class = "com.example.DisabledHooksFuzzer",
 )
+
+java_fuzz_target_test(
+    name = "BytesMemoryLeakFuzzer",
+    timeout = "short",
+    srcs = ["src/test/java/com/example/BytesMemoryLeakFuzzer.java"],
+    env = {
+        "JAVA_OPTS": "-Xmx200m",
+    },
+    expect_crash = False,
+    fuzzer_args = [
+        # Before the bug was fixed, either the GC overhead limit or the overall heap limit was
+        # reached by this target in this number of runs.
+        "-runs=10000000",
+    ],
+    target_class = "com.example.BytesMemoryLeakFuzzer",
+)

--- a/tests/src/test/java/com/example/BytesMemoryLeakFuzzer.java
+++ b/tests/src/test/java/com/example/BytesMemoryLeakFuzzer.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+public class BytesMemoryLeakFuzzer {
+  public static void fuzzerTestOneInput(byte[] data) {}
+}


### PR DESCRIPTION
We never deleted the local reference to the byte[] array passed to the
fuzz target.