### PR TITLE
junit: Use JUnit-provided test instance

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/driver/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/driver/BUILD.bazel
@@ -27,6 +27,7 @@ java_library(
     name = "fuzz_target_finder",
     srcs = ["FuzzTargetFinder.java"],
     deps = [
+        ":fuzz_target_instance_holder",
         ":opt",
         "//src/main/java/com/code_intelligence/jazzer/api",
         "//src/main/java/com/code_intelligence/jazzer/utils:manifest_utils",
@@ -34,6 +35,12 @@ java_library(
         "@org_ow2_asm_asm_commons//jar",
         "@org_ow2_asm_asm_tree//jar",
     ],
+)
+
+java_library(
+    name = "fuzz_target_instance_holder",
+    srcs = ["FuzzTargetInstanceHolder.java"],
+    visibility = ["//src/main/java/com/code_intelligence/jazzer/junit:__pkg__"],
 )
 
 java_jni_library(

--- a/src/main/java/com/code_intelligence/jazzer/driver/FuzzTargetInstanceHolder.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/FuzzTargetInstanceHolder.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.driver;
+
+public class FuzzTargetInstanceHolder {
+  /**
+   * The instance of the fuzz target class that is to be executed. This is set by the JUnit
+   * executor. If it isn't set, the parameterless constructor of the fuzz target class is used to
+   * construct an instance.
+   */
+  public static Object fuzzTargetInstance;
+}

--- a/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -55,6 +55,7 @@ java_jni_library(
     deps = [
         ":utils",
         "//src/main/java/com/code_intelligence/jazzer/api",
+        "//src/main/java/com/code_intelligence/jazzer/driver:fuzz_target_instance_holder",
         "//src/main/java/com/code_intelligence/jazzer/driver:fuzz_target_runner",
         "//src/main/java/com/code_intelligence/jazzer/utils",
         "@maven//:org_junit_jupiter_junit_jupiter_api",

--- a/src/main/java/com/code_intelligence/jazzer/junit/FuzzTestExecutor.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/FuzzTestExecutor.java
@@ -20,6 +20,7 @@ import static com.code_intelligence.jazzer.junit.Utils.inputsDirectorySourcePath
 import static com.code_intelligence.jazzer.utils.Utils.getReadableDescriptor;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.driver.FuzzTargetInstanceHolder;
 import com.code_intelligence.jazzer.driver.FuzzTargetRunner;
 import java.io.File;
 import java.io.IOException;
@@ -140,7 +141,8 @@ class FuzzTestExecutor {
     return new FuzzTestExecutor(libFuzzerArgs);
   }
 
-  public Optional<Throwable> execute() {
+  public Optional<Throwable> execute(Object testClassInstance) {
+    FuzzTargetInstanceHolder.fuzzTargetInstance = testClassInstance;
     AtomicReference<Throwable> atomicFinding = new AtomicReference<>();
     FuzzTargetRunner.registerFindingHandler(t -> {
       atomicFinding.set(t);

--- a/src/main/java/com/code_intelligence/jazzer/junit/FuzzTestExtensions.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/FuzzTestExtensions.java
@@ -42,7 +42,7 @@ class FuzzTestExtensions implements ExecutionCondition, InvocationInterceptor {
       invocation.skip();
       Optional<Throwable> throwable = extensionContext.getStore(Namespace.GLOBAL)
                                           .get(FuzzTestExecutor.class, FuzzTestExecutor.class)
-                                          .execute();
+                                          .execute(extensionContext.getRequiredTestInstance());
       if (throwable.isPresent()) {
         throw throwable.get();
       }


### PR DESCRIPTION
This ensures compatibility with non-trivial test class constructors and test instance post processing, which is common with mocking frameworks such as Mockito.