### PR TITLE
autofuzz: Do not report finding for failed autofuzz in consume

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -346,3 +346,21 @@ java_fuzz_target_test(
     target_class = "com.example.TimeoutFuzzer",
     verify_crash_reproducer = False,
 )
+
+java_library(
+    name = "autofuzz_crashing_setter_target",
+    srcs = ["src/test/java/com/example/AutofuzzCrashingSetterTarget.java"],
+)
+
+# Regression test for https://github.com/CodeIntelligenceTesting/jazzer/issues/586.
+java_fuzz_target_test(
+    name = "AutofuzzCrashingSetterFuzzer",
+    fuzzer_args = [
+        "--autofuzz=com.example.AutofuzzCrashingSetterTarget::start",
+        "--autofuzz_ignore=java.lang.NullPointerException",
+        "-runs=100000",
+    ],
+    runtime_deps = [
+        ":autofuzz_crashing_setter_target",
+    ],
+)

--- a/tests/src/test/java/com/example/AutofuzzCrashingSetterTarget.java
+++ b/tests/src/test/java/com/example/AutofuzzCrashingSetterTarget.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+public class AutofuzzCrashingSetterTarget extends Thread {
+  public void start(final byte[] out) {}
+}


### PR DESCRIPTION
When an invocatin of `autofuzz` in `consume` fails, this is not a finding but rather a failure to construct a valid object.