### PR TITLE
docker: Update to OpenJDK 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you want to learn more about Jazzer and OSS-Fuzz, [watch the FuzzCon 2020 tal
 
 ### Using Docker
 
-The "distroless" Docker image [cifuzz/jazzer](https://hub.docker.com/r/cifuzz/jazzer) includes Jazzer together with OpenJDK 11. Just mount a directory containing your compiled fuzz target into the container under `/fuzzing` by running:
+The "distroless" Docker image [cifuzz/jazzer](https://hub.docker.com/r/cifuzz/jazzer) includes Jazzer together with OpenJDK 17. Just mount a directory containing your compiled fuzz target into the container under `/fuzzing` by running:
 
 ```sh
 docker run -v path/containing/the/application:/fuzzing cifuzz/jazzer <arguments>

--- a/docker/jazzer-autofuzz/Dockerfile
+++ b/docker/jazzer-autofuzz/Dockerfile
@@ -17,7 +17,7 @@ FROM cifuzz/jazzer as jazzer
 FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y curl openjdk-11-jdk-headless
+RUN apt-get update && apt-get install -y curl openjdk-17-jdk-headless
 
 WORKDIR /app
 RUN curl -L 'https://github.com/coursier/coursier/releases/download/v2.0.16/coursier.jar' -o coursier.jar && \

--- a/docker/jazzer/Dockerfile
+++ b/docker/jazzer/Dockerfile
@@ -15,10 +15,10 @@
 FROM ubuntu:20.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y curl git python3 python-is-python3 openjdk-11-jdk-headless
+RUN apt-get update && apt-get install -y curl git python3 openjdk-17-jdk-headless
 
 WORKDIR /root
-RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64 -o /usr/bin/bazelisk && \
+RUN curl -L https://github.com/bazelbuild/bazelisk/releases/download/v1.15.0/bazelisk-linux-amd64 -o /usr/bin/bazelisk && \
     chmod +x /usr/bin/bazelisk && \
     git clone --depth=1 https://github.com/CodeIntelligenceTesting/jazzer.git && \
     cd jazzer && \


### PR DESCRIPTION
Also updates Bazelisk and removes `python-is-python3`, which is no longer needed with Bazel 6.

Fixes #558 