### PR TITLE
Fix Docker build and prevent unnecessary rebuilds

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -10,6 +10,9 @@ build -c opt
 #  https://github.com/bazelbuild/bazel/pull/16973 has been merged.
 build:linux --nozip_undeclared_test_outputs
 build:macos --nozip_undeclared_test_outputs
+# Improve caching for builds involving multiple configurations and work around
+# the Bazel issue fixed by https://github.com/bazelbuild/bazel/pull/17158.
+build --experimental_output_directory_naming_scheme=diff_against_baseline
 
 # C/C++
 # GCC is supported on a best-effort basis.


### PR DESCRIPTION
Due to a Bazel issue (https://github.com/bazelbuild/bazel/pull/17158), the recent introduction of `universal_binary` ended up forking the configuration for dependencies of the Jazzer launcher. As a result, some Java targets were built twice and the Docker images failed to build as the Jazzer standalone jar was no longer a dependency of the launcher in the default configuration.

As a workaround and also because it prevents similar issues on a more fundamental level, switch to the soon to be default improved config hash algorithm.