### PR TITLE
deploy: Host linked javadocs for all Maven artifacts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,3 +77,17 @@ Requires an accounts on [Sonatype](https://issues.sonatype.org) with access to t
 7. Log into https://oss.sonatype.org, select both staging repositories and "Close" them.
    Wait and refresh, then select them again and "Release" them.
 8. Locally, with Docker credentials available, run `docker/push_all.sh` to build and push the `cifuzz/jazzer` and `cifuzz/jazzer-autofuzz` Docker images.
+
+### Updating the hosted javadocs
+
+Javadocs are hosted at https://codeintelligencetesting.github.io/jazzer-docs, which is populated from https://github.com/CodeIntelligenceTesting/jazzer-docs.
+
+To update the docs after a release with API changes, follow these steps to get properly linked cross-references:
+
+1. Delete the contents of all subdirectories of `jazzer-docs`.
+2. Run `bazel build --//deploy:linked_javadoc //deploy:jazzer-api-docs` and unpack the jar into the `jazzer-api` subdirectory of `jazzer-docs`.
+3. Commit and push the changes, then wait for them to be published (can take a minute).
+4. Run `bazel build --//deploy:linked_javadoc //deploy:jazzer-docs` and unpack the jar into the `jazzer` subdirectory of `jazzer-docs`.
+5. Commit and push the changes, then wait for them to be published (can take a minute).
+6. Run `bazel build --//deploy:linked_javadoc //deploy:jazzer-junit-docs` and unpack the jar into the `jazzer-junit` subdirectory of `jazzer-docs`.
+7. Commit and push the changes, then wait for them to be published (can take a minute).

--- a/deploy/BUILD.bazel
+++ b/deploy/BUILD.bazel
@@ -1,6 +1,20 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("@rules_jvm_external//:defs.bzl", "java_export")
 load("//:maven.bzl", "JAZZER_API_COORDINATES", "JAZZER_COORDINATES", "JAZZER_JUNIT_COORDINATES")
 load("//bazel:compat.bzl", "SKIP_ON_WINDOWS")
+
+bool_flag(
+    name = "linked_javadoc",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "emit_linked_javadoc",
+    flag_values = {
+        ":linked_javadoc": "True",
+    },
+    visibility = ["//:__subpackages__"],
+)
 
 sh_binary(
     name = "deploy",
@@ -10,6 +24,10 @@ sh_binary(
 
 java_export(
     name = "jazzer-api",
+    javadocopts = [
+        "-link",
+        "https://docs.oracle.com/en/java/javase/17/docs/api/",
+    ],
     maven_coordinates = JAZZER_API_COORDINATES,
     pom_template = "//deploy:jazzer-api.pom",
     visibility = ["//visibility:public"],
@@ -44,6 +62,18 @@ java_export(
     # Exclude the unshaded classes comprising com.code-intelligence:jazzer since the java_library
     # target comprising jazzer-junit depend on the individual libraries, not the shaded jar.
     deploy_env = ["//driver/src/main/java/com/code_intelligence/jazzer:jazzer_lib"],
+    javadocopts = [
+        "-link",
+        "https://docs.oracle.com/en/java/javase/17/docs/api/",
+    ] + select({
+        ":emit_linked_javadoc": [
+            "-link",
+            "https://codeintelligencetesting.github.io/jazzer-docs/jazzer-api/",
+            "-link",
+            "https://codeintelligencetesting.github.io/jazzer-docs/jazzer/",
+        ],
+        "//conditions:default": [],
+    }),
     maven_coordinates = JAZZER_JUNIT_COORDINATES,
     pom_template = "jazzer-junit.pom",
     visibility = ["//visibility:public"],

--- a/driver/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
+++ b/driver/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
@@ -69,6 +69,16 @@ java_binary(
 # considered a public interface.
 javadoc(
     name = "jazzer-docs",
+    javadocopts = [
+        "-link",
+        "https://docs.oracle.com/en/java/javase/17/docs/api/",
+    ] + select({
+        "//deploy:emit_linked_javadoc": [
+            "-link",
+            "https://codeintelligencetesting.github.io/jazzer-docs/jazzer-api/",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = ["//deploy:__pkg__"],
     deps = [":jazzer_lib"],
 )


### PR DESCRIPTION
Getting clickable cross-references in Javadocs requires publishing the docs in order, which is documented in the new `CONTRIBUTING.md` guide.