### PR TITLE
Generate docs and source JAR for jazzer-junit

### DIFF
--- a/deploy/BUILD.bazel
+++ b/deploy/BUILD.bazel
@@ -16,8 +16,16 @@ java_export(
     name = "junit",
     maven_coordinates = JAZZER_JUNIT_COORDINATES,
     pom_template = "jazzer-junit.pom",
+    # Do not generate an implicit javadocs target - the current target is based on the shaded deploy
+    # JAR including all dependencies, which breaks javadoc.
+    tags = ["no-javadocs"],
     visibility = ["//visibility:public"],
     runtime_deps = [
         "//driver/src/main/java/com/code_intelligence/jazzer/junit",
     ] + JAZZER_JUNIT_MAVEN_DEPS,
+)
+
+alias(
+    name = "junit-javadocs",
+    actual = "//driver/src/main/java/com/code_intelligence/jazzer/junit:junit-docs",
 )

--- a/deploy/BUILD.bazel
+++ b/deploy/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@rules_jvm_external//:defs.bzl", "java_export")
 load("//:maven.bzl", "JAZZER_API_COORDINATES", "JAZZER_JUNIT_COORDINATES", "JAZZER_JUNIT_MAVEN_DEPS")
+load("//bazel:compat.bzl", "SKIP_ON_WINDOWS")
+load("//bazel:jar.bzl", "strip_jar")
 
 # To publish a new release of the Jazzer API to Maven, run:
 # bazel run --config=maven --define "maven_user=..." --define "maven_password=..." --define gpg_sign=true //deploy:api.publish
