### PR TITLE
driver: Find @FuzzTests even if @FuzzTest is not on the classpath

### DIFF
--- a/driver/src/main/java/com/code_intelligence/jazzer/driver/BUILD.bazel
+++ b/driver/src/main/java/com/code_intelligence/jazzer/driver/BUILD.bazel
@@ -27,6 +27,9 @@ java_library(
         ":opt",
         "//agent/src/main/java/com/code_intelligence/jazzer/api",
         "//agent/src/main/java/com/code_intelligence/jazzer/utils:manifest_utils",
+        "@org_ow2_asm_asm//jar",
+        "@org_ow2_asm_asm_commons//jar",
+        "@org_ow2_asm_asm_tree//jar",
     ],
 )
 


### PR DESCRIPTION
This makes it much easier to execute fuzz tests with Jazzer from build
systems such as Maven in which it is rather difficult to build a "fat"
JAR for tests.