### PR TITLE
junit: Fix seed corpus URL to path conversion 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
+# Allow directories as sources.
+startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 build --incompatible_strict_action_env
 build --sandbox_tmpfs_path=/tmp
 build --enable_platform_specific_config

--- a/driver/src/main/java/com/code_intelligence/jazzer/junit/JazzerFuzzTestExecutor.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/junit/JazzerFuzzTestExecutor.java
@@ -20,9 +20,11 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Optional;
@@ -47,7 +49,7 @@ public class JazzerFuzzTestExecutor {
     this.baseDir = baseDir;
   }
 
-  public TestExecutionResult execute() throws IOException {
+  public TestExecutionResult execute() throws IOException, URISyntaxException {
     if (!hasExecutedOnce.compareAndSet(false, true)) {
       throw new IllegalStateException(
           "Only a single fuzz test can be executed by JazzerFuzzTestExecutor per test run");
@@ -94,8 +96,8 @@ public class JazzerFuzzTestExecutor {
       }
     } else if ("file".equals(seedCorpusUrl.getProtocol())) {
       // From the second positional argument on, files and directories are used as seeds but not
-      // modified.
-      libFuzzerArgs.add(seedCorpusUrl.getFile());
+      // modified. Using seedCorpusUrl.getFile() fails on Windows.
+      libFuzzerArgs.add(Paths.get(seedCorpusUrl.toURI()).toString());
       // We try to find the source tree representation of the seed corpus directory and emit
       // findings into it.
       findSeedCorpusDirectoryInSourceTree().ifPresent(

--- a/driver/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/driver/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@bazel_skylib//rules:copy_directory.bzl", "copy_directory")
+
 [
     java_test(
         name = "RegressionTestTest" + JAZZER_FUZZ,
@@ -110,5 +112,63 @@
     for JAZZER_VALUE_PROFILE in [
         "true",
         "false",
+    ]
+]
+
+copy_directory(
+    name = "test_resources_root_windows",
+    src = "test_resources_root",
+    out = "test_resources_root",
+    tags = ["manual"],
+)
+
+[
+    java_test(
+        name = "DirectorySeedCorpusTest" + JAZZER_FUZZ,
+        srcs = ["DirectorySeedCorpusTest.java"],
+        args = select({
+            "@platforms//os:windows": [
+                # --main_advice_classpath isn't passed through Rlocation on Windows, which makes it
+                # impossible to resolve the resources root from runfiles. Instead, we abuse the fact
+                # that execution isn't sandboxed to resolve the regular exec path location relative
+                # to the runfiles root:
+                # .../jazzer/junit/DirectorySeedCorpusTest.runfiles/jazzer -->
+                # .../jazzer/junit/test_resources_root
+                # TODO: Get rid of this hack when https://github.com/bazelbuild/bazel/pull/16227 has
+                #  been merged.
+                "--main_advice_classpath=../../test_resources_root",
+            ],
+            "//conditions:default": [
+                # Add a test resource root containing the seed corpus directory in a Maven layout to
+                # the classpath rather than seeds in a resource directory packaged in a JAR, as
+                # would happen if we added the directory to java_test's resources.
+                "--main_advice_classpath=$(rootpath test_resources_root)",
+            ],
+        }),
+        data = select({
+            "@platforms//os:windows": [":test_resources_root_windows"],
+            "//conditions:default": ["test_resources_root"],
+        }),
+        env = {
+            "JAZZER_FUZZ": JAZZER_FUZZ,
+        },
+        test_class = "com.code_intelligence.jazzer.junit.DirectorySeedCorpusTest",
+        runtime_deps = [
+            "//examples/junit/src/test/java/com/example:ExampleFuzzTests_deploy.jar",
+        ],
+        deps = [
+            "//agent/src/main/java/com/code_intelligence/jazzer/api:hooks",
+            "@maven//:com_google_truth_extensions_truth_java8_extension",
+            "@maven//:com_google_truth_truth",
+            "@maven//:junit_junit",
+            "@maven//:org_junit_jupiter_junit_jupiter_api",
+            "@maven//:org_junit_jupiter_junit_jupiter_engine",
+            "@maven//:org_junit_platform_junit_platform_engine",
+            "@maven//:org_junit_platform_junit_platform_testkit",
+        ],
+    )
+    for JAZZER_FUZZ in [
+        "",
+        "_fuzzing",
     ]
 ]

--- a/driver/src/test/java/com/code_intelligence/jazzer/junit/DirectorySeedCorpusTest.java
+++ b/driver/src/test/java/com/code_intelligence/jazzer/junit/DirectorySeedCorpusTest.java
@@ -1,0 +1,119 @@
+// Copyright 2022 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.junit;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.container;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.EventConditions.test;
+import static org.junit.platform.testkit.engine.EventConditions.type;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.platform.testkit.engine.EventType;
+import org.junit.rules.TemporaryFolder;
+
+public class DirectorySeedCorpusTest {
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  @Test
+  public void fuzzingEnabled() throws IOException {
+    assumeFalse(System.getenv("JAZZER_FUZZ").isEmpty());
+
+    Path baseDir = temp.getRoot().toPath();
+    // Create a fake test resource directory structure with a seed corpus directory to verify that
+    // Jazzer uses it and emits a crash file into it.
+    Path seedCorpus = baseDir.resolve(
+        Paths.get("src", "test", "resources", "com", "example", "DirectoryBasedSeedCorpus"));
+    Files.createDirectories(seedCorpus);
+
+    EngineExecutionResults results =
+        EngineTestKit.engine("com.code_intelligence.jazzer")
+            .selectors(selectClass("com.example.DirectorySeedCorpusFuzzTest"))
+            .configurationParameter("jazzer.internal.basedir", baseDir.toAbsolutePath().toString())
+            .execute();
+
+    results.testEvents().debug().assertEventsMatchExactly(
+        event(type(EventType.STARTED),
+            test("com.example.DirectorySeedCorpusFuzzTest",
+                "seedCorpusFuzz(FuzzedDataProvider) (Fuzzing)")),
+        event(type(EventType.FINISHED),
+            test("com.example.DirectorySeedCorpusFuzzTest",
+                "seedCorpusFuzz(FuzzedDataProvider) (Fuzzing)"),
+            finishedWithFailure(instanceOf(FuzzerSecurityIssueMedium.class))));
+    results.containerEvents().debug().assertEventsMatchExactly(
+        event(type(EventType.STARTED), container("com.code_intelligence.jazzer")),
+        event(type(EventType.FINISHED), container("com.code_intelligence.jazzer")));
+
+    // Should crash on the exact input "directory" as provided by the seed, with the crash emitted
+    // into the seed corpus.
+    try (Stream<Path> crashFiles =
+             Files.list(baseDir).filter(path -> path.getFileName().startsWith("crash-"))) {
+      assertThat(crashFiles).isEmpty();
+    }
+    try (Stream<Path> seeds = Files.list(seedCorpus)) {
+      assertThat(seeds).containsExactly(
+          seedCorpus.resolve("crash-8d392f56d616a516ceabb82ed8906418bce4647d"));
+    }
+    assertThat(
+        Files.readAllBytes(seedCorpus.resolve("crash-8d392f56d616a516ceabb82ed8906418bce4647d")))
+        .isEqualTo("directory".getBytes(StandardCharsets.UTF_8));
+
+    // Verify that the engine created the generated corpus directory. Since the crash was found on a
+    // seed, it should be empty.
+    Path generatedCorpus =
+        baseDir.resolve(Paths.get(".cifuzz-corpus", "com.example.DirectorySeedCorpusFuzzTest"));
+    assertThat(Files.isDirectory(generatedCorpus)).isTrue();
+    try (Stream<Path> entries = Files.list(generatedCorpus)) {
+      assertThat(entries).isEmpty();
+    }
+  }
+
+  @Test
+  public void fuzzingDisabled() {
+    assumeTrue(System.getenv("JAZZER_FUZZ").isEmpty());
+
+    EngineExecutionResults results =
+        EngineTestKit.engine("junit-jupiter")
+            .selectors(selectClass("com.example.DirectorySeedCorpusFuzzTest"))
+            .execute();
+
+    results.testEvents().debug().assertEventsMatchExactly(
+        event(type(EventType.DYNAMIC_TEST_REGISTERED)), event(type(EventType.STARTED)),
+        // "No fuzzing has been performed..."
+        event(type(EventType.REPORTING_ENTRY_PUBLISHED)),
+        event(test("seedCorpusFuzz", "<empty input>"), finishedSuccessfully()),
+        event(type(EventType.DYNAMIC_TEST_REGISTERED)), event(type(EventType.STARTED)),
+        event(type(EventType.REPORTING_ENTRY_PUBLISHED)),
+        event(test("seedCorpusFuzz", "seed"),
+            finishedWithFailure(instanceOf(FuzzerSecurityIssueMedium.class))));
+  }
+}

--- a/driver/src/test/java/com/code_intelligence/jazzer/junit/test_resources_root/com/example/DirectoryBasedSeedCorpus/nested_dir/seed
+++ b/driver/src/test/java/com/code_intelligence/jazzer/junit/test_resources_root/com/example/DirectoryBasedSeedCorpus/nested_dir/seed
@@ -1,0 +1,1 @@
+directory

--- a/examples/junit/src/test/java/com/example/DirectorySeedCorpusFuzzTest.java
+++ b/examples/junit/src/test/java/com/example/DirectorySeedCorpusFuzzTest.java
@@ -1,0 +1,34 @@
+// Copyright 2022 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+
+public class DirectorySeedCorpusFuzzTest {
+  private static long runs = 0;
+
+  @FuzzTest(seedCorpus = "/com/example/DirectoryBasedSeedCorpus", maxDuration = "0s")
+  public void seedCorpusFuzz(FuzzedDataProvider data) {
+    if (runs++ > 1) {
+      // Only execute the fuzz test logic on the empty input and the only seed.
+      return;
+    }
+    if (data.consumeRemainingAsString().equals("directory")) {
+      throw new FuzzerSecurityIssueMedium();
+    }
+  }
+}

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -31,10 +31,10 @@ def jazzer_dependencies():
     maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+        sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
-            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
The conversion did not work on Windows, where `file:///c:/foo` became
`/C:\foo` rather than `C:\foo`.

Fixes CLI-451