### PR TITLE
junit: Add support for coverage runs

### DIFF
--- a/driver/src/main/java/com/code_intelligence/jazzer/junit/JazzerFuzzTestExecutor.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/junit/JazzerFuzzTestExecutor.java
@@ -62,7 +62,7 @@ public class JazzerFuzzTestExecutor {
     // https://github.com/CodeIntelligenceTesting/cifuzz/blob/bf410dcfbafbae2a73cf6c5fbed031cdfe234f2f/internal/cmd/run/run.go#L381
     // The path is specified relative to the current working directory, which with JUnit is the
     // project directory.
-    Path generatedCorpusDir = Paths.get(".cifuzz-corpus", fuzzTestClass.getName());
+    Path generatedCorpusDir = Utils.generatedCorpusPath(fuzzTestClass);
     Files.createDirectories(generatedCorpusDir);
     libFuzzerArgs.add(generatedCorpusDir.toAbsolutePath().toString());
 

--- a/driver/src/main/java/com/code_intelligence/jazzer/junit/RegressionTestArgumentProvider.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/junit/RegressionTestArgumentProvider.java
@@ -52,9 +52,12 @@ class RegressionTestArgumentProvider implements ArgumentsProvider, AnnotationCon
   @Override
   public Stream<? extends Arguments> provideArguments(ExtensionContext extensionContext)
       throws IOException {
-    Stream<Map.Entry<String, byte[]>> rawSeeds =
-        Stream.concat(Stream.of(new SimpleEntry<>("<empty input>", new byte[] {})),
-            walkSeedCorpus(extensionContext.getRequiredTestClass()));
+    Class<?> testClass = extensionContext.getRequiredTestClass();
+    Stream<Map.Entry<String, byte[]>> rawSeeds = Stream.concat(
+        Stream.of(new SimpleEntry<>("<empty input>", new byte[] {})), walkSeedCorpus(testClass));
+    if (Utils.isCoverageAgentPresent() && Files.isDirectory(Utils.generatedCorpusPath(testClass))) {
+      rawSeeds = Stream.concat(rawSeeds, walkSeedsInPath(Utils.generatedCorpusPath(testClass)));
+    }
     return adaptSeedsForFuzzTest(extensionContext.getRequiredTestMethod(), rawSeeds);
   }
 

--- a/driver/src/main/java/com/code_intelligence/jazzer/junit/Utils.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/junit/Utils.java
@@ -14,13 +14,21 @@
 
 package com.code_intelligence.jazzer.junit;
 
+import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class Utils {
   static String defaultSeedCorpusPath(Class<?> testClass) {
     return testClass.getSimpleName() + "SeedCorpus";
+  }
+
+  static Path generatedCorpusPath(Class<?> testClass) {
+    return Paths.get(".cifuzz-corpus", testClass.getName());
   }
 
   static String defaultInstrumentationFilter(Class<?> testClass) {
@@ -40,5 +48,12 @@ class Utils {
     }
     return Stream.concat(Arrays.stream(packageSegments).limit(numSegments), Stream.of("**"))
         .collect(Collectors.joining("."));
+  }
+
+  private static final Pattern COVERAGE_AGENT_ARG =
+      Pattern.compile("-javaagent:.*(?:intellij-coverage-agent|jacoco).*");
+  static boolean isCoverageAgentPresent() {
+    return ManagementFactory.getRuntimeMXBean().getInputArguments().stream().anyMatch(
+        s -> COVERAGE_AGENT_ARG.matcher(s).matches());
   }
 }

--- a/examples/junit/src/main/java/com/example/BUILD.bazel
+++ b/examples/junit/src/main/java/com/example/BUILD.bazel
@@ -1,0 +1,5 @@
+java_library(
+    name = "parser",
+    srcs = ["Parser.java"],
+    visibility = ["//examples/junit/src/test/java/com/example:__pkg__"],
+)

--- a/examples/junit/src/main/java/com/example/Parser.java
+++ b/examples/junit/src/main/java/com/example/Parser.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+public class Parser {
+  public static void parse(byte[] data) {
+    if (data[4] == 'c' && new String(data).startsWith("aaaaaa")) {
+      throw new IllegalStateException("Not reached");
+    }
+  }
+}

--- a/examples/junit/src/test/java/com/example/BUILD.bazel
+++ b/examples/junit/src/test/java/com/example/BUILD.bazel
@@ -12,6 +12,7 @@ java_binary(
         "//agent/src/main/java/com/code_intelligence/jazzer/api",
         "//agent/src/main/java/com/code_intelligence/jazzer/api:hooks",
         "//driver/src/main/java/com/code_intelligence/jazzer/junit:junit_for_testing",
+        "//examples/junit/src/main/java/com/example:parser",
         "//examples/junit/src/test/resources:example_seed_corpora",
         "@maven//:org_junit_jupiter_junit_jupiter_api",
     ],
@@ -27,6 +28,7 @@ java_fuzz_target_test(
     verify_crash_reproducer = False,
     deps = [
         "//driver/src/main/java/com/code_intelligence/jazzer/junit:fuzz_test",
+        "//examples/junit/src/main/java/com/example:parser",
         "@maven//:org_junit_jupiter_junit_jupiter_api",
     ],
 )
@@ -41,6 +43,7 @@ java_fuzz_target_test(
     verify_crash_reproducer = False,
     deps = [
         "//driver/src/main/java/com/code_intelligence/jazzer/junit:fuzz_test",
+        "//examples/junit/src/main/java/com/example:parser",
         "@maven//:org_junit_jupiter_junit_jupiter_api",
     ],
 )

--- a/examples/junit/src/test/java/com/example/ValidFuzzTests.java
+++ b/examples/junit/src/test/java/com/example/ValidFuzzTests.java
@@ -69,8 +69,6 @@ class ValidFuzzTests {
     if (data.length < 10) {
       return;
     }
-    if (data[4] == 'c' && new String(data).startsWith("aaaaaa")) {
-      throw new IllegalStateException("Not reached");
-    }
+    Parser.parse(data);
   }
 }


### PR DESCRIPTION
When a known coverage agent is present, also let the regression test run
over the generated corpus, if it exists.