### PR TITLE
tests: Deflake tests

### DIFF
--- a/driver/src/test/java/com/code_intelligence/jazzer/junit/AutofuzzTest.java
+++ b/driver/src/test/java/com/code_intelligence/jazzer/junit/AutofuzzTest.java
@@ -76,7 +76,7 @@ public class AutofuzzTest {
         event(type(EventType.STARTED), container("com.code_intelligence.jazzer")),
         event(type(EventType.FINISHED), container("com.code_intelligence.jazzer")));
 
-    // Should crash on an input that starts with "jazzer", with the crash emitted into the base
+    // Should crash on an input that contains "jazzer", with the crash emitted into the base
     // directory since there is no seed corpus.
     Path crashingInput;
     try (Stream<Path> crashFiles = Files.list(baseDir).filter(
@@ -86,7 +86,7 @@ public class AutofuzzTest {
       crashingInput = crashFilesList.get(0);
     }
     assertThat(new String(Files.readAllBytes(crashingInput), StandardCharsets.UTF_8))
-        .startsWith("jazzer");
+        .contains("jazzer");
 
     try (Stream<Path> seeds = Files.list(seedCorpus)) {
       assertThat(seeds).isEmpty();

--- a/examples/junit/src/test/java/com/example/AutofuzzFuzzTests.java
+++ b/examples/junit/src/test/java/com/example/AutofuzzFuzzTests.java
@@ -34,7 +34,7 @@ class AutofuzzFuzzTests {
   @FuzzTest(maxDuration = "5m")
   void autofuzz(String str, IntHolder holder) {
     assumeTrue(holder != null);
-    if (holder.getI() == 1234 && "jazzer".equals(str)) {
+    if (holder.getI() == 1234 && str != null && str.contains("jazzer")) {
       throw new RuntimeException();
     }
   }

--- a/examples/junit/src/test/java/com/example/ValueProfileFuzzTest.java
+++ b/examples/junit/src/test/java/com/example/ValueProfileFuzzTest.java
@@ -22,7 +22,7 @@ import java.util.Base64;
 
 class ValueProfileFuzzTest {
   // Only passed with the configuration parameter jazzer.valueprofile=true.
-  @FuzzTest(maxDuration = "10s")
+  @FuzzTest(maxDuration = "20s")
   void valueProfileFuzz(byte[] data) {
     // Trigger some coverage even with value profiling disabled.
     if (data.length < 1 || data[0] > 100) {


### PR DESCRIPTION
Before this commit:

```
//driver/src/test/java/com/code_intelligence/jazzer/junit:AutofuzzTest_fuzzing FLAKY, failed in 3 out of 10 in 301.8s
  Stats over 10 runs: max = 301.8s, min = 26.4s, avg = 124.0s, dev = 118.9s
```

After this commit:

```
//driver/src/test/java/com/code_intelligence/jazzer/junit:AutofuzzTest_fuzzing PASSED in 82.4s
  Stats over 20 runs: max = 82.4s, min = 14.3s, avg = 32.6s, dev = 14.5s
```

Fixes #486 