### PR TITLE
Revert "agent: Fix custom_hook_excludes not applying to additional cl…

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
@@ -28,7 +28,6 @@ kt_jvm_library(
         "//agent/src/main/java/com/code_intelligence/jazzer/runtime:jazzer_bootstrap_compile_only",
         "//agent/src/main/java/com/code_intelligence/jazzer/utils",
         "//agent/src/main/java/com/code_intelligence/jazzer/utils:class_name_globber",
-        "//driver/src/main/java/com/code_intelligence/jazzer/driver:opt",
         "@com_github_classgraph_classgraph//:classgraph",
         "@com_github_jetbrains_kotlin//:kotlin-reflect",
         "@jazzer_jacoco//:jacoco_internal",

--- a/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Hooks.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/instrumentor/Hooks.kt
@@ -16,7 +16,6 @@ package com.code_intelligence.jazzer.instrumentor
 
 import com.code_intelligence.jazzer.api.MethodHook
 import com.code_intelligence.jazzer.api.MethodHooks
-import com.code_intelligence.jazzer.driver.Opt
 import com.code_intelligence.jazzer.utils.ClassNameGlobber
 import com.code_intelligence.jazzer.utils.descriptor
 import io.github.classgraph.ClassGraph
@@ -70,7 +69,7 @@ data class Hooks(
                 val hookClasses = hooksWithHookClasses.map { it.second }.toSet()
                 val additionalHookClassNameGlobber = ClassNameGlobber(
                     hooks.flatMap(Hook::additionalClassesToHook),
-                    Opt.customHookExcludes + hookClassNames,
+                    emptyList()
                 )
                 return Hooks(hooks, hookClasses, additionalHookClassNameGlobber)
             }


### PR DESCRIPTION
…asses"

This reverts commit 079733e1a967552ab1be0e7da0de652e8557e6bc.

The blow-up in instrumented classes was caused by something else. We do
want additional classes explicitly mentioned by hooks to be instrumented
in all cases.