### PR TITLE
junit: Disable hooks in non-fuzz tests during regression testing 

### DIFF
--- a/examples/junit/src/test/java/com/example/HermeticInstrumentationFuzzTest.java
+++ b/examples/junit/src/test/java/com/example/HermeticInstrumentationFuzzTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+class HermeticInstrumentationFuzzTest {
+  class VulnerableFuzzClass {
+    public void vulnerableMethod(String input) {
+      Pattern.compile(input);
+    }
+  }
+
+  class VulnerableUnitClass {
+    public void vulnerableMethod(String input) {
+      Pattern.compile(input);
+    }
+  }
+
+  @FuzzTest
+  @Execution(ExecutionMode.CONCURRENT)
+  void fuzzTest1(byte[] data) {
+    new VulnerableFuzzClass().vulnerableMethod("[");
+  }
+
+  @Test
+  @Execution(ExecutionMode.CONCURRENT)
+  void unitTest1() {
+    new VulnerableUnitClass().vulnerableMethod("[");
+  }
+
+  @FuzzTest
+  @Execution(ExecutionMode.CONCURRENT)
+  void fuzzTest2(byte[] data) {
+    Pattern.compile("[");
+  }
+
+  @Test
+  @Execution(ExecutionMode.CONCURRENT)
+  void unitTest2() {
+    Pattern.compile("[");
+  }
+}

--- a/src/jmh/java/com/code_intelligence/jazzer/instrumentor/CoverageInstrumentationBenchmark.java
+++ b/src/jmh/java/com/code_intelligence/jazzer/instrumentor/CoverageInstrumentationBenchmark.java
@@ -159,7 +159,7 @@ class InstrumentingClassLoader extends ClassLoader {
         throw new ClassNotFoundException(String.format("Failed to find class file for %s", name));
       }
       byte[] bytecode = readAllBytes(stream);
