### PR TITLE
ci: Do not pin Xcode version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
           echo "build --config=maven" >> .bazelrc
           echo "build:linux --config=toolchain" >> .bazelrc
           echo "build:linux --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux" >> .bazelrc
-          echo "build:macos  --xcode_version_config=//.github:host_xcodes" >> .bazelrc
 
       - name: Build
         shell: bash


### PR DESCRIPTION
We pin the Xcode version in our build & test workflow as detecting host Xcodes is slow and frequently led to timeouts on the slow macOS runners. Since our release workflow uses an older version of macOS, it may not have the pinned Xcode available.