### PR TITLE
agent: Fix Kotlin compiler warnings about `@OptIn`

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -49,7 +49,7 @@ class RuntimeInstrumentor(
     private val dumpClassesDir: Path?,
 ) : ClassFileTransformer {
 
-    @OptIn(kotlin.time.ExperimentalTime::class)
+    @kotlin.time.ExperimentalTime
     override fun transform(
         loader: ClassLoader?,
         internalClassName: String,
@@ -102,6 +102,7 @@ class RuntimeInstrumentor(
         dumpFile.writeBytes(bytecode)
     }
 
+    @kotlin.time.ExperimentalTime
     override fun transform(
         module: Module?,
         loader: ClassLoader?,
@@ -143,7 +144,7 @@ class RuntimeInstrumentor(
         return transform(loader, internalClassName, classBeingRedefined, protectionDomain, classfileBuffer)
     }
 
-    @OptIn(kotlin.time.ExperimentalTime::class)
+    @kotlin.time.ExperimentalTime
     fun transformInternal(internalClassName: String, maybeClassfileBuffer: ByteArray?): ByteArray? {
         val (fullInstrumentation, printInfo) = when {
             classesToFullyInstrument.includes(internalClassName) -> Pair(true, true)

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
@@ -51,7 +51,6 @@ internal class TraceDataFlowInstrumentor(
         return writer.toByteArray()
     }
 
-    @OptIn(ExperimentalUnsignedTypes::class)
     private fun addDataFlowInstrumentation(method: MethodNode) {
         loop@ for (inst in method.instructions.toArray()) {
             when (inst.opcode) {

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/CoverageInstrumentationTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/CoverageInstrumentationTest.kt
@@ -132,7 +132,6 @@ class CoverageInstrumentationTest {
         )
     }
 
-    @OptIn(ExperimentalUnsignedTypes::class)
     @Test
     fun testCounters() {
         MockCoverageMap.clear()


### PR DESCRIPTION
Some `@OptIn`s aren't needed anymore, the other can be replaced with dedicated annotations that do not require special compiler flags.