-      byte[] instrumentedBytecode = instrumentor.instrument(bytecode);
+      byte[] instrumentedBytecode = instrumentor.instrument(name.replace('.', '/'), bytecode);
       return defineClass(name, instrumentedBytecode, 0, instrumentedBytecode.length);
     } catch (IOException e) {
       throw new ClassNotFoundException(String.format("Failed to read class file for %s", name), e);

--- a/src/jmh/java/com/code_intelligence/jazzer/instrumentor/EdgeCoverageInstrumentation.java
+++ b/src/jmh/java/com/code_intelligence/jazzer/instrumentor/EdgeCoverageInstrumentation.java
@@ -56,7 +56,7 @@ public class EdgeCoverageInstrumentation {
 
   private byte[] applyInstrumentation(byte[] bytecode) {
     return new EdgeCoverageInstrumentor(new StaticMethodStrategy(), CoverageMap.class, 0)
-        .instrument(bytecode);
+        .instrument(EdgeCoverageTarget.class.getName().replace('.', '/'), bytecode);
   }
 
   @Benchmark

--- a/src/main/java/com/code_intelligence/jazzer/agent/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/agent/BUILD.bazel
@@ -26,5 +26,6 @@ kt_jvm_library(
         "//src/main/java/com/code_intelligence/jazzer/instrumentor",
         "//src/main/java/com/code_intelligence/jazzer/utils:class_name_globber",
         "//src/main/java/com/code_intelligence/jazzer/utils:manifest_utils",
+        "@com_github_classgraph_classgraph//:classgraph",
     ],
 )

--- a/src/main/java/com/code_intelligence/jazzer/driver/Opt.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/Opt.java
@@ -129,6 +129,11 @@ public final class Opt {
   public static final boolean dedup =
       boolSetting("dedup", hooks, "Compute and print a deduplication token for every finding");
 
+  // Whether hook instrumentation should add a check for JazzerInternal#hooksEnabled before
+  // executing hooks. Used to disable hooks during non-fuzz JUnit tests.
+  public static final boolean conditionalHooks =
+      boolSetting("internal.conditional_hooks", false, null);
+
   static final boolean mergeInner = boolSetting("internal.merge_inner", false, null);
 
   private static final boolean help =

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/EdgeCoverageInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/EdgeCoverageInstrumentor.kt
@@ -101,7 +101,7 @@ class EdgeCoverageInstrumentor(
             ),
         )
 
-    override fun instrument(bytecode: ByteArray): ByteArray {
+    override fun instrument(internalClassName: String, bytecode: ByteArray): ByteArray {
         val reader = InstrSupport.classReaderFor(bytecode)
         val writer = ClassWriter(reader, 0)
         val version = InstrSupport.getMajorVersion(reader)

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/HookMethodVisitor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/HookMethodVisitor.kt
@@ -287,6 +287,7 @@ private class HookMethodVisitor(
                         mv.visitMethodInsn(opcode, owner, methodName, methodDescriptor, isInterface)
                     }
                 }
+
                 HookType.REPLACE -> {
                     // Call the hook method
                     mv.visitMethodInsn(
@@ -314,6 +315,7 @@ private class HookMethodVisitor(
                         }
                     }
                 }
+
                 HookType.AFTER -> {
                     // Call the original method before the first AFTER hook
                     if (index == 0 || matchingHooks[index - 1].hookType != HookType.AFTER) {

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/Instrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/Instrumentor.kt
@@ -27,7 +27,7 @@ enum class InstrumentationType {
 }
 
 internal interface Instrumentor {
-    fun instrument(bytecode: ByteArray): ByteArray
+    fun instrument(internalClassName: String, bytecode: ByteArray): ByteArray
 
     fun shouldInstrument(access: Int): Boolean {
         return (access and Opcodes.ACC_ABSTRACT == 0) &&

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
@@ -35,7 +35,7 @@ internal class TraceDataFlowInstrumentor(
 
     private lateinit var random: DeterministicRandom
 
-    override fun instrument(bytecode: ByteArray): ByteArray {
+    override fun instrument(internalClassName: String, bytecode: ByteArray): ByteArray {
         val node = ClassNode()
         val reader = ClassReader(bytecode)
         reader.accept(node, 0)

--- a/src/main/java/com/code_intelligence/jazzer/junit/AgentConfigurator.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/AgentConfigurator.java
@@ -28,6 +28,8 @@ class AgentConfigurator {
 
     applyCommonConfiguration();
 
+    // Add logic to the hook instrumentation that allows us to enable and disable hooks at runtime.
+    System.setProperty("jazzer.internal.conditional_hooks", "true");
     // Apply all hooks, but no coverage or compare instrumentation.
     System.setProperty("jazzer.instrumentation_excludes", "**");
     extensionContext.getConfigurationParameter("jazzer.instrument")

--- a/src/main/java/com/code_intelligence/jazzer/junit/FuzzTest.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/FuzzTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.ResourceAccessMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
+import org.junit.jupiter.api.parallel.Resources;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
@@ -90,10 +91,11 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 // {0} is expanded to the basename of the seed by the ArgumentProvider.
 @ParameterizedTest(name = "{0}")
 @Tag("jazzer")
-// JazzerInternal keeps global state about the last finding. Compared to the cost of starting up the
-// agent, running individual regression test cases should be very fast, so we wouldn't gain much
-// from parallelization.
-@ResourceLock(value = "jazzer", mode = ResourceAccessMode.READ_WRITE)
+// Fuzz tests can't run in parallel with other fuzz tests since the last finding is kept in a global
+// variable.
+// Fuzz tests also can't run in parallel with other non-fuzz tests since method hooks are enabled
+// conditionally based on a global variable.
+@ResourceLock(value = Resources.GLOBAL, mode = ResourceAccessMode.READ_WRITE)
 public @interface FuzzTest {
   /**
    * A duration string such as "1h 2m 30s" indicating for how long the fuzz test should be executed

--- a/src/main/java/com/code_intelligence/jazzer/runtime/JazzerInternal.java
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/JazzerInternal.java
@@ -18,6 +18,15 @@ import java.util.ArrayList;
 
 final public class JazzerInternal {
   public static Throwable lastFinding;
+  // The value is only relevant when regression testing. Read by the bytecode emitted by
+  // HookMethodVisitor to enable hooks only when invoked from a @FuzzTest.
+  //
+  // Alternatives considered:
+  // Making this thread local rather than global may potentially allow to run fuzz tests in
+  // parallel with regular unit tests, but it is next to impossible to determine which thread is
+  // currently doing work for a fuzz test versus a regular unit test. Instead, @FuzzTest is
+  // annotated with @Isolated.
+  @SuppressWarnings("unused") public static boolean hooksEnabled = true;
 
   private static final ArrayList<Runnable> onFuzzTargetReadyCallbacks = new ArrayList<>();
 

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentationTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentationTest.kt
@@ -19,24 +19,20 @@ import com.code_intelligence.jazzer.instrumentor.PatchTestUtils.classToBytecode
 import org.junit.Test
 import java.io.File
 
-private fun applyInstrumentation(bytecode: ByteArray): ByteArray {
-    return TraceDataFlowInstrumentor(
-        setOf(
-            InstrumentationType.CMP,
-            InstrumentationType.DIV,
-            InstrumentationType.GEP,
-        ),
-        MockTraceDataFlowCallbacks::class.java.name.replace('.', '/'),
-    ).instrument(bytecode)
-}
-
 private fun getOriginalInstrumentationTargetInstance(): DynamicTestContract {
     return TraceDataFlowInstrumentationTarget()
 }
 
 private fun getInstrumentedInstrumentationTargetInstance(): DynamicTestContract {
     val originalBytecode = classToBytecode(TraceDataFlowInstrumentationTarget::class.java)
-    val patchedBytecode = applyInstrumentation(originalBytecode)
+    val patchedBytecode = TraceDataFlowInstrumentor(
+        setOf(
+            InstrumentationType.CMP,
+            InstrumentationType.DIV,
+            InstrumentationType.GEP,
+        ),
+        MockTraceDataFlowCallbacks::class.java.name.replace('.', '/'),
+    ).instrument(TraceDataFlowInstrumentationTarget::class.java.name.replace('.', '/'), originalBytecode)
     // Make the patched class available in bazel-testlogs/.../test.outputs for manual inspection.
     val outDir = System.getenv("TEST_UNDECLARED_OUTPUTS_DIR")
     File("$outDir/${TraceDataFlowInstrumentationTarget::class.simpleName}.class").writeBytes(originalBytecode)

--- a/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -17,6 +17,8 @@ java_test(
     ],
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/api:hooks",
+        "@maven//:com_google_truth_extensions_truth_java8_extension",
+        "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
         "@maven//:org_junit_jupiter_junit_jupiter_api",
         "@maven//:org_junit_platform_junit_platform_engine",
@@ -202,3 +204,20 @@ java_test(
         "_fuzzing",
     ]
 ]
+
+java_test(
+    name = "HermeticInstrumentationTest",
+    srcs = ["HermeticInstrumentationTest.java"],
+    test_class = "com.code_intelligence.jazzer.junit.HermeticInstrumentationTest",
+    runtime_deps = [
+        "//examples/junit/src/test/java/com/example:ExampleFuzzTests_deploy.jar",
+        "@maven//:org_junit_jupiter_junit_jupiter_engine",
+    ],
+    deps = [
+        "//src/main/java/com/code_intelligence/jazzer/api:hooks",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "@maven//:org_junit_platform_junit_platform_engine",
+        "@maven//:org_junit_platform_junit_platform_testkit",
+    ],
+)

--- a/src/test/java/com/code_intelligence/jazzer/junit/HermeticInstrumentationTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/junit/HermeticInstrumentationTest.java
@@ -1,0 +1,108 @@
+// Copyright 2022 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.junit;
+
+import static org.junit.Assume.assumeTrue;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.container;
+import static org.junit.platform.testkit.engine.EventConditions.displayName;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
+import static org.junit.platform.testkit.engine.EventConditions.finishedWithFailure;
+import static org.junit.platform.testkit.engine.EventConditions.test;
+import static org.junit.platform.testkit.engine.EventConditions.type;
+import static org.junit.platform.testkit.engine.EventConditions.uniqueIdSubstrings;
+import static org.junit.platform.testkit.engine.EventType.DYNAMIC_TEST_REGISTERED;
+import static org.junit.platform.testkit.engine.EventType.FINISHED;
+import static org.junit.platform.testkit.engine.EventType.REPORTING_ENTRY_PUBLISHED;
+import static org.junit.platform.testkit.engine.EventType.STARTED;
+import static org.junit.platform.testkit.engine.TestExecutionResultConditions.instanceOf;
+
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueLow;
+import java.nio.file.Path;
+import java.util.regex.PatternSyntaxException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.rules.TemporaryFolder;
+
+public class HermeticInstrumentationTest {
+  private static final String ENGINE = "engine:junit-jupiter";
+  private static final String CLAZZ = "class:com.example.HermeticInstrumentationFuzzTest";
+  private static final String FUZZ_TEST_1 = "test-template:fuzzTest1([B)";
+  private static final String FUZZ_TEST_2 = "test-template:fuzzTest2([B)";
+  private static final String UNIT_TEST_1 = "method:unitTest1()";
+  private static final String UNIT_TEST_2 = "method:unitTest2()";
+  private static final String INVOCATION = "test-template-invocation:#1";
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  Path baseDir;
+
+  @Before
+  public void setup() {
+    baseDir = temp.getRoot().toPath();
+  }
+
+  private EngineExecutionResults executeTests() {
+    return EngineTestKit.engine("junit-jupiter")
+        .selectors(selectClass("com.example.HermeticInstrumentationFuzzTest"))
+        .configurationParameter(
+            "jazzer.instrument", "com.other.package.**,com.example.**,com.yet.another.package.*")
+        .configurationParameter("jazzer.internal.basedir", baseDir.toAbsolutePath().toString())
+        .configurationParameter("junit.jupiter.execution.parallel.enabled", "true")
+        .execute();
+  }
+
+  @Test
+  public void fuzzingDisabled() {
+    assumeTrue(System.getenv("JAZZER_FUZZ") == null);
+
+    EngineExecutionResults results = executeTests();
+
+    results.containerEvents().assertEventsMatchLoosely(event(type(STARTED), container(ENGINE)),
+        event(type(STARTED), container(uniqueIdSubstrings(ENGINE, CLAZZ))),
+        event(type(STARTED), container(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_1))),
+        event(type(REPORTING_ENTRY_PUBLISHED),
+            container(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_1))),
+        event(type(FINISHED), container(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_1))),
+        event(type(STARTED), container(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_2))),
+        event(type(REPORTING_ENTRY_PUBLISHED),
+            container(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_2))),
+        event(type(FINISHED), container(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_2))),
+        event(type(FINISHED), container(uniqueIdSubstrings(ENGINE, CLAZZ)), finishedSuccessfully()),
+        event(type(FINISHED), container(ENGINE), finishedSuccessfully()));
+
+    results.testEvents().assertEventsMatchLoosely(
+        event(type(DYNAMIC_TEST_REGISTERED), test(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_1))),
+        event(type(STARTED), test(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_1, INVOCATION)),
+            displayName("<empty input>")),
+        event(type(FINISHED), test(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_1, INVOCATION)),
+            displayName("<empty input>"),
+            finishedWithFailure(instanceOf(FuzzerSecurityIssueLow.class))),
+        event(type(STARTED), test(uniqueIdSubstrings(ENGINE, CLAZZ, UNIT_TEST_1))),
+        event(type(FINISHED), test(uniqueIdSubstrings(ENGINE, CLAZZ, UNIT_TEST_1)),
+            finishedWithFailure(instanceOf(PatternSyntaxException.class))),
+        event(type(DYNAMIC_TEST_REGISTERED), test(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_2))),
+        event(type(STARTED), test(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_2, INVOCATION)),
+            displayName("<empty input>")),
+        event(type(FINISHED), test(uniqueIdSubstrings(ENGINE, CLAZZ, FUZZ_TEST_2, INVOCATION)),
+            displayName("<empty input>"),
+            finishedWithFailure(instanceOf(FuzzerSecurityIssueLow.class))),
+        event(type(STARTED), test(uniqueIdSubstrings(ENGINE, CLAZZ, UNIT_TEST_2))),
+        event(type(FINISHED), test(uniqueIdSubstrings(ENGINE, CLAZZ, UNIT_TEST_2)),
+            finishedWithFailure(instanceOf(PatternSyntaxException.class))));
+  }
+}


### PR DESCRIPTION
This makes it possible to run fuzz tests alongside unit tests without having the instrumentation applied by the agent interfere with unit tests, e.g. by throwing unexpected exceptions.