### PR TITLE
driver: Fix --keep_going not enabled implicitly for Autofuzz

### DIFF
--- a/driver/jvm_tooling.cpp
+++ b/driver/jvm_tooling.cpp
@@ -194,10 +194,9 @@ std::string getInstrumentorAgentPath(std::string_view executable_path) {
 }
 
 std::vector<std::string> optsAsDefines() {
-  return {
+  std::vector<std::string> defines{
       absl::StrFormat("-Djazzer.target_class=%s", FLAGS_target_class),
       absl::StrFormat("-Djazzer.target_args=%s", FLAGS_target_args),
-      absl::StrFormat("-Djazzer.keep_going=%d", FLAGS_keep_going),
       absl::StrFormat("-Djazzer.dedup=%s", FLAGS_dedup ? "true" : "false"),
       absl::StrFormat("-Djazzer.ignore=%s", FLAGS_ignore),
       absl::StrFormat("-Djazzer.reproducer_path=%s", FLAGS_reproducer_path),
@@ -220,6 +219,11 @@ std::vector<std::string> optsAsDefines() {
       absl::StrFormat("-Djazzer.trace=%s", FLAGS_trace),
       absl::StrFormat("-Djazzer.dump_classes_dir=%s", FLAGS_dump_classes_dir),
   };
+  if (!gflags::GetCommandLineFlagInfoOrDie("keep_going").is_default) {
+    defines.emplace_back(
+        absl::StrFormat("-Djazzer.keep_going=%d", FLAGS_keep_going));
+  }
+  return defines;
 }
 
 // Splits a string at the ARG_SEPARATOR unless it is escaped with a backslash.

--- a/driver/src/main/java/com/code_intelligence/jazzer/driver/FuzzTargetRunner.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/driver/FuzzTargetRunner.java
@@ -197,7 +197,7 @@ public final class FuzzTargetRunner {
     // target.
     dumpReproducer(data);
 
-    if (Opt.keepGoing == 1 || ignoredTokens.size() >= Opt.keepGoing) {
+    if (Opt.keepGoing == 1 || Long.compareUnsigned(ignoredTokens.size(), Opt.keepGoing) >= 0) {
       // Reached the maximum amount of findings to keep going for, crash after shutdown. We use
       // _Exit rather than System.exit to not trigger libFuzzer's exit handlers.
       shutdown();

--- a/driver/src/main/java/com/code_intelligence/jazzer/driver/Opt.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/driver/Opt.java
@@ -67,7 +67,7 @@ public final class Opt {
       : Collections.unmodifiableList(
           Stream.concat(Stream.of(autofuzz), autofuzzIgnore.stream()).collect(Collectors.toList()));
   public static final long keepGoing =
-      uint32Setting("keep_going", autofuzz.isEmpty() ? 1 : Integer.MIN_VALUE);
+      uint64Setting("keep_going", autofuzz.isEmpty() ? 1 : Long.MAX_VALUE);
 
   // Default to false if hooks is false to mimic the original behavior of the native fuzz target
   // runner, but still support hooks = false && dedup = true.
@@ -119,12 +119,12 @@ public final class Opt {
     return Boolean.parseBoolean(value);
   }
 
-  private static long uint32Setting(String name, int defaultValue) {
+  private static long uint64Setting(String name, long defaultValue) {
     String value = System.getProperty(optionsPrefix + name);
     if (value == null) {
       return defaultValue;
     }
-    return Integer.parseUnsignedInt(value, 10);
+    return Long.parseUnsignedLong(value, 10);
   }
 
   /**


### PR DESCRIPTION
Makes `--keep_going` a proper uint64 flag as it was before the Java
rewrite and ensures that the default value defined in Java is honored.