### PR TITLE
driver: Make native sanitizer lib location overridable 

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -131,6 +131,7 @@ The required compilation flags for native libraries are as follows:
 Then, start Jazzer with `--asan` and/or `--ubsan` to automatically preload the sanitizer runtimes.
 Jazzer defaults to using the runtimes associated with `clang` on the `PATH`.
 If you used a different compiler to compile the native libraries, specify it with `CC` to override this default.
+If no compiler is available in your runtime environment (e.g. in OSS-Fuzz) but you have a directory that contains the required sanitier libraries, specify its path in `JAZZER_NATIVE_SANITIZERS_DIR`.
 
 **Note:** On macOS, you may see Gatekeeper warnings when using `--asan` and/or `--ubsan` since these flags cause the native sanitizer libraries to be preloaded into the codesigned `java` executable via `DYLD_INSERT_LIBRARIES`.
 

--- a/src/main/java/com/code_intelligence/jazzer/Jazzer.java
+++ b/src/main/java/com/code_intelligence/jazzer/Jazzer.java
@@ -255,7 +255,7 @@ public class Jazzer {
         .findFirst()
         .orElseGet(() -> {
           Log.error(String.format(
-              "'%s' failed to find one of: %s%n", hostClang(), String.join(", ", candidateNames)));
+              "'%s' failed to find one of: %s", hostClang(), String.join(", ", candidateNames)));
           exit(1);
           throw new IllegalStateException("not reached");
         })
@@ -275,14 +275,14 @@ public class Jazzer {
       Process process = processBuilder.start();
       if (process.waitFor() != 0) {
         Log.error(String.format(
-            "'%s' exited with exit code %d%n", String.join(" ", command), process.exitValue()));
+            "'%s' exited with exit code %d", String.join(" ", command), process.exitValue()));
         copy(process.getInputStream(), System.out);
         copy(process.getErrorStream(), System.err);
         exit(1);
       }
       output = readAllBytes(process.getInputStream());
     } catch (IOException | InterruptedException e) {
-      Log.error(String.format("Failed to run '%s'%n", String.join(" ", command)), e);
+      Log.error(String.format("Failed to run '%s'", String.join(" ", command)), e);
       exit(1);
       throw new IllegalStateException("not reached");
     }


### PR DESCRIPTION
In OSS-Fuzz, `clang` is only available at build time, not when the fuzzer is executed. It thus can't be used to find the native sanitizer libraries.

Instead, make it possible to specify the directory containing the shared libraries with the new `JAZZER_NATIVE_SANITIZERS_DIR` env variable.