### PR TITLE
all: Do not end all log messages with a colon

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/utils/Log.java
+++ b/src/main/java/com/code_intelligence/jazzer/utils/Log.java
@@ -87,7 +87,7 @@ public class Log {
     PrintStream err = getErr();
     err.print(prefix);
     if (message != null) {
-      err.print(message + ":\n");
+      err.println(message + (t != null ? ":" : ""));
     }
     if (t != null) {
       t.printStackTrace(err);


### PR DESCRIPTION
When a message is logged without a stack trace, it should not end with a colon.