@@ -28,4 +30,46 @@ java_export(
 alias(
     name = "junit-javadocs",
     actual = "//driver/src/main/java/com/code_intelligence/jazzer/junit:junit-docs",
+)
+
+strip_jar(
+    name = "junit_sources",
+    out = "junit-sources.jar",
+    jar = ":junit-sources-unfiltered",
+    paths_to_strip = [
+        "META-INF/**",
+        "com/github/**",
+        "io/**",
+        "jaz/**",
+        "kotlin/**",
+        "net/**",
+        "nonapi/**",
+        "org/**",
+        "sanitizers/**",
+    ],
+)
+
+sh_test(
+    name = "junit_sources_shading_test",
+    srcs = ["verify_shading.sh"],
+    args = [
+        "$(rootpath junit-sources.jar)",
+    ],
+    data = [
+        "junit-sources.jar",
+        "@local_jdk//:bin/jar",
+    ],
+    tags = [
+        # Coverage instrumentation necessarily adds files to the jar that we
+        # wouldn't want to release and thus causes this test to fail.
+        "no-coverage",
+    ],
+    target_compatible_with = SKIP_ON_WINDOWS,
+)
+
+filegroup(
+    name = "junit-sources-unfiltered",
+    srcs = [":junit-project"],
+    # https://github.com/bazelbuild/rules_jvm_external/blob/3cf0d483d59e9d817c356e1c6873697507853dbe/private/rules/maven_project_jar.bzl#L79
+    output_group = "_source_jars",
 )

--- a/deploy/verify_shading.sh
+++ b/deploy/verify_shading.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+# Copyright 2022 Code Intelligence GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[ -f "$1" ] || exit 1
+# List all files in the jar and exclude an allowed list of files.
+# Since grep fails if there is no match, ! ... | grep ... fails if there is a
+# match.
+! external/local_jdk/bin/jar tf "$1" | \
+  grep -v \
+    -e '^com/$' \
+    -e '^com/code_intelligence/'

--- a/driver/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
+++ b/driver/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
@@ -15,6 +15,5 @@ write_file(
 java_library(
     name = "constants",
     srcs = [":constants_java"],
-    neverlink = True,
     visibility = ["//visibility:public"],
 )

--- a/driver/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/driver/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -1,10 +1,25 @@
 load("@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl", "jar_jar")
 load("@fmeum_rules_jni//jni:defs.bzl", "java_jni_library")
+load("@rules_jvm_external//:defs.bzl", "javadoc")
 load("//bazel:compat.bzl", "SKIP_ON_WINDOWS")
 load("//bazel:jar.bzl", "strip_jar")
 load("//:maven.bzl", "JAZZER_JUNIT_MAVEN_DEPS")
 load("//sanitizers:sanitizers.bzl", "SANITIZER_CLASSES")
 
+javadoc(
+    name = "junit-docs",
+    visibility = ["//deploy:__pkg__"],
+    deps = [
+        ":agent_configurator",
+        ":fuzz_test",
+        ":jazzer_test_engine",
+        ":utils",
+        "//agent/src/main/java/com/code_intelligence/jazzer/api",
+    ],
+)
+
+jar_jar(
+    name = "junit_shaded",
 # The Jazzer JUnit integration without its dependencies declared in the pom.xml.
 jar_jar(
     name = "junit",

--- a/driver/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/driver/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -6,6 +6,14 @@ load("//bazel:jar.bzl", "strip_jar")
 load("//:maven.bzl", "JAZZER_JUNIT_MAVEN_DEPS")
 load("//sanitizers:sanitizers.bzl", "SANITIZER_CLASSES")
 
+# The Jazzer JUnit integration without its dependencies declared in the pom.xml, together with the unshaded sources.
+java_import(
+    name = "junit",
+    jars = ["junit_shaded.jar"],
+    srcjar = "junit_unshaded_deploy-src.jar",
+    visibility = ["//visibility:public"],
+)
+
 javadoc(
     name = "junit-docs",
     visibility = ["//deploy:__pkg__"],
@@ -20,12 +28,8 @@ javadoc(
 
 jar_jar(
     name = "junit_shaded",
-# The Jazzer JUnit integration without its dependencies declared in the pom.xml.
-jar_jar(
-    name = "junit",
     input_jar = "junit_stripped.jar",
     rules = "junit_shade_rules",
-    visibility = ["//visibility:public"],
 )
 
 # :junit together with all its Maven dependencies.
@@ -33,7 +37,7 @@ java_import(
     name = "junit_for_testing",
     testonly = True,
     jars = [
-        "junit.jar",
+        "junit_shaded.jar",
         "junit_maven_deps_deploy.jar",
     ],
     visibility = ["//visibility:public"],
@@ -68,10 +72,10 @@ sh_test(
     name = "junit_shading_test",
     srcs = ["verify_shading.sh"],
     args = [
-        "$(rootpath junit.jar)",
+        "$(rootpath junit_shaded.jar)",
     ],
     data = [
-        "junit.jar",
+        "junit_shaded.jar",
         "@local_jdk//:bin/jar",
     ],
     tags = [

--- a/driver/src/main/java/com/code_intelligence/jazzer/junit/JazzerFuzzTestExecutor.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/junit/JazzerFuzzTestExecutor.java
@@ -39,7 +39,7 @@ import org.junit.platform.engine.ExecutionRequest;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.reporting.ReportEntry;
 
-public class JazzerFuzzTestExecutor {
+class JazzerFuzzTestExecutor {
   private static final AtomicBoolean hasExecutedOnce = new AtomicBoolean();
 
   private final ExecutionRequest request;

--- a/driver/src/main/java/com/code_intelligence/jazzer/junit/JazzerTestEngine.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/junit/JazzerTestEngine.java
@@ -39,7 +39,7 @@ import org.junit.platform.engine.support.descriptor.AbstractTestDescriptor;
 import org.junit.platform.engine.support.descriptor.EngineDescriptor;
 
 public class JazzerTestEngine implements TestEngine {
-  public static class JazzerSetupError extends Error {
+  static class JazzerSetupError extends Error {
     public JazzerSetupError(Throwable e) {
       super("Jazzer fuzz test failed to execute", e);
     }
@@ -48,7 +48,7 @@ public class JazzerTestEngine implements TestEngine {
     }
   }
 
-  public static class JazzerFuzzTestDescriptor extends AbstractTestDescriptor {
+  static class JazzerFuzzTestDescriptor extends AbstractTestDescriptor {
     private final Method method;
 
     public JazzerFuzzTestDescriptor(UniqueId uniqueId, Method method) {

--- a/driver/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/driver/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -88,12 +88,17 @@ load("@bazel_skylib//rules:copy_directory.bzl", "copy_directory")
 
 [
     java_test(
-        name = "ValueProfileTest_" + JAZZER_VALUE_PROFILE,
+        name = "ValueProfileTest_" + str(JAZZER_VALUE_PROFILE),
         srcs = ["ValueProfileTest.java"],
         env = {
             "JAZZER_FUZZ": "true",
-            "JAZZER_VALUE_PROFILE": JAZZER_VALUE_PROFILE,
+            "JAZZER_VALUE_PROFILE": str(JAZZER_VALUE_PROFILE),
         },
+        # The test is both CPU-intensive and sensitive to timing, which causes it to be flaky on
+        # slow runners (particularly macOS on GitHub Actions). Since we need to distinguish the two
+        # test variants by whether they find a finding, we can't just increase the timeout without
+        # the risk to make the other variant flaky.
+        tags = ["exclusive"] if JAZZER_VALUE_PROFILE else [],
         test_class = "com.code_intelligence.jazzer.junit.ValueProfileTest",
         runtime_deps = [
             "//examples/junit/src/test/java/com/example:ExampleFuzzTests_deploy.jar",
@@ -110,8 +115,8 @@ load("@bazel_skylib//rules:copy_directory.bzl", "copy_directory")
         ],
     )
     for JAZZER_VALUE_PROFILE in [
-        "true",
-        "false",
+        True,
+        False,
     ]
 ]
 


### PR DESCRIPTION
The automatic docs and source JAR generation provided by `rules_jvm_external`'s `java_export` couldn't handle our shading and stripping.

Fixes #474 