### PR TITLE
deps: Update rules_jvm_external to preserve directories in JARs

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -45,10 +45,10 @@ http_archive(
 
 http_archive(
     name = "rules_jvm_external",
-    sha256 = "1582bcdf8e288696770fe5d9878f2f9e7905ce1cfe19c9a09571d9555c899110",
+    sha256 = "6ebe13d95fc5549cc32b27d41c907426b16464c5aae893a163c7fe0c9051ec1d",
     # TODO: Return to the next release.
-    strip_prefix = "rules_jvm_external-061788bf3aacc7aba405739af9ecd830d61f3c89",
-    url = "https://github.com/bazelbuild/rules_jvm_external/archive/061788bf3aacc7aba405739af9ecd830d61f3c89.tar.gz",
+    strip_prefix = "rules_jvm_external-90280783fa4e74439b88191acafd99232ada61aa",
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/90280783fa4e74439b88191acafd99232ada61aa.tar.gz",
 )
 
 http_archive(

--- a/deploy/jazzer-junit_artifact_test.sh
+++ b/deploy/jazzer-junit_artifact_test.sh
@@ -23,7 +23,9 @@
     -e '^com/code_intelligence/$' \
     -e '^com/code_intelligence/jazzer/$' \
     -e '^com/code_intelligence/jazzer/junit/' \
+    -e '^com/code_intelligence/jazzer/sanitizers/$' \
     -e '^com/code_intelligence/jazzer/sanitizers/Constants.class$' \
     -e '^META-INF/$' \
     -e '^META-INF/MANIFEST.MF$' \
+    -e '^META-INF/services/$' \
     -e '^META-INF/services/org.junit.platform.engine.TestEngine$'


### PR DESCRIPTION
Before https://github.com/bazelbuild/rules_jvm_external/commit/90280783fa4e74439b88191acafd99232ada61aa, parent directories of files were not necessarily included in JARs generated with `java_export`, which could confuse Java tooling expecting them to exist.