### PR TITLE
agent: Hook JUnit assertNotEquals methods

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
+++ b/agent/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
@@ -344,4 +344,21 @@ final public class TraceCmpHooks {
           currentKey, upperBoundKey, hookId + upperBoundKey.hashCode());
     }
   }
+
+  @MethodHook(type = HookType.AFTER, targetClassName = "org.junit.jupiter.api.Assertions",
+      targetMethod = "assertNotEquals",
+      targetMethodDescriptor = "(Ljava/lang/Object;Ljava/lang/Object;)V")
+  @MethodHook(type = HookType.AFTER, targetClassName = "org.junit.jupiter.api.Assertions",
+      targetMethod = "assertNotEquals",
+      targetMethodDescriptor = "(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)V")
+  @MethodHook(type = HookType.AFTER, targetClassName = "org.junit.jupiter.api.Assertions",
+      targetMethod = "assertNotEquals",
+      targetMethodDescriptor =
+          "(Ljava/lang/Object;Ljava/lang/Object;Ljava/util/function/Supplier;)V")
+  public static void
+  assertEquals(MethodHandle method, Object node, Object[] args, int hookId, Object alwaysNull) {
+    if (args[0] != null && args[1] != null && args[0].getClass() == args[1].getClass()) {
+      TraceDataFlowNativeCallbacks.traceGenericCmp(args[0], args[1], hookId);
+    }
+  }
 }

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -265,3 +265,12 @@ java_fuzz_target_test(
     verify_crash_reproducer = False,
     runtime_deps = [":native_value_profile_fuzzer"],
 )
+
+java_fuzz_target_test(
+    name = "JUnitAssertFuzzer",
+    timeout = "short",
+    srcs = ["src/test/java/com/example/JUnitAssertFuzzer.java"],
+    expected_findings = ["org.opentest4j.AssertionFailedError"],
+    target_class = "com.example.JUnitAssertFuzzer",
+    deps = ["@maven//:org_junit_jupiter_junit_jupiter_api"],
+)

--- a/tests/src/test/java/com/example/JUnitAssertFuzzer.java
+++ b/tests/src/test/java/com/example/JUnitAssertFuzzer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+
+public class JUnitAssertFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    assertNotEquals("JUnit rocks!", data.consumeRemainingAsString());
+  }
+}


### PR DESCRIPTION
For now, we only hook these equals methods for object compares, but we
should add hooks for other primitive types and other common assert helpers.