### PR TITLE
junit: Sort inputs by path

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/junit/FuzzTestArgumentsProvider.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/FuzzTestArgumentsProvider.java
@@ -173,6 +173,10 @@ class FuzzTestArgumentsProvider implements ArgumentsProvider, AnnotationConsumer
             (fileOrDir, basicFileAttributes)
                 -> !basicFileAttributes.isDirectory(),
             FileVisitOption.FOLLOW_LINKS)
+        // JUnit identifies individual runs of a `@ParameterizedTest` via their invocation number.
+        // In order to get reproducible behavior e.g. when trying to debug a particular input, all
+        // inputs thus have to be provided in deterministic order.
+        .sorted()
         .map(file -> new SimpleEntry<>(file.getFileName().toString(), readAllBytesUnchecked(file)));
   }
 


### PR DESCRIPTION
JUnit identifies individual runs of a `@ParameterizedTest` via their invocation number. In order to get reproducible behavior e.g. when trying to debug a particular input, all inputs thus have to be provided in deterministic order.

This is achieved by sorting all inputs by path in their respective groups: The empty input always comes first, then the inputs directory contents in path order, then (only with coverage) the generated corpus in path order.