### PR TITLE
driver: Make `jazzer_standalone.jar` executable without the launcher

### DIFF
--- a/driver/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
+++ b/driver/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
@@ -7,6 +7,7 @@ load("//sanitizers:sanitizers.bzl", "SANITIZER_CLASSES")
 
 java_binary(
     name = "jazzer_standalone",
+    main_class = "com.code_intelligence.jazzer.Jazzer",
     visibility = [
         "//:__pkg__",
         "//launcher:__pkg__",


### PR DESCRIPTION
Fixes #536 