### PR TITLE
ci: Pin runner images to latest non-deprecated versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       matrix:
         # Keep arch names in sync with replayer and junit download and merge
-        os: [ubuntu-latest, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-11, windows-2019]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             arch: "linux"
             bazel_args: "--config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux"
-          - os: macos-10.15
+          - os: macos-11
             arch: "macos-x86_64"
             bazel_args: "--config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-darwin --xcode_version_config=//.github:host_xcodes"
           - os: windows-2019
@@ -59,7 +59,7 @@ jobs:
           path: release-${{ matrix.arch}}.tar.gz
 
   merge_jars:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: build_release
 
     steps:

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11, windows-latest]
+        os: [ubuntu-20.04, macos-11, windows-2019]
         jdk: [8, 17]
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             arch: "linux"
             cache: "/home/runner/.cache/bazel-disk"
           - os: macos-11
@@ -25,7 +25,7 @@ jobs:
             # Always use the toolchain as UBSan produces linker errors with Apple LLVM 13.
             bazel_args: "--config=toolchain --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-darwin --xcode_version_config=//.github:host_xcodes"
             cache: "/private/var/tmp/bazel-disk"
-          - os: windows-latest
+          - os: windows-2019
             arch: "windows"
             cache: "%HOME%/bazel-disk"
 


### PR DESCRIPTION
- `*-latest` can lead to unexpected build failures on updates
- `macos-10.15` is deprecated and started to have planned brownouts

Ref: CLI-545