### PR TITLE
junit: Simplify and improve inputs directory discovery

### DIFF
--- a/examples/junit/src/test/java/com/example/DirectoryInputsFuzzTest.java
+++ b/examples/junit/src/test/java/com/example/DirectoryInputsFuzzTest.java
@@ -28,7 +28,7 @@ public class DirectoryInputsFuzzTest {
       return;
     }
     if (!firstSeed) {
-      return;
+      throw new IllegalStateException("Should have crashed on the first non-empty input");
     }
     firstSeed = false;
     if (data.consumeRemainingAsString().equals("directory")) {

--- a/src/main/java/com/code_intelligence/jazzer/junit/FuzzTestExecutor.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/FuzzTestExecutor.java
@@ -14,6 +14,8 @@
 
 package com.code_intelligence.jazzer.junit;
 
+import static com.code_intelligence.jazzer.junit.Utils.generatedCorpusPath;
+import static com.code_intelligence.jazzer.junit.Utils.inputsDirectoryResourcePath;
 import static com.code_intelligence.jazzer.junit.Utils.inputsDirectorySourcePath;
 import static com.code_intelligence.jazzer.utils.Utils.getReadableDescriptor;
 
@@ -65,53 +67,50 @@ class FuzzTestExecutor {
     // https://github.com/CodeIntelligenceTesting/cifuzz/blob/bf410dcfbafbae2a73cf6c5fbed031cdfe234f2f/internal/cmd/run/run.go#L381
     // The path is specified relative to the current working directory, which with JUnit is the
     // project directory.
-    Path generatedCorpusDir = baseDir.resolve(Utils.generatedCorpusPath(fuzzTestClass));
+    Path generatedCorpusDir = baseDir.resolve(generatedCorpusPath(fuzzTestClass));
     Files.createDirectories(generatedCorpusDir);
     libFuzzerArgs.add(generatedCorpusDir.toAbsolutePath().toString());
 
-    // If the default or configured inputs directory for the fuzz test exists as a regular directory
-    // on disk (i.e., the test is not run from a JAR), use it as a seeds directory for libFuzzer and
-    // also emit findings into it so that the regression test can be used to debug them.
-    String inputsDirectoryResourcePath = Utils.inputsDirectoryResourcePath(fuzzTestClass);
-    URL inputsDirectoryUrl = fuzzTestClass.getResource(inputsDirectoryResourcePath);
-    if (inputsDirectoryUrl == null) {
-      String message = String.format(
-          "Collecting crashing inputs in the project root directory.\nIf you want to keep them organized by "
-              + "fuzz test and automatically run them as regression tests with JUnit Jupiter, create a "
-              + "test resource directory called '%s' in package '%s' and move the files there.",
-          inputsDirectoryResourcePath, fuzzTestClass.getPackage().getName());
-      context.publishReportEntry("missing inputs directory", message);
-      libFuzzerArgs.add(String.format("-artifact_prefix=%s%c", baseDir, File.separatorChar));
-    } else if ("file".equals(inputsDirectoryUrl.getProtocol())) {
-      // From the second positional argument on, files and directories are used as seeds but not
-      // modified. Using inputsDirectoryUrl.getFile() fails on Windows.
-      try {
-        libFuzzerArgs.add(Paths.get(inputsDirectoryUrl.toURI()).toString());
-      } catch (URISyntaxException e) {
-        throw new IOException(e);
-      }
-      // We try to find the source tree representation of the inputs directory and emit findings
-      // into it.
-      inputsDirectorySourcePath(fuzzTestClass, baseDir)
-          .ifPresent((path)
-                         -> libFuzzerArgs.add(
-                             String.format("-artifact_prefix=%s%c", path, File.separatorChar)));
-    } else {
-      // We can't directly use the inputs directory from resources as it's packaged into a JAR.
-      // Instead, try to get its source tree path.
-      Optional<Path> inputsDirectory = inputsDirectorySourcePath(fuzzTestClass, baseDir);
-      if (inputsDirectory.isPresent()) {
-        libFuzzerArgs.add(inputsDirectory.get().toString());
-        // We try to find the source tree representation of the inputs directory and emit findings
-        // into it.
-        libFuzzerArgs.add(
-            String.format("-artifact_prefix=%s%c", inputsDirectory.get(), File.separatorChar));
-      } else {
-        context.publishReportEntry("missing inputs directory",
-            "When running Jazzer fuzz tests from a JAR rather than class files, the inputs directory isn't used "
-                + "unless it is located under src/test/resources/...");
-      }
+    // We can only emit findings into the source tree version of the inputs directory, not e.g. the
+    // copy under Maven's target directory. If it doesn't exist, collect the inputs in the current
+    // working directory, which is usually the project's source root.
+    Optional<Path> findingsDirectory = inputsDirectorySourcePath(fuzzTestClass, baseDir);
+    if (!findingsDirectory.isPresent()) {
+      context.publishReportEntry(String.format(
+          "Collecting crashing inputs in the project root directory.\nIf you want to keep them "
+              + "organized by fuzz test and automatically run them as regression tests with "
+              + "JUnit Jupiter, create a test resource directory called '%s' in package '%s' "
+              + "and move the files there.",
+          inputsDirectoryResourcePath(fuzzTestClass), fuzzTestClass.getPackage().getName()));
     }
+
+    // We prefer the inputs directory on the classpath, if it exists, as that is more reliable than
+    // heuristically looking into the source tree based on the current working directory.
+    Optional<Path> inputsDirectory;
+    URL inputsDirectoryUrl = fuzzTestClass.getResource(inputsDirectoryResourcePath(fuzzTestClass));
+    if (inputsDirectoryUrl != null && "file".equals(inputsDirectoryUrl.getProtocol())) {
+      // The inputs directory is a regular directory on disk (i.e., the test is not run from a
+      // JAR).
+      try {
+        // Using inputsDirectoryUrl.getFile() fails on Windows.
+        inputsDirectory = Optional.of(Paths.get(inputsDirectoryUrl.toURI()));
+      } catch (URISyntaxException e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      if (inputsDirectoryUrl != null && !findingsDirectory.isPresent()) {
+        context.publishReportEntry(
+            "When running Jazzer fuzz tests from a JAR rather than class files, the inputs "
+            + "directory isn't used unless it is located under src/test/resources/...");
+      }
+      inputsDirectory = findingsDirectory;
+    }
+
+    // From the second positional argument on, files and directories are used as seeds but not
+    // modified.
+    inputsDirectory.ifPresent(dir -> libFuzzerArgs.add(dir.toAbsolutePath().toString()));
+    libFuzzerArgs.add(String.format("-artifact_prefix=%s%c",
+        findingsDirectory.orElse(baseDir).toAbsolutePath(), File.separatorChar));
 
     libFuzzerArgs.add("-max_total_time=" + durationStringToSeconds(maxDuration));
     // Disable libFuzzer's out of memory detection: It is only useful for native library fuzzing,

--- a/src/test/java/com/code_intelligence/jazzer/junit/FuzzingWithoutCrashTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/junit/FuzzingWithoutCrashTest.java
@@ -84,7 +84,10 @@ public class FuzzingWithoutCrashTest {
     results.containerEvents().assertEventsMatchExactly(event(type(STARTED), container(ENGINE)),
         event(type(STARTED), container(uniqueIdSubstrings(ENGINE, CLAZZ))),
         event(type(STARTED), container(uniqueIdSubstrings(ENGINE, CLAZZ, NO_CRASH_FUZZ))),
-        // Warning because the seed corpus directory hasn't been found.
+        // Warning because the inputs directory hasn't been found in the source tree.
+        event(type(REPORTING_ENTRY_PUBLISHED),
+            container(uniqueIdSubstrings(ENGINE, CLAZZ, NO_CRASH_FUZZ))),
+        // Warning because the inputs directory has been found on the classpath, but only in a JAR.
         event(type(REPORTING_ENTRY_PUBLISHED),
             container(uniqueIdSubstrings(ENGINE, CLAZZ, NO_CRASH_FUZZ))),
         event(type(FINISHED), container(uniqueIdSubstrings(ENGINE, CLAZZ, NO_CRASH_FUZZ)),


### PR DESCRIPTION
Inputs directory handling was confusing as e.g. Maven doesn't copy over empty resource directories by default. Instead of relying on that, always fall back to locating the inputs directory in the source tree and even try to create it if at least the test resources root is found.