### PR TITLE
junit: Fix working directory path construction on Windows

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/junit/FuzzTestExecutor.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/FuzzTestExecutor.java
@@ -52,7 +52,8 @@ class FuzzTestExecutor {
     }
 
     Path baseDir =
-        Paths.get(context.getConfigurationParameter("jazzer.internal.basedir").orElse(""));
+        Paths.get(context.getConfigurationParameter("jazzer.internal.basedir").orElse(""))
+            .toAbsolutePath();
 
     final Method fuzzTestMethod = context.getRequiredTestMethod();
     final Class<?> fuzzTestClass = context.getRequiredTestClass();


### PR DESCRIPTION
On Windows, `Paths.get("")` does not behave like the current working directory when used to resolve other paths relative to it. Instead, convert it to an absolute path.

Fixes #546