### PR TITLE
autofuzz: Filter out unnamed classes

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
+++ b/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
@@ -601,6 +601,9 @@ public class Meta {
           implementingClasses = children.getStandardClasses()
                                     .filter(info -> !Modifier.isAbstract(info.getModifiers()))
                                     .filter(info -> lookup.isAccessible(info, info.getModifiers()))
+                                    // Filter out anonymous and local classes, which can't be
+                                    // instantiated in reproducers.
+                                    .filter(info -> info.getName() != null)
                                     .loadClasses();
           implementingClassesCache.put(type, implementingClasses);
         }


### PR DESCRIPTION
Classes without a canonical name cannot be instantiated by reproducers and thus also shouldn't be used by Autofuzz. If we find constructing them useful, we should instead look for factory methods.

Fixes #619