### PR TITLE
Fix sanitizers not being loaded with jazzer_standalone_deploy.jar

### DIFF
--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/Agent.kt
@@ -20,6 +20,7 @@ import com.code_intelligence.jazzer.driver.Opt
 import com.code_intelligence.jazzer.instrumentor.CoverageRecorder
 import com.code_intelligence.jazzer.instrumentor.Hooks
 import com.code_intelligence.jazzer.instrumentor.InstrumentationType
+import com.code_intelligence.jazzer.sanitizers.Constants
 import com.code_intelligence.jazzer.utils.ClassNameGlobber
 import com.code_intelligence.jazzer.utils.ManifestUtils
 import java.lang.instrument.Instrumentation
@@ -32,7 +33,8 @@ fun install(instrumentation: Instrumentation) {
         ManifestUtils.combineManifestValues(ManifestUtils.HOOK_CLASSES).flatMap {
             it.split(':')
         }.filter { it.isNotBlank() }
-    val allCustomHookNames = (manifestCustomHookNames + Opt.customHooks).toSet()
+    val allCustomHookNames = (Constants.SANITIZER_HOOK_NAMES + manifestCustomHookNames + Opt.customHooks).toSet()
+    check(allCustomHookNames.isNotEmpty()) { "No hooks registered; expected at least the built-in hooks" }
     val disabledCustomHookNames = Opt.disabledHooks.toSet()
     val customHookNames = allCustomHookNames - disabledCustomHookNames
     val disabledCustomHooksToPrint = allCustomHookNames - customHookNames.toSet()

--- a/agent/src/main/java/com/code_intelligence/jazzer/agent/BUILD.bazel
+++ b/agent/src/main/java/com/code_intelligence/jazzer/agent/BUILD.bazel
@@ -25,5 +25,6 @@ kt_jvm_library(
         "//agent/src/main/java/com/code_intelligence/jazzer/utils:class_name_globber",
         "//agent/src/main/java/com/code_intelligence/jazzer/utils:manifest_utils",
         "//driver/src/main/java/com/code_intelligence/jazzer/driver:opt",
+        "//sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers:constants",
     ],
 )

--- a/driver/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
+++ b/driver/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
@@ -50,10 +50,6 @@ jar_jar(
     rules = "jazzer_shade_rules.jarjar",
 )
 
-DEPLOY_MANIFEST_LINES = [
-    "Jazzer-Hook-Classes: ",
-] + [" {}:".format(c) for c in SANITIZER_CLASSES]
-
 java_binary(
     name = "jazzer_unshaded",
     # Note: We can't add
@@ -64,7 +60,6 @@ java_binary(
         "//agent/src/main/java/com/code_intelligence/jazzer/api:api_deploy_env",
         "//agent/src/main/java/com/code_intelligence/jazzer/runtime:jazzer_bootstrap_env",
     ],
-    deploy_manifest_lines = DEPLOY_MANIFEST_LINES,
     main_class = "com.code_intelligence.jazzer.Jazzer",
     runtime_deps = [":jazzer_lib"],
 )
@@ -91,7 +86,6 @@ strip_jar(
 # The _deploy-src.jar for this target includes the sources for the jazzer_bootstrap library.
 java_binary(
     name = "jazzer_transitive_sources",
-    deploy_manifest_lines = DEPLOY_MANIFEST_LINES,
     main_class = "com.code_intelligence.jazzer.Jazzer",
     runtime_deps = [
         ":jazzer_lib",

--- a/driver/src/main/java/com/code_intelligence/jazzer/junit/AgentConfigurator.java
+++ b/driver/src/main/java/com/code_intelligence/jazzer/junit/AgentConfigurator.java
@@ -14,8 +14,6 @@
 
 package com.code_intelligence.jazzer.junit;
 
-import static com.code_intelligence.jazzer.sanitizers.Constants.SANITIZER_HOOK_NAMES;
-
 import java.io.File;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -56,7 +54,6 @@ class AgentConfigurator {
   }
 
   private static void applyCommonConfiguration() {
-    System.setProperty("jazzer.custom_hooks", SANITIZER_HOOK_NAMES);
     // Do not hook common IDE and JUnit classes and their dependencies.
     System.setProperty("jazzer.custom_hook_excludes",
         String.join(File.pathSeparator, "com.google.testing.junit.**", "com.intellij.**",

--- a/driver/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/driver/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -16,7 +16,6 @@ java_library(
     ],
     deps = [
         ":utils",
-        "//sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers:constants",
         "@maven//:org_junit_jupiter_junit_jupiter_api",
         "@maven//:org_junit_platform_junit_platform_engine",
     ],

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BUILD.bazel
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BUILD.bazel
@@ -46,7 +46,7 @@ kt_jvm_library(
 java_library(
     name = "constants",
     srcs = [":constants_java"],
-    visibility = ["//visibility:public"],
+    visibility = ["//agent/src/main/java/com/code_intelligence/jazzer/agent:__pkg__"],
 )
 
 write_file(
@@ -54,9 +54,10 @@ write_file(
     out = "Constants.java",
     content = [
         "package com.code_intelligence.jazzer.sanitizers;",
-        "import java.io.File;",
+        "import java.util.Arrays;",
+        "import java.util.List;",
         "public final class Constants {",
-        "  public static final String SANITIZER_HOOK_NAMES = \"%s\";" % "\" + File.pathSeparator + \"".join(SANITIZER_CLASSES),
+        "  public static final List<String> SANITIZER_HOOK_NAMES = Arrays.asList(%s);" % ", ".join(["\"%s\"" % name for name in SANITIZER_CLASSES]),
         "}",
     ],
 )


### PR DESCRIPTION
I forgot to add the deploy manifest line to `jazzer_standalone_deploy.jar`. Since this is error-prone, use code generation to load the list of built-in hooks instead in a single location.

Also add a check to verify that built-in hooks are loaded. This would have let existing tests catch this regression.