### PR TITLE
mutation: Add explicit support for oneof message fields

### DIFF
--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
@@ -45,3 +45,12 @@ message RepeatedRecursiveMessageField3 {
   bool some_field = 1;
   repeated RepeatedRecursiveMessageField3 message_field = 2;
 }
+
+message OneOfField3 {
+  bool other_field = 4;
+  oneof oneof_field {
+    bool bool_field = 7;
+    PrimitiveField3 message_field = 2;
+  }
+  bool yet_another_field = 1;
+}


### PR DESCRIPTION
While `oneof`s were handled by the existing code, the mutator wasn't aware of the `oneof`'s state and would thus change it frequently, which ends up invalidating mutations applied to its other fields.

With this commit, `oneof` fields have their current state tracked and mutated in 1 out of 100 cases, which allows individual fields to reach more complicated states.