### PR TITLE
Check arguments size in all hooks without a method descriptor

### DIFF
--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/ExpressionLanguageInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/ExpressionLanguageInjection.kt
@@ -62,6 +62,8 @@ object ExpressionLanguageInjection {
         arguments: Array<Any>,
         hookId: Int,
     ) {
+        // The overloads taking a second string argument have either three or four arguments
+        if (arguments.size < 3) { return }
         val expression = arguments[1] as? String ?: return
         Jazzer.guideTowardsContainment(expression, EXPRESSION_LANGUAGE_ATTACK, hookId)
     }
@@ -85,6 +87,7 @@ object ExpressionLanguageInjection {
         arguments: Array<Any>,
         hookId: Int,
     ) {
+        if (arguments.size != 1) { return }
         val message = arguments[0] as String
         Jazzer.guideTowardsContainment(message, EXPRESSION_LANGUAGE_ATTACK, hookId)
     }

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/OsCommandInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/OsCommandInjection.kt
@@ -43,6 +43,7 @@ object OsCommandInjection {
     )
     @JvmStatic
     fun processImplStartHook(method: MethodHandle?, alwaysNull: Any?, args: Array<Any?>, hookId: Int) {
+        if (args.isEmpty()) { return }
         // Calling ProcessBuilder already checks if command array is empty
         @Suppress("UNCHECKED_CAST")
         (args[0] as? Array<String>)?.first().let { cmd ->

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/ReflectiveCall.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/ReflectiveCall.kt
@@ -61,6 +61,7 @@ object ReflectiveCall {
     )
     @JvmStatic
     fun loadLibraryHook(method: MethodHandle?, alwaysNull: Any?, args: Array<Any?>, hookId: Int) {
+        if (args.isEmpty()) { return }
         val libraryName = args[0] as? String ?: return
         if (libraryName == HONEYPOT_LIBRARY_NAME) {
             Jazzer.reportFindingFromHook(


### PR DESCRIPTION
For all hooks where we don't specify a method descriptor, we now check the size of the parameters before accessing them.