### PR TITLE
ci: Run memory-hungry tests in isolation

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -188,6 +188,7 @@ java_fuzz_target_test(
     fuzzer_args = [
         "-fork=2",
     ],
+    tags = ["exclusive-if-local"],
     target_class = "com.example.JpegImageParserFuzzer",
     # The exit codes of the forked libFuzzer processes are not picked up correctly.
     target_compatible_with = SKIP_ON_MACOS,

--- a/src/jmh/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
+++ b/src/jmh/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
@@ -14,7 +14,10 @@ java_test(
     args = JMH_TEST_ARGS,
     main_class = "org.openjdk.jmh.Main",
     # CriticalJNINatives have been removed in Java 18.
-    tags = ["no-linux-jdk19"],
+    tags = [
+        "exclusive-if-local",
+        "no-linux-jdk19",
+    ],
     # Directly invoke JMH's main without using a testrunner.
     use_testrunner = False,
     runtime_deps = [


### PR DESCRIPTION
These tests reproducibly fail on Windows due to high memory usage.