### PR TITLE
autofuzz: Fix handling of generic array types 

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
+++ b/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
@@ -202,7 +202,7 @@ public class Meta {
         Arrays.stream(arguments).map(Meta::deepToString).collect(Collectors.joining(", ")));
   }
 
-  private static Class<?> getRawType(Type genericType) {
+  static Class<?> getRawType(Type genericType) {
     if (genericType instanceof Class<?>) {
       return (Class<?>) genericType;
     } else if (genericType instanceof ParameterizedType) {
@@ -213,8 +213,9 @@ public class Meta {
     } else if (genericType instanceof TypeVariable<?>) {
       throw new AutofuzzError("Did not expect genericType to be a TypeVariable: " + genericType);
     } else if (genericType instanceof GenericArrayType) {
-      // TODO: Improve this;
-      return Object[].class;
+      return Array
+          .newInstance(getRawType(((GenericArrayType) genericType).getGenericComponentType()), 0)
+          .getClass();
     } else {
       throw new AutofuzzError("Got unexpected class implementing Type: " + genericType);
     }

--- a/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
+++ b/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
@@ -183,14 +183,23 @@ public class Meta {
     return bytesToSpend / Math.max(sizeOfElement, 1);
   }
 
+  private static String deepToString(Object obj) {
+    if (obj == null) {
+      return "null";
+    }
+    if (obj.getClass().isArray()) {
+      return String.format("(%s[]) %s", obj.getClass().getComponentType().getName(),
+          Arrays.deepToString((Object[]) obj));
+    }
+    return obj.toString();
+  }
+
   private static String getDebugSummary(
       Executable executable, Object thisObject, Object[] arguments) {
     return String.format("%nMethod: %s::%s%s%nthis: %s%nArguments: %s",
         executable.getDeclaringClass().getName(), executable.getName(),
         Utils.getReadableDescriptor(executable), thisObject,
-        Arrays.stream(arguments)
-            .map(arg -> arg == null ? "null" : arg.toString())
-            .collect(Collectors.joining(", ")));
+        Arrays.stream(arguments).map(Meta::deepToString).collect(Collectors.joining(", ")));
   }
 
   private static Class<?> getRawType(Type genericType) {

--- a/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
+++ b/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
@@ -328,43 +328,51 @@ public class Meta {
     Class<?> type = getRawType(genericType);
     if (type == byte.class || type == Byte.class) {
       byte result = data.consumeByte();
-      if (visitor != null)
+      if (visitor != null) {
         visitor.pushElement(String.format("(byte) %s", result));
+      }
       return result;
     } else if (type == short.class || type == Short.class) {
       short result = data.consumeShort();
-      if (visitor != null)
+      if (visitor != null) {
         visitor.pushElement(String.format("(short) %s", result));
+      }
       return result;
     } else if (type == int.class || type == Integer.class) {
       int result = data.consumeInt();
-      if (visitor != null)
+      if (visitor != null) {
         visitor.pushElement(Integer.toString(result));
+      }
       return result;
     } else if (type == long.class || type == Long.class) {
       long result = data.consumeLong();
-      if (visitor != null)
+      if (visitor != null) {
         visitor.pushElement(String.format("%sL", result));
+      }
       return result;
     } else if (type == float.class || type == Float.class) {
       float result = data.consumeFloat();
-      if (visitor != null)
+      if (visitor != null) {
         visitor.pushElement(String.format("%sF", result));
+      }
       return result;
     } else if (type == double.class || type == Double.class) {
       double result = data.consumeDouble();
-      if (visitor != null)
+      if (visitor != null) {
         visitor.pushElement(Double.toString(result));
+      }
       return result;
     } else if (type == boolean.class || type == Boolean.class) {
       boolean result = data.consumeBoolean();
-      if (visitor != null)
+      if (visitor != null) {
         visitor.pushElement(Boolean.toString(result));
+      }
       return result;
     } else if (type == char.class || type == Character.class) {
       char result = data.consumeChar();
-      if (visitor != null)
+      if (visitor != null) {
         visitor.addCharLiteral(result);
+      }
       return result;
     }
     // Sometimes, but rarely return null for non-primitive and non-boxed types.
@@ -383,8 +391,9 @@ public class Meta {
     }
     if (type == String.class || type == CharSequence.class) {
       String result = data.consumeString(consumeArrayLength(data, 1));
-      if (visitor != null)
+      if (visitor != null) {
         visitor.addStringLiteral(result);
+      }
       return result;
     } else if (type.isArray()) {
       if (type == byte[].class) {
@@ -525,8 +534,9 @@ public class Meta {
       }
       return enumValue;
     } else if (type == Class.class) {
-      if (visitor != null)
+      if (visitor != null) {
         visitor.pushElement(String.format("%s.class", YourAverageJavaClass.class.getName()));
+      }
       return YourAverageJavaClass.class;
     } else if (type == Method.class) {
       if (visitor != null) {
@@ -716,7 +726,7 @@ public class Meta {
     Object[] result;
     try {
       result = Arrays.stream(executable.getGenericParameterTypes())
-                   .map((type) -> consume(data, type, visitor))
+                   .map(type -> consume(data, type, visitor))
                    .toArray();
       return result;
     } catch (AutofuzzConstructionException e) {

--- a/src/test/java/com/code_intelligence/jazzer/autofuzz/MetaTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/autofuzz/MetaTest.java
@@ -195,6 +195,18 @@ public class MetaTest {
             (byte) 1, // do not return null
             0 /* first (and only) constructor*/));
   }
+
+  Class<?>[] returnsClassArray() {
+    throw new IllegalStateException(
+        "Should not be called, only exists to construct its generic return type");
+  }
+
+  @Test
+  public void testGetRawType() throws NoSuchMethodException {
+    Type classArrayType =
+        MetaTest.class.getDeclaredMethod("returnsClassArray").getGenericReturnType();
+    assertEquals(Class[].class, Meta.getRawType(classArrayType));
+  }
 }
 
 class OpinionatedClass {


### PR DESCRIPTION
Before this commit, `consume` would construct an `Object[]` when a `Class<?>[]` was requested, leading to `IllegalArgumentExeption`s.

Fixes #582