### PR TITLE
BREAKING: autofuzz: Do not enable --keep_going by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,6 @@ Jazzer addresses this issue by ignoring exceptions that the target method declar
 In addition to that, you can provide a list of exceptions to be ignored during fuzzing via the `--autofuzz_ignore` flag in the form of a comma-separated list.
 You can specify concrete exceptions (e.g., `java.lang.NullPointerException`), in which case also subclasses of these exception classes will be ignored, or glob patterns to ignore all exceptions in a specific package (e.g. `java.lang.*` or `com.company.**`).
 
-When fuzzing with `--autofuzz`, Jazzer automatically enables the `--keep_going` mode to keep fuzzing indefinitely after the first finding.
-Set `--keep_going=N` explicitly to stop after the `N`-th finding.
-
 #### Docker
 To facilitate using the Autofuzz mode, there is a docker image that you can use to fuzz libraries just by providing their Maven coordinates.
 The dependencies will then be downloaded and autofuzzed:
@@ -297,8 +294,7 @@ As an example, you can autofuzz the `json-sanitizer` library as follows:
 docker run -it cifuzz/jazzer-autofuzz \
    com.mikesamuel:json-sanitizer:1.2.0 \
    com.google.json.JsonSanitizer::sanitize \
-   --autofuzz_ignore=java.lang.ArrayIndexOutOfBoundsException \
-   --keep_going=1
+   --autofuzz_ignore=java.lang.ArrayIndexOutOfBoundsException
 ```
 
 ####

--- a/driver/src/main/java/com/code_intelligence/jazzer/driver/Opt.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/driver/Opt.java
@@ -61,19 +61,18 @@ public final class Opt {
                                       .stream()
                                       .map(token -> Long.parseUnsignedLong(token, 16))
                                       .collect(Collectors.toSet()));
+  public static final long keepGoing = uint64Setting("keep_going", 1);
   public static final String reproducerPath = stringSetting("reproducer_path", ".");
   public static final String targetClass = stringSetting("target_class", "");
   // Used to disambiguate between multiple methods annotated with @FuzzTest in the target class.
   public static final String targetMethod = stringSetting("target_method", "");
   public static final List<String> trace = stringListSetting("trace");
 
-  // The values of these settings depend on autofuzz.
+  // The values of this setting depends on autofuzz.
   public static final List<String> targetArgs = autofuzz.isEmpty()
       ? stringListSetting("target_args", ' ')
       : Collections.unmodifiableList(
           Stream.concat(Stream.of(autofuzz), autofuzzIgnore.stream()).collect(Collectors.toList()));
-  public static final long keepGoing =
-      uint64Setting("keep_going", autofuzz.isEmpty() ? 1 : Long.MAX_VALUE);
 
   // Default to false if hooks is false to mimic the original behavior of the native fuzz target
   // runner, but still support hooks = false && dedup = true.

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -8,8 +8,6 @@ java_fuzz_target_test(
     expected_findings = ["java.lang.ArrayIndexOutOfBoundsException"],
     fuzzer_args = [
         "--autofuzz=com.google.json.JsonSanitizer::sanitize",
-        # Exit after the first finding for testing purposes.
-        "--keep_going=1",
     ],
     runtime_deps = [
         "@maven//:com_mikesamuel_json_sanitizer",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -21,8 +21,6 @@ java_fuzz_target_test(
     expected_findings = ["java.lang.NegativeArraySizeException"],
     fuzzer_args = [
         "--autofuzz=org.apache.commons.imaging.formats.jpeg.JpegImageParser::getBufferedImage",
-        # Exit after the first finding for testing purposes.
-        "--keep_going=1",
         "--autofuzz_ignore=java.lang.NullPointerException",
     ],
     runtime_deps = [
@@ -53,7 +51,6 @@ java_fuzz_target_test(
         # Autofuzz a method that triggers no coverage instrumentation (the Java standard library is
         # excluded by default).
         "--autofuzz=java.util.regex.Pattern::compile",
-        "--keep_going=1",
     ],
 )
 
@@ -65,7 +62,6 @@ java_fuzz_target_test(
         "--instrumentation_includes=java.util.regex.**",
         "--autofuzz=java.util.regex.Pattern::compile",
         "--autofuzz_ignore=java.lang.Exception",
-        "--keep_going=1",
     ],
     # FIXME(fabian): Regularly times out on Windows with 0 exec/s for minutes.
     target_compatible_with = SKIP_ON_WINDOWS,
@@ -133,7 +129,6 @@ java_fuzz_target_test(
     expected_findings = ["com.code_intelligence.jazzer.api.FuzzerSecurityIssueLow"],
     fuzzer_args = [
         "--autofuzz=com.example.AutofuzzInnerClassTarget.Middle.Inner::test",
-        "--keep_going=1",
     ],
     runtime_deps = [
         ":autofuzz_inner_class_target",
@@ -287,7 +282,6 @@ java_fuzz_target_test(
         "--autofuzz=com.example.AutofuzzIgnoreTarget::doStuff",
         "--autofuzz_ignore=java.lang.NullPointerException",
         "--ignore=bdde2af8735993f3,0123456789ABCDEF",
-        "--keep_going=1",
     ],
     runtime_deps = [
         ":autofuzz_ignore_target",


### PR DESCRIPTION
Users reported that the implicit --keep_going of Autofuzz results in
poor UX as findings fly by unnoticed and it is not clear whether fuzzing
will ever stop by itself.

Instead, stop after the first finding as usual but print helpful
follow-up commands to skip a particular finding or a finding of a
particular type.

Stacked on #472 