### PR TITLE
Ignore regex pattern syntax exceptions caused by stack overflows

### DIFF
--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/RegexInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/RegexInjection.kt
@@ -23,6 +23,9 @@ import java.lang.invoke.MethodHandle
 import java.util.regex.Pattern
 import java.util.regex.PatternSyntaxException
 
+// message introduced in JDK14 and ported back to previous versions
+private const val STACK_OVERFLOW_ERROR_MESSAGE = "Stack overflow during pattern compilation"
+
 @Suppress("unused_parameter", "unused")
 object RegexInjection {
     /**
@@ -143,7 +146,7 @@ memory allocations, even when wrapped with Pattern.quote(...)."""
                 }
             }
         } catch (e: Exception) {
-            if (e is PatternSyntaxException) {
+            if (e is PatternSyntaxException && !(e.message ?: "").startsWith(STACK_OVERFLOW_ERROR_MESSAGE)) {
                 Jazzer.reportFindingFromHook(
                     FuzzerSecurityIssueLow(
                         """Regular Expression Injection

--- a/sanitizers/src/test/java/com/example/BUILD.bazel
+++ b/sanitizers/src/test/java/com/example/BUILD.bazel
@@ -161,6 +161,21 @@ java_fuzz_target_test(
     verify_crash_reproducer = False,
 )
 
+# Catching StackOverflowErrors doesn't work reliably across all systems and JDK versions.
+# It may lead to a native crash before we can handle the exception in Java, therefore the
+# test is set to manual execution.
+java_fuzz_target_test(
+    name = "StackOverflowRegexInjection",
+    srcs = ["StackOverflowRegexInjection.java"],
+    allowed_findings = ["java.util.regex.PatternSyntaxException"],
+    fuzzer_args = [
+        "-runs=1",
+    ],
+    tags = ["manual"],
+    target_class = "com.example.StackOverflowRegexInjection",
+    verify_crash_reproducer = False,
+)
+
 java_fuzz_target_test(
     name = "SqlInjection",
     srcs = [

--- a/sanitizers/src/test/java/com/example/StackOverflowRegexInjection.java
+++ b/sanitizers/src/test/java/com/example/StackOverflowRegexInjection.java
@@ -1,0 +1,51 @@
+// Copyright 2022 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import java.util.regex.Pattern;
+
+/**
+ * Compiling a regex pattern can lead to stack overflows and thus is caught
+ * in the constructor of {@link java.util.regex.Pattern} and rethrown as a
+ * {@link java.util.regex.PatternSyntaxException}.
+ * The {@link com.code_intelligence.jazzer.sanitizers.RegexInjection} sanitizer
+ * uses this exception to detect injections and would incorrectly report a
+ * finding. Exceptions caused by stack overflows should not be handled in the
+ * hook as it's very unlikely that the fuzzer generates a pattern causing a
+ * stack overflow before it generates an invalid one.
+ */
+@SuppressWarnings({"ReplaceOnLiteralHasNoEffect", "ResultOfMethodCallIgnored"})
+public class StackOverflowRegexInjection {
+  public static void fuzzerTestOneInput(FuzzedDataProvider ignored) {
+    // load regex classes by using them beforehand,
+    // otherwise initialization would cause other issues.
+    Pattern.compile("\n").matcher("some string").replaceAll("\\\\n");
+
+    generatePatternSyntaxException();
+  }
+
+  @SuppressWarnings("InfiniteRecursion")
+  private static void generatePatternSyntaxException() {
+    // try-catch on every level to not unwind the stack
+    try {
+      // generate stack overflow
+      generatePatternSyntaxException();
+    } catch (StackOverflowError e) {
+      // invoke regex injection hook
+      "some sting".replaceAll("\n", "\\\\n");
+    }
+  }
+}


### PR DESCRIPTION
Compiling regex patterns can cause stack overflows and so the Pattern class handles this case and throws a PatternSyntaxException after unwinding the stack.

We encountered a situation where a library doesn't unwind the stack and uses a regex during handling of a stack overflow. This in turn causes another stack overflow error and the RegexInjection bug detector wrongly reports a finding.

It is very unlikely that the fuzzer triggers a stack overflow while trying to provoke a PatternSyntaxException. Hence, the RegexInjection bug detector now ignores PatternSyntaxExceptions caused by stack overflows.

Apparently stack overflow handling was introduced in JDK 14 and ported back to older versions. The exception message seems to be stable across all versions.