### PR TITLE
driver: Fix driver crash when not supplying -seed 

### DIFF
--- a/driver/src/main/java/com/code_intelligence/jazzer/driver/Driver.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/driver/Driver.java
@@ -79,7 +79,7 @@ public class Driver {
               // Only add the -seed argument to the command line if not running in a mode
               // that spawns subprocesses. These would inherit the same seed, which might
               // make them less effective.
-              if (spawnsSubprocesses) {
+              if (!spawnsSubprocesses) {
                 args.add("-seed=" + newSeed);
               }
               return newSeed;

--- a/driver/src/main/java/com/code_intelligence/jazzer/driver/Driver.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/driver/Driver.java
@@ -70,20 +70,17 @@ public class Driver {
     // occurrence of a "-seed" argument as that is the one that is used by libFuzzer. If none is
     // set, generate one and pass it to libFuzzer so that a fuzzing run can be reproduced simply by
     // setting the seed printed by libFuzzer.
-    String seed =
-        args.stream()
-            .reduce(
-                (prev, cur) -> cur.startsWith("-seed=") ? cur.substring("-seed=".length()) : prev)
-            .orElseGet(() -> {
-              String newSeed = Integer.toUnsignedString(new SecureRandom().nextInt());
-              // Only add the -seed argument to the command line if not running in a mode
-              // that spawns subprocesses. These would inherit the same seed, which might
-              // make them less effective.
-              if (!spawnsSubprocesses) {
-                args.add("-seed=" + newSeed);
-              }
-              return newSeed;
-            });
+    String seed = args.stream().reduce(
+        null, (prev, cur) -> cur.startsWith("-seed=") ? cur.substring("-seed=".length()) : prev);
+    if (seed == null) {
+      seed = Integer.toUnsignedString(new SecureRandom().nextInt());
+      // Only add the -seed argument to the command line if not running in a mode
+      // that spawns subprocesses. These would inherit the same seed, which might
+      // make them less effective.
+      if (!spawnsSubprocesses) {
+        args.add("-seed=" + seed);
+      }
+    }
     System.setProperty("jazzer.seed", seed);
 
     if (args.stream().noneMatch(arg -> arg.startsWith("-rss_limit_mb="))) {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -223,3 +223,17 @@ java_fuzz_target_test(
     ],
     target_class = "com.example.SeedFuzzer",
 )
+
+java_fuzz_target_test(
+    name = "NoSeedFuzzer",
+    timeout = "short",
+    srcs = ["src/test/java/com/example/NoSeedFuzzer.java"],
+    env = {
+        "JAZZER_NO_EXPLICIT_SEED": "1",
+    },
+    expect_crash = False,
+    fuzzer_args = [
+        "-runs=0",
+    ],
+    target_class = "com.example.NoSeedFuzzer",
+)

--- a/tests/src/test/java/com/example/NoSeedFuzzer.java
+++ b/tests/src/test/java/com/example/NoSeedFuzzer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.Jazzer;
+
+public class NoSeedFuzzer {
+  public static void fuzzerInitialize() {
+    // Verify that the seed was randomly generated and not taken to be the fixed
+    // one set in FuzzTargetTestWrapper. This has a 1 / INT_MAX chance to be
+    // flaky, which is acceptable.
+    if (Jazzer.SEED == (int) 2735196724L) {
+      System.err.println(
+          "Jazzer.SEED should not equal the fixed seed set in FuzzTargetTestWrapper");
+      System.exit(1);
+    }
+  }
+
+  public static void fuzzerTestOneInput(byte[] data) {}
+}


### PR DESCRIPTION
The reduce function was misused - prev was always the first CLI
argument, not an empty Optional.