### PR TITLE
Ignore offline instrumentation

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -145,6 +145,7 @@ def jazzer_dependencies():
         patches = [
             Label("//third_party:jacoco-make-probe-adapter-subclassable.patch"),
             Label("//third_party:jacoco-make-probe-inserter-subclassable.patch"),
+            Label("//third_party:jacoco-ignore-offline-instrumentation.patch"),
         ],
         sha256 = "c603cfcc5f3d95ecda46fb369dc54c82a453bb6b640a605c3970607d10896725",
         strip_prefix = "jacoco-0.8.8",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -389,3 +389,38 @@ java_fuzz_target_test(
     allowed_findings = ["com.code_intelligence.jazzer.api.FuzzerSecurityIssueHigh"],
     target_class = "com.example.SilencedFuzzer",
 )
+
+java_binary(
+    name = "jacococli",
+    main_class = "org.jacoco.cli.internal.Main",
+    runtime_deps = ["@jacococli//file:jacococli.jar"],
+)
+
+java_library(
+    name = "OfflineInstrumentedTarget",
+    srcs = ["src/test/java/com/example/OfflineInstrumentedTarget.java"],
+)
+
+genrule(
+    name = "OfflineInstrumentedTargetInstrumented",
+    srcs = [":OfflineInstrumentedTarget"],
+    outs = ["OfflineInstrumentedTargetInstrumented.jar"],
+    cmd = """
+$(location :jacococli) instrument $< --dest jacoco-instrumented
+cp jacoco-instrumented/*.jar $@
+""",
+    tags = ["manual"],
+    tools = [":jacococli"],
+)
+
+java_fuzz_target_test(
+    name = "OfflineInstrumentedFuzzer",
+    timeout = "short",
+    srcs = ["src/test/java/com/example/OfflineInstrumentedFuzzer.java"],
+    allowed_findings = ["java.lang.IllegalStateException"],
+    target_class = "com.example.OfflineInstrumentedFuzzer",
+    deps = [
+        ":OfflineInstrumentedTargetInstrumented",
+        "@jacocoagent//file:jacocoagent.jar",  # Offline instrumented classes depend on the jacoco agent
+    ],
+)

--- a/tests/src/test/java/com/example/OfflineInstrumentedFuzzer.java
+++ b/tests/src/test/java/com/example/OfflineInstrumentedFuzzer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+public class OfflineInstrumentedFuzzer {
+  public static void fuzzerTestOneInput(byte[] data) {
+    OfflineInstrumentedTarget.someFunction(data);
+  }
+}

--- a/tests/src/test/java/com/example/OfflineInstrumentedTarget.java
+++ b/tests/src/test/java/com/example/OfflineInstrumentedTarget.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+public class OfflineInstrumentedTarget {
+  public static void someFunction(byte[] data) {
+    if (new String(data).equals("found it")) {
+      throw new IllegalStateException("Expected exception");
+    }
+  }
+}

--- a/third_party/jacoco-ignore-offline-instrumentation.patch
+++ b/third_party/jacoco-ignore-offline-instrumentation.patch
@@ -1,0 +1,16 @@
+diff --git org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
+index b8333a2f..1c728638 100644
+--- org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
++++ org.jacoco.core/src/org/jacoco/core/internal/instr/InstrSupport.java
+@@ -234,11 +234,6 @@ public final class InstrSupport {
+ 	 */
+ 	public static void assertNotInstrumented(final String member,
+ 			final String owner) throws IllegalStateException {
+-		if (member.equals(DATAFIELD_NAME) || member.equals(INITMETHOD_NAME)) {
+-			throw new IllegalStateException(format(
+-					"Cannot process instrumented class %s. Please supply original non-instrumented classes.",
+-					owner));
+-		}
+ 	}
+
+ 	/**


### PR DESCRIPTION
JaCoCo is able to offline instrument classes. It determines if classes,
which should be instrumented dynamically, are already instrumented by
checking the existence of the coverage data field, and throws an
exception if it's present.

Jazzer's `IProbeArrayStrategy` already does not add the coverage data
field. This PR also removes JaCoCo's check if the field is present, and
so enables fuzzing of offline instrumented classes.