### PR TITLE
ci: Do not use toolchain for macOS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,6 @@ jobs:
           echo "build --config=maven" >> .bazelrc
           echo "build:linux --config=toolchain" >> .bazelrc
           echo "build:linux --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux" >> .bazelrc
-          echo "build:macos --config=toolchain" >> .bazelrc
-          echo "build:macos --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-darwin" >> .bazelrc
 
       - name: Build
         shell: bash


### PR DESCRIPTION
The toolchain doesn't use a sysroot and is not available on arm64 yet, so it's not clear what the benefit of keeping it is.