### PR TITLE
agent: Hook Kotlin's compare method for integral types

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -373,6 +373,28 @@ java_fuzz_target_test(
     runtime_deps = [":ExampleKotlinFuzzTarget"],
 )
 
+kt_jvm_library(
+    name = "ExampleKotlinValueProfileFuzzTarget",
+    srcs = [
+        "src/main/java/com/example/ExampleKotlinValueProfileFuzzer.kt",
+    ],
+    deps = [
+        "//deploy:jazzer-api",
+    ],
+)
+
+java_fuzz_target_test(
+    name = "ExampleKotlinValueProfileFuzzer",
+    allowed_findings = [
+        "com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium",
+    ],
+    fuzzer_args = [
+        "-use_value_profile=1",
+    ],
+    target_class = "com.example.ExampleKotlinValueProfileFuzzer",
+    runtime_deps = [":ExampleKotlinValueProfileFuzzTarget"],
+)
+
 java_fuzz_target_test(
     name = "TurboJpegFuzzer",
     srcs = [

--- a/examples/src/main/java/com/example/ExampleKotlinValueProfileFuzzer.kt
+++ b/examples/src/main/java/com/example/ExampleKotlinValueProfileFuzzer.kt
@@ -1,0 +1,37 @@
+// Copyright 2023 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium
+
+object ExampleKotlinValueProfileFuzzer {
+
+    @JvmStatic
+    fun fuzzerTestOneInput(data: FuzzedDataProvider) {
+        if (data.consumeInt().compareTo(0x11223344) != 0) {
+            return
+        }
+        if (encrypt(data.consumeLong()).compareTo(5788627691251634856) == 0 &&
+            encrypt(data.consumeLong()).compareTo(6293579535917519017) == 0
+        ) {
+            throw FuzzerSecurityIssueMedium("Jazzer can handle integral comparisons in Kotlin")
+        }
+    }
+
+    private fun encrypt(n: Long): Long {
+        return n.xor(0x1122334455667788)
+    }
+}

--- a/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
@@ -33,8 +33,10 @@ final public class TraceCmpHooks {
       targetMethod = "compare", targetMethodDescriptor = "(II)I")
   @MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.Integer",
       targetMethod = "compareUnsigned", targetMethodDescriptor = "(II)I")
+  @MethodHook(type = HookType.BEFORE, targetClassName = "kotlin.jvm.internal.Intrinsics ",
+      targetMethod = "compare", targetMethodDescriptor = "(II)I")
   public static void
-  integerCompare(MethodHandle method, Object thisObject, Object[] arguments, int hookId) {
+  integerCompare(MethodHandle method, Object alwaysNull, Object[] arguments, int hookId) {
     TraceDataFlowNativeCallbacks.traceCmpInt((int) arguments[0], (int) arguments[1], hookId);
   }
 
@@ -63,6 +65,13 @@ final public class TraceCmpHooks {
   public static void
   longCompareTo(MethodHandle method, Long thisObject, Object[] arguments, int hookId) {
     TraceDataFlowNativeCallbacks.traceCmpLong(thisObject, (long) arguments[0], hookId);
+  }
+
+  @MethodHook(type = HookType.BEFORE, targetClassName = "kotlin.jvm.internal.Intrinsics ",
+      targetMethod = "compare", targetMethodDescriptor = "(JJ)I")
+  public static void
+  longCompareKt(MethodHandle method, Object alwaysNull, Object[] arguments, int hookId) {
+    TraceDataFlowNativeCallbacks.traceCmpLong((long) arguments[0], (long) arguments[1], hookId);
   }
 
   @MethodHook(type = HookType.AFTER, targetClassName = "java.lang.String", targetMethod = "equals")


### PR DESCRIPTION
Kotlin's integral types have `compareTo` methods that are compiled to calls into one of two `compare` overloads from the `kotlin.jvm.internal.Intrinsics` class:
1. `public static int compare(long thisVal, long anotherVal)`
2. `public static int compare(int thisVal, int anotherVal)`