### PR TITLE
Experimentally integrate the new mutator into Jazzer

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/driver/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/driver/BUILD.bazel
@@ -88,6 +88,7 @@ java_jni_library(
         "//src/main/java/com/code_intelligence/jazzer/api",
         "//src/main/java/com/code_intelligence/jazzer/autofuzz",
         "//src/main/java/com/code_intelligence/jazzer/instrumentor",
+        "//src/main/java/com/code_intelligence/jazzer/mutation",
         "//src/main/java/com/code_intelligence/jazzer/runtime:jazzer_bootstrap_compile_only",
         "//src/main/java/com/code_intelligence/jazzer/utils:log",
         "//src/main/java/com/code_intelligence/jazzer/utils:manifest_utils",

--- a/src/main/java/com/code_intelligence/jazzer/driver/Opt.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/Opt.java
@@ -93,6 +93,8 @@ public final class Opt {
       "Names of classes from which hooks (custom or built-in) should not be loaded from");
   public static final String dumpClassesDir = stringSetting(
       "dump_classes_dir", "", "Directory to dump instrumented .class files into (if non-empty)");
+  public static final boolean experimentalMutator =
+      boolSetting("experimental_mutator", false, "Use an experimental structured mutator");
   public static final boolean hooks = boolSetting(
       "hooks", true, "Apply fuzzing instrumentation (use 'trace' for finer-grained control)");
   public static final String idSyncFile = stringSetting("id_sync_file", null, null);

--- a/src/main/java/com/code_intelligence/jazzer/mutation/ArgumentsMutator.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/ArgumentsMutator.java
@@ -115,6 +115,11 @@ public final class ArgumentsMutator {
   }
 
   public void invoke() throws Throwable {
+    // TODO: Sometimes hash the serialized value before and after the invocation and check that the
+    //  hashes match to catch fuzz tests that mutate mutable inputs (e.g. byte[]).
+    //  Alternatively, always detach arguments and instead of the SafeToMutate annotation have a
+    //  Mutable annotation that can be used to e.g. receive a mutable implementation of List. This
+    //  is always safe, but could incur additional overhead for arrays.
     try {
       method.invoke(instance, productMutator.detachSelectively(arguments, shouldDetach));
     } catch (IllegalAccessException e) {

--- a/src/main/java/com/code_intelligence/jazzer/mutation/ArgumentsMutator.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/ArgumentsMutator.java
@@ -16,6 +16,7 @@
 
 package com.code_intelligence.jazzer.mutation;
 
+import static com.code_intelligence.jazzer.mutation.mutator.Mutators.validateAnnotationUsage;
 import static com.code_intelligence.jazzer.mutation.support.Preconditions.require;
 import static com.code_intelligence.jazzer.mutation.support.StreamSupport.toArrayOrEmpty;
 import static com.code_intelligence.jazzer.mutation.support.StreamSupport.toBooleanArray;
@@ -33,6 +34,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -56,6 +58,9 @@ public final class ArgumentsMutator {
 
   private static Optional<ArgumentsMutator> forMethod(
       MutatorFactory mutatorFactory, Object instance, Method method) {
+    for (AnnotatedType parameter : method.getAnnotatedParameterTypes()) {
+      validateAnnotationUsage(parameter);
+    }
     return toArrayOrEmpty(
         stream(method.getAnnotatedParameterTypes()).map(mutatorFactory::tryCreate),
         SerializingMutator<?>[] ::new)

--- a/src/main/java/com/code_intelligence/jazzer/mutation/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/BUILD.bazel
@@ -9,6 +9,7 @@ java_library(
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
         "//src/main/java/com/code_intelligence/jazzer/mutation/combinator",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
     ],
 )

--- a/src/main/java/com/code_intelligence/jazzer/mutation/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/BUILD.bazel
@@ -9,6 +9,7 @@ java_library(
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
         "//src/main/java/com/code_intelligence/jazzer/mutation/combinator",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/engine",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
     ],

--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/AppliesTo.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/AppliesTo.java
@@ -16,14 +16,25 @@
 
 package com.code_intelligence.jazzer.mutation.annotation;
 
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-@Target({PARAMETER, TYPE_USE})
+/**
+ * A meta-annotation that limits the concrete types an annotation for type usages applies to.
+ */
+@Target(ANNOTATION_TYPE)
 @Retention(RUNTIME)
-@AppliesTo(subClassesOf = Object.class)
-public @interface NotNull {}
+public @interface AppliesTo {
+  /**
+   * The meta-annotated annotation can be applied to these classes.
+   */
+  Class<?>[] value() default {};
+
+  /**
+   * The meta-annotated annotation can be applied to subclasses of these classes.
+   */
+  Class<?>[] subClassesOf() default {};
+}

--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/Ascii.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/Ascii.java
@@ -16,4 +16,13 @@
 
 package com.code_intelligence.jazzer.mutation.annotation;
 
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target(TYPE_USE)
+@Retention(RUNTIME)
+@AppliesTo(String.class)
 public @interface Ascii {}

--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/Ascii.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/Ascii.java
@@ -14,16 +14,6 @@
  * limitations under the License.
  */
 
-package com.code_intelligence.jazzer.mutation.mutator.lang;
+package com.code_intelligence.jazzer.mutation.annotation;
 
-import com.code_intelligence.jazzer.mutation.api.ChainedMutatorFactory;
-import com.code_intelligence.jazzer.mutation.api.MutatorFactory;
-
-public final class LangMutators {
-  private LangMutators() {}
-
-  public static MutatorFactory newFactory() {
-    return new ChainedMutatorFactory(new NullableMutatorFactory(), new BooleanMutatorFactory(),
-        new IntegralMutatorFactory(), new ByteArrayMutatorFactory(), new StringMutatorFactory());
-  }
-}
+public @interface Ascii {}

--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/InRange.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/InRange.java
@@ -16,14 +16,20 @@
 
 package com.code_intelligence.jazzer.mutation.annotation;
 
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
+@Target(TYPE_USE)
+@Retention(RUNTIME)
+@AppliesTo({byte.class, Byte.class, short.class, Short.class, int.class, Integer.class, long.class,
+    Long.class})
 public @interface InRange {
   long min() default Long.MIN_VALUE;
+
   long max() default Long.MAX_VALUE;
 }

--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/SafeToMutate.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/SafeToMutate.java
@@ -16,11 +16,12 @@
 
 package com.code_intelligence.jazzer.mutation.annotation;
 
-import java.lang.annotation.ElementType;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
 import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.PARAMETER)
+@Target(PARAMETER)
+@Retention(RUNTIME)
 public @interface SafeToMutate {}

--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/WithSize.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/WithSize.java
@@ -16,14 +16,18 @@
 
 package com.code_intelligence.jazzer.mutation.annotation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.PARAMETER, ElementType.TYPE_USE})
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.List;
+
+@Target(TYPE_USE)
+@Retention(RUNTIME)
+@AppliesTo(List.class)
 public @interface WithSize {
   int min() default 0;
+
   int max() default 1000;
 }

--- a/src/main/java/com/code_intelligence/jazzer/mutation/api/PseudoRandom.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/api/PseudoRandom.java
@@ -70,4 +70,9 @@ public interface PseudoRandom {
    * {@code [lowerInclusive, upperInclusive]}.
    */
   long closedRange(long lowerInclusive, long upperInclusive);
+
+  /**
+   * Fills the given array with random bytes.
+   */
+  void bytes(byte[] bytes);
 }

--- a/src/main/java/com/code_intelligence/jazzer/mutation/engine/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/engine/BUILD.bazel
@@ -2,6 +2,7 @@ java_library(
     name = "engine",
     srcs = glob(["*.java"]),
     visibility = [
+        "//src/main/java/com/code_intelligence/jazzer/mutation:__pkg__",
         "//src/test/java/com/code_intelligence/jazzer/mutation:__subpackages__",
     ],
     deps = [

--- a/src/main/java/com/code_intelligence/jazzer/mutation/engine/SeededPseudoRandom.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/engine/SeededPseudoRandom.java
@@ -19,6 +19,7 @@ package com.code_intelligence.jazzer.mutation.engine;
 import static com.code_intelligence.jazzer.mutation.support.Preconditions.require;
 
 import com.code_intelligence.jazzer.mutation.api.PseudoRandom;
+import com.code_intelligence.jazzer.mutation.support.RandomSupport;
 import java.util.List;
 import java.util.SplittableRandom;
 
@@ -110,5 +111,10 @@ public final class SeededPseudoRandom implements PseudoRandom {
       } while (r < lowerInclusive);
       return r;
     }
+  }
+
+  @Override
+  public void bytes(byte[] bytes) {
+    RandomSupport.nextBytes(random, bytes);
   }
 }

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/BUILD.bazel
@@ -4,9 +4,11 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/api",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/support",
     ],
 )

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/Mutators.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/Mutators.java
@@ -16,11 +16,19 @@
 
 package com.code_intelligence.jazzer.mutation.mutator;
 
+import static com.code_intelligence.jazzer.mutation.support.TypeSupport.visitAnnotatedType;
+import static java.lang.String.format;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+
+import com.code_intelligence.jazzer.mutation.annotation.AppliesTo;
 import com.code_intelligence.jazzer.mutation.api.ChainedMutatorFactory;
 import com.code_intelligence.jazzer.mutation.api.MutatorFactory;
 import com.code_intelligence.jazzer.mutation.mutator.collection.CollectionMutators;
 import com.code_intelligence.jazzer.mutation.mutator.lang.LangMutators;
 import com.code_intelligence.jazzer.mutation.mutator.proto.ProtoMutators;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedType;
 
 public final class Mutators {
   private Mutators() {}
@@ -28,5 +36,46 @@ public final class Mutators {
   public static MutatorFactory newFactory() {
     return new ChainedMutatorFactory(
         LangMutators.newFactory(), CollectionMutators.newFactory(), ProtoMutators.newFactory());
+  }
+
+  /**
+   * Throws an exception if any annotation on {@code type} violates the restrictions of its
+   * {@link AppliesTo} meta-annotation.
+   */
+  public static void validateAnnotationUsage(AnnotatedType type) {
+    visitAnnotatedType(type, (clazz, annotations) -> {
+      outer:
+        for (Annotation annotation : annotations) {
+          AppliesTo appliesTo = annotation.annotationType().getAnnotation(AppliesTo.class);
+          if (appliesTo == null) {
+            continue;
+          }
+          for (Class<?> allowedClass : appliesTo.value()) {
+            if (allowedClass == clazz) {
+              continue outer;
+            }
+          }
+          for (Class<?> allowedSuperClass : appliesTo.subClassesOf()) {
+            if (allowedSuperClass.isAssignableFrom(clazz)) {
+              continue outer;
+            }
+          }
+
+          String helpText = "";
+          if (appliesTo.value().length != 0) {
+            helpText = stream(appliesTo.value()).map(Class::getName).collect(joining(", "));
+          }
+          if (appliesTo.subClassesOf().length != 0) {
+            if (!helpText.isEmpty()) {
+              helpText += "as well as ";
+            }
+            helpText += "subclasses of ";
+            helpText += stream(appliesTo.subClassesOf()).map(Class::getName).collect(joining(", "));
+          }
+          // Use the simple name as our annotations live in a single package.
+          throw new IllegalArgumentException(format("%s does not apply to %s, only applies to %s",
+              annotation.annotationType().getSimpleName(), clazz.getName(), helpText));
+        }
+    });
   }
 }

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorFactory.java
@@ -62,7 +62,7 @@ final class ListMutatorFactory extends MutatorFactory {
 
     @Override
     public List<T> read(DataInputStream in) throws IOException {
-      int size = in.readInt();
+      int size = Math.max(in.readInt(), 0);
       ArrayList<T> list = new ArrayList<>(size);
       for (int i = 0; i < size; i++) {
         list.add(elementMutator.read(in));

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/BUILD.bazel
@@ -8,6 +8,7 @@ java_library(
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/combinator",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
         "@com_google_errorprone_error_prone_annotations//jar",

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/BUILD.bazel
@@ -8,6 +8,7 @@ java_library(
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
         "@com_google_errorprone_error_prone_annotations//jar",
     ],

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/ByteArrayMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/ByteArrayMutatorFactory.java
@@ -49,7 +49,8 @@ final class ByteArrayMutatorFactory extends MutatorFactory {
 
     @Override
     public byte[] read(DataInputStream in) throws IOException {
-      byte[] bytes = new byte[in.readInt()];
+      int length = Math.max(in.readInt(), 0);
+      byte[] bytes = new byte[length];
       in.readFully(bytes);
       return bytes;
     }

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/ByteArrayMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/ByteArrayMutatorFactory.java
@@ -23,6 +23,7 @@ import com.code_intelligence.jazzer.mutation.api.Debuggable;
 import com.code_intelligence.jazzer.mutation.api.MutatorFactory;
 import com.code_intelligence.jazzer.mutation.api.PseudoRandom;
 import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
+import com.code_intelligence.jazzer.mutation.mutator.libfuzzer.LibFuzzerMutator;
 import com.google.errorprone.annotations.Immutable;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -76,17 +77,23 @@ final class ByteArrayMutatorFactory extends MutatorFactory {
 
     @Override
     public byte[] init(PseudoRandom prng) {
-      throw new UnsupportedOperationException("not implemented");
+      // TODO: Improve the way the upper bound is determined, e.g. grow it over time and/or add
+      //  support for the WithSize annotation.
+      byte[] bytes = new byte[prng.indexIn(1000)];
+      prng.bytes(bytes);
+      return bytes;
     }
 
     @Override
     public byte[] mutate(byte[] value, PseudoRandom prng) {
-      throw new UnsupportedOperationException("not implemented");
+      // TODO: The way maxSizeIncrease is determined is just a heuristic and hasn't been
+      //  benchmarked.
+      return LibFuzzerMutator.mutateDefault(value, Math.max(8, value.length / 16));
     }
 
     @Override
     public String toDebugString(Predicate<Debuggable> isInCycle) {
-      return "ByteArray";
+      return "byte[]";
     }
   }
 }

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer/BUILD.bazel
@@ -1,0 +1,14 @@
+java_library(
+    name = "libfuzzer",
+    srcs = ["LibFuzzerMutator.java"],
+    visibility = [
+        # libFuzzer's mutators should only by used by mutators for primitive types as we want to get
+        # rid of this dependency eventually.
+        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang:__pkg__",
+    ],
+    deps = [
+        "//src/main/java/com/code_intelligence/jazzer/mutation/api",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/support",
+        "//src/main/java/com/code_intelligence/jazzer/runtime:mutator",
+    ],
+)

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer/LibFuzzerMutator.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer/LibFuzzerMutator.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.mutator.libfuzzer;
+
+import static com.code_intelligence.jazzer.mutation.support.Preconditions.require;
+
+import com.code_intelligence.jazzer.mutation.api.Serializer;
+import com.code_intelligence.jazzer.runtime.Mutator;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+public final class LibFuzzerMutator {
+  public static byte[] mutateDefault(byte[] data, int maxSizeIncrease) {
+    byte[] mutatedBytes;
+    if (maxSizeIncrease == 0) {
+      mutatedBytes = data;
+    } else {
+      mutatedBytes = Arrays.copyOf(data, data.length + maxSizeIncrease);
+    }
+    int newSize = defaultMutate(mutatedBytes, data.length);
+    if (newSize == 0) {
+      // Mutation failed. This should happen very rarely.
+      return data;
+    }
+    return Arrays.copyOf(mutatedBytes, newSize);
+  }
+
+  public static <T> T mutateDefault(T value, Serializer<T> serializer, int maxSizeIncrease) {
+    require(maxSizeIncrease >= 0);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try {
+      serializer.writeExclusive(value, out);
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "writeExclusive is not expected to throw if the underlying stream doesn't", e);
+    }
+
+    byte[] mutatedBytes = mutateDefault(out.toByteArray(), maxSizeIncrease);
+
+    try {
+      return serializer.readExclusive(new ByteArrayInputStream(mutatedBytes));
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "readExclusive is not expected to throw if the underlying stream doesn't", e);
+    }
+  }
+
+  private static int defaultMutate(byte[] buffer, int size) {
+    if (Mutator.SHOULD_MOCK) {
+      return defaultMutateMock(buffer, size);
+    } else {
+      return Mutator.defaultMutateNative(buffer, size);
+    }
+  }
+
+  private static int defaultMutateMock(byte[] buffer, int size) {
+    int newSize = (buffer.length + size) / 2;
+    for (int i = 0; i < newSize; i++) {
+      buffer[i] += i + 1;
+    }
+    return newSize;
+  }
+
+  private LibFuzzerMutator() {}
+}

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorFactory.java
@@ -176,7 +176,7 @@ public final class BuilderMutatorFactory extends MutatorFactory {
     return new Serializer<Builder>() {
       @Override
       public Builder read(DataInputStream in) throws IOException {
-        int length = in.readInt();
+        int length = Math.max(in.readInt(), 0);
         return parseLeniently(cap(in, length));
       }
 

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/ByteStringMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/ByteStringMutatorFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.mutator.proto;
+
+import static com.code_intelligence.jazzer.mutation.combinator.MutatorCombinators.mutateThenMapToImmutable;
+import static com.code_intelligence.jazzer.mutation.support.TypeSupport.asAnnotatedType;
+import static com.code_intelligence.jazzer.mutation.support.TypeSupport.findFirstParentIfClass;
+import static com.code_intelligence.jazzer.mutation.support.TypeSupport.notNull;
+
+import com.code_intelligence.jazzer.mutation.api.MutatorFactory;
+import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
+import com.google.protobuf.ByteString;
+import java.lang.reflect.AnnotatedType;
+import java.util.Optional;
+
+final class ByteStringMutatorFactory extends MutatorFactory {
+  ByteStringMutatorFactory() {}
+
+  @Override
+  public Optional<SerializingMutator<?>> tryCreate(AnnotatedType type, MutatorFactory factory) {
+    return findFirstParentIfClass(type, ByteString.class)
+        .flatMap(parent -> factory.tryCreate(notNull(asAnnotatedType(byte[].class))))
+        .map(byteArrayMutator
+            -> mutateThenMapToImmutable((SerializingMutator<byte[]>) byteArrayMutator,
+                ByteString::copyFrom, ByteString::toByteArray));
+  }
+}

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/ProtoMutators.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/ProtoMutators.java
@@ -25,7 +25,8 @@ public final class ProtoMutators {
   public static MutatorFactory newFactory() {
     try {
       Class.forName("com.google.protobuf.Message");
-      return new ChainedMutatorFactory(new MessageMutatorFactory(), new BuilderMutatorFactory());
+      return new ChainedMutatorFactory(
+          new ByteStringMutatorFactory(), new MessageMutatorFactory(), new BuilderMutatorFactory());
     } catch (ClassNotFoundException e) {
       return new ChainedMutatorFactory();
     }

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/TypeLibrary.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/TypeLibrary.java
@@ -23,6 +23,7 @@ import static com.code_intelligence.jazzer.mutation.support.TypeSupport.withType
 
 import com.code_intelligence.jazzer.mutation.annotation.NotNull;
 import com.code_intelligence.jazzer.mutation.support.TypeHolder;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message.Builder;
 import java.lang.annotation.Annotation;
@@ -65,10 +66,11 @@ final class TypeLibrary {
         return new TypeHolder<Integer>() {}.annotatedType();
       case LONG:
         return new TypeHolder<Long>() {}.annotatedType();
+      case BYTE_STRING:
+        return new TypeHolder<ByteString>() {}.annotatedType();
       case FLOAT:
       case DOUBLE:
       case STRING:
-      case BYTE_STRING:
       case ENUM:
         throw new UnsupportedOperationException(field.getType() + " has not been implemented");
       default:

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/TypeLibrary.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/TypeLibrary.java
@@ -25,6 +25,7 @@ import com.code_intelligence.jazzer.mutation.annotation.NotNull;
 import com.code_intelligence.jazzer.mutation.support.TypeHolder;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FieldDescriptor.Type;
 import com.google.protobuf.Message.Builder;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedType;
@@ -68,9 +69,10 @@ final class TypeLibrary {
         return new TypeHolder<Long>() {}.annotatedType();
       case BYTE_STRING:
         return new TypeHolder<ByteString>() {}.annotatedType();
+      case STRING:
+        return new TypeHolder<String>() {}.annotatedType();
       case FLOAT:
       case DOUBLE:
-      case STRING:
       case ENUM:
         throw new UnsupportedOperationException(field.getType() + " has not been implemented");
       default:

--- a/src/main/java/com/code_intelligence/jazzer/mutation/support/RandomSupport.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/support/RandomSupport.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.support;
+
+import java.util.SplittableRandom;
+
+public final class RandomSupport {
+  private RandomSupport() {}
+
+  /**
+   * Polyfill for {@link SplittableRandom#nextBytes(byte[])}, which is not available in Java 8.
+   */
+  public static void nextBytes(SplittableRandom random, byte[] bytes) {
+    // Taken from the implementation contract
+    // https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/random/RandomGenerator.html#nextBytes(byte%5B%5D)
+    // for interoperability with the RandomGenerator interface available as of Java 17.
+    int i = 0;
+    int len = bytes.length;
+    for (int words = len >> 3; words-- > 0;) {
+      long rnd = random.nextLong();
+      for (int n = 8; n-- > 0; rnd >>>= Byte.SIZE) bytes[i++] = (byte) rnd;
+    }
+    if (i < len)
+      for (long rnd = random.nextLong(); i<len; rnd>>>= Byte.SIZE) bytes[i++] = (byte) rnd;
+  }
+}

--- a/src/main/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
@@ -126,6 +126,15 @@ java_jni_library(
     ],
 )
 
+java_jni_library(
+    name = "mutator",
+    srcs = ["Mutator.java"],
+    visibility = [
+        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer:__pkg__",
+        "//src/main/native/com/code_intelligence/jazzer/driver:__pkg__",
+    ],
+)
+
 java_library(
     name = "runtime",
     srcs = [
@@ -143,6 +152,7 @@ java_library(
     ],
     runtime_deps = [
         ":fuzz_target_runner_natives",
+        ":mutator",
         # Access to Unsafe is possible without any tricks if the class that does it is loaded by the
         # bootstrap loader. We thus want Jazzer to use this class from jazzer_bootstrap.
         "//src/main/java/com/code_intelligence/jazzer/utils:unsafe_provider",

--- a/src/main/java/com/code_intelligence/jazzer/runtime/FuzzTargetRunnerNatives.java
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/FuzzTargetRunnerNatives.java
@@ -33,7 +33,8 @@ public class FuzzTargetRunnerNatives {
     RulesJni.loadLibrary("jazzer_driver", "/com/code_intelligence/jazzer/driver");
   }
 
-  public static native int startLibFuzzer(byte[][] args, Class<?> runner);
+  public static native int startLibFuzzer(
+      byte[][] args, Class<?> runner, boolean useExperimentalMutator);
 
   public static native void printCrashingInput();
 

--- a/src/main/java/com/code_intelligence/jazzer/runtime/Mutator.java
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/Mutator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.runtime;
+
+import com.github.fmeum.rules_jni.RulesJni;
+
+public final class Mutator {
+  public static final boolean SHOULD_MOCK =
+      Boolean.parseBoolean(System.getenv("JAZZER_MOCK_LIBFUZZER_MUTATOR"));
+
+  static {
+    if (!SHOULD_MOCK) {
+      RulesJni.loadLibrary("jazzer_driver", "/com/code_intelligence/jazzer/driver");
+    }
+  }
+
+  public static native int defaultMutateNative(byte[] buffer, int size);
+
+  private Mutator() {}
+}

--- a/src/main/native/com/code_intelligence/jazzer/driver/BUILD.bazel
+++ b/src/main/native/com/code_intelligence/jazzer/driver/BUILD.bazel
@@ -28,6 +28,7 @@ cc_library(
         ":fuzz_target_runner",
         ":jazzer_fuzzer_callbacks",
         ":libfuzzer_callbacks",
+        ":mutator",
     ],
 )
 
@@ -101,6 +102,14 @@ cc_library(
         "//src/main/java/com/code_intelligence/jazzer/runtime:trace_data_flow_native_callbacks.hdrs",
         "@com_google_absl//absl/strings",
     ],
+    # Symbols are only referenced dynamically via JNI.
+    alwayslink = True,
+)
+
+cc_library(
+    name = "mutator",
+    srcs = ["mutator.cpp"],
+    deps = ["//src/main/java/com/code_intelligence/jazzer/runtime:mutator.hdrs"],
     # Symbols are only referenced dynamically via JNI.
     alwayslink = True,
 )

--- a/src/main/native/com/code_intelligence/jazzer/driver/mutator.cpp
+++ b/src/main/native/com/code_intelligence/jazzer/driver/mutator.cpp
@@ -1,0 +1,31 @@
+// Copyright 2023 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include <cstdint>
+
+#include "com_code_intelligence_jazzer_runtime_Mutator.h"
+
+extern "C" size_t LLVMFuzzerMutate(uint8_t *Data, size_t Size, size_t MaxSize);
+
+[[maybe_unused]] jint
+Java_com_code_1intelligence_jazzer_runtime_Mutator_defaultMutateNative(
+    JNIEnv *env, jclass, jbyteArray jni_data, jint size) {
+  jint maxSize = env->GetArrayLength(jni_data);
+  uint8_t *data =
+      static_cast<uint8_t *>(env->GetPrimitiveArrayCritical(jni_data, nullptr));
+  jint res = LLVMFuzzerMutate(data, size, maxSize);
+  env->ReleasePrimitiveArrayCritical(jni_data, data, 0);
+  return res;
+}

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/BUILD.bazel
@@ -4,6 +4,7 @@ java_test_suite(
     name = "MutatorTests",
     size = "small",
     srcs = glob(["*.java"]),
+    env = {"JAZZER_MOCK_LIBFUZZER_MUTATOR": "true"},
     runner = "junit5",
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/BUILD.bazel
@@ -1,11 +1,10 @@
-load("@contrib_rules_jvm//java:defs.bzl", "java_test_suite")
+load("@contrib_rules_jvm//java:defs.bzl", "java_junit5_test")
 
-java_test_suite(
-    name = "MutatorTests",
-    size = "small",
-    srcs = glob(["*.java"]),
+java_junit5_test(
+    name = "StressTest",
+    size = "medium",
+    srcs = ["StressTest.java"],
     env = {"JAZZER_MOCK_LIBFUZZER_MUTATOR": "true"},
-    runner = "junit5",
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -41,6 +41,7 @@ import com.code_intelligence.jazzer.protobuf.Proto3.IntegralField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.OptionalPrimitiveField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedIntegralField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedRecursiveMessageField3;
+import com.code_intelligence.jazzer.protobuf.Proto3.StringField3;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -171,6 +172,9 @@ public class StressTest {
             distinctElementsRatio(0.25)),
         arguments(new TypeHolder<@NotNull BytesField3>() {}.annotatedType(),
             "{Builder.byte[] -> ByteString} -> Message", manyDistinctElements(),
+            manyDistinctElements()),
+        arguments(new TypeHolder<@NotNull StringField3>() {}.annotatedType(),
+            "{Builder.byte[] -> String} -> Message", manyDistinctElements(),
             manyDistinctElements()));
   }
 

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -36,6 +36,7 @@ import com.code_intelligence.jazzer.mutation.api.PseudoRandom;
 import com.code_intelligence.jazzer.mutation.api.Serializer;
 import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
 import com.code_intelligence.jazzer.mutation.support.TypeHolder;
+import com.code_intelligence.jazzer.protobuf.Proto3.BytesField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.IntegralField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.OptionalPrimitiveField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedIntegralField3;
@@ -167,7 +168,10 @@ public class StressTest {
             // TODO: This ratio is on the lower end, most likely because of the strong bias towards
             //  special values combined with the small initial size of the list. When we improve the
             //  list mutator, this may be increased.
-            distinctElementsRatio(0.25)));
+            distinctElementsRatio(0.25)),
+        arguments(new TypeHolder<@NotNull BytesField3>() {}.annotatedType(),
+            "{Builder.byte[] -> ByteString} -> Message", manyDistinctElements(),
+            manyDistinctElements()));
   }
 
   @SafeVarargs

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -16,6 +16,7 @@
 
 package com.code_intelligence.jazzer.mutation.mutator;
 
+import static com.code_intelligence.jazzer.mutation.mutator.Mutators.validateAnnotationUsage;
 import static com.code_intelligence.jazzer.mutation.support.InputStreamSupport.extendWithZeros;
 import static com.code_intelligence.jazzer.mutation.support.Preconditions.require;
 import static com.code_intelligence.jazzer.mutation.support.TestSupport.anyPseudoRandom;
@@ -251,6 +252,7 @@ public class StressTest {
   void genericMutatorStressTest(AnnotatedType type, String mutatorTree,
       Consumer<List<Object>> expectedInitValues, Consumer<List<Object>> expectedMutatedValues)
       throws IOException {
+    validateAnnotationUsage(type);
     SerializingMutator mutator = Mutators.newFactory().createOrThrow(type);
     assertThat(mutator.toString()).isEqualTo(mutatorTree);
 

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/lang/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/lang/BUILD.bazel
@@ -11,5 +11,6 @@ java_test_suite(
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
         "//src/test/java/com/code_intelligence/jazzer/mutation/support:test_support",
+        "@com_google_protobuf//java/core",
     ],
 )

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/lang/StringMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/lang/StringMutatorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.mutator.lang;
+
+import static com.code_intelligence.jazzer.mutation.mutator.lang.StringMutatorFactory.fixUpAscii;
+import static com.code_intelligence.jazzer.mutation.mutator.lang.StringMutatorFactory.fixUpUtf8;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.code_intelligence.jazzer.mutation.support.RandomSupport;
+import com.google.protobuf.ByteString;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.SplittableRandom;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
+
+class StringMutatorTest {
+  @RepeatedTest(10)
+  void testFixAscii_randomInputFixed(RepetitionInfo info) {
+    SplittableRandom random = new SplittableRandom(
+        (long) "testFixAscii_randomInputFixed".hashCode() * info.getCurrentRepetition());
+
+    for (int length = 0; length < 1000; length++) {
+      byte[] randomBytes = generateRandomBytes(random, length);
+      byte[] copy = Arrays.copyOf(randomBytes, randomBytes.length);
+      fixUpAscii(copy);
+      if (isValidAscii(randomBytes)) {
+        assertThat(copy).isEqualTo(randomBytes);
+      } else {
+        assertThat(isValidAscii(copy)).isTrue();
+      }
+    }
+  }
+
+  @RepeatedTest(10)
+  void testFixAscii_validInputNotChanged(RepetitionInfo info) {
+    SplittableRandom random = new SplittableRandom(
+        (long) "testFixAscii_validInputNotChanged".hashCode() * info.getCurrentRepetition());
+
+    for (int codePoints = 0; codePoints < 1000; codePoints++) {
+      byte[] validAscii = generateValidAsciiBytes(random, codePoints);
+      byte[] copy = Arrays.copyOf(validAscii, validAscii.length);
+      fixUpAscii(copy);
+      assertThat(copy).isEqualTo(validAscii);
+    }
+  }
+
+  @RepeatedTest(20)
+  void testFixUtf8_randomInputFixed(RepetitionInfo info) {
+    SplittableRandom random = new SplittableRandom(
+        (long) "testFixUtf8_randomInputFixed".hashCode() * info.getCurrentRepetition());
+
+    for (int length = 0; length < 1000; length++) {
+      byte[] randomBytes = generateRandomBytes(random, length);
+      byte[] copy = Arrays.copyOf(randomBytes, randomBytes.length);
+      fixUpUtf8(copy);
+      if (isValidUtf8(randomBytes)) {
+        assertThat(copy).isEqualTo(randomBytes);
+      } else {
+        assertThat(isValidUtf8(copy)).isTrue();
+      }
+    }
+  }
+
+  @RepeatedTest(20)
+  void testFixUtf8_validInputNotChanged(RepetitionInfo info) {
+    SplittableRandom random = new SplittableRandom(
+        (long) "testFixUtf8_validInputNotChanged".hashCode() * info.getCurrentRepetition());
+
+    for (int codePoints = 0; codePoints < 1000; codePoints++) {
+      byte[] validUtf8 = generateValidUtf8Bytes(random, codePoints);
+      byte[] copy = Arrays.copyOf(validUtf8, validUtf8.length);
+      fixUpUtf8(copy);
+      assertThat(copy).isEqualTo(validUtf8);
+    }
+  }
+
+  private static boolean isValidUtf8(byte[] data) {
+    return ByteString.copyFrom(data).isValidUtf8();
+  }
+
+  private static boolean isValidAscii(byte[] data) {
+    for (byte b : data) {
+      if ((b & 0xFF) > 0x7F) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static byte[] generateRandomBytes(SplittableRandom random, int length) {
+    byte[] bytes = new byte[length];
+    RandomSupport.nextBytes(random, bytes);
+    return bytes;
+  }
+
+  private static byte[] generateValidAsciiBytes(SplittableRandom random, int length) {
+    return random.ints(0, 0x7F)
+        .limit(length)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString()
+        .getBytes(StandardCharsets.UTF_8);
+  }
+
+  private static byte[] generateValidUtf8Bytes(SplittableRandom random, long codePoints) {
+    return random.ints(0, Character.MAX_CODE_POINT + 1)
+        .filter(code -> code < Character.MIN_SURROGATE || code > Character.MAX_SURROGATE)
+        .limit(codePoints)
+        .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
+        .toString()
+        .getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
@@ -62,3 +62,7 @@ message IntegralField3 {
 message RepeatedIntegralField3 {
   repeated uint32 some_field = 1;
 }
+
+message BytesField3 {
+  bytes some_field = 1;
+}

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
@@ -66,3 +66,7 @@ message RepeatedIntegralField3 {
 message BytesField3 {
   bytes some_field = 1;
 }
+
+message StringField3 {
+  string some_field = 1;
+}

--- a/src/test/java/com/code_intelligence/jazzer/mutation/support/TestSupport.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/support/TestSupport.java
@@ -187,6 +187,14 @@ public final class TestSupport {
     }
 
     @Override
+    public void bytes(byte[] bytes) {
+      assertThat(elements).isNotEmpty();
+      byte[] result = (byte[]) elements.poll();
+      assertThat(result).hasLength(bytes.length);
+      System.arraycopy(result, 0, bytes, 0, bytes.length);
+    }
+
+    @Override
     public void close() {
       assertThat(elements).isEmpty();
     }

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -424,3 +424,24 @@ java_fuzz_target_test(
         "@jacocoagent//file:jacocoagent.jar",  # Offline instrumented classes depend on the jacoco agent
     ],
 )
+
+# TODO: Move to //examples eventually.
+java_fuzz_target_test(
+    name = "ExperimentalMutatorFuzzer",
+    srcs = ["src/test/java/com/example/ExperimentalMutatorFuzzer.java"],
+    allowed_findings = ["com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium"],
+    fuzzer_args = [
+        "--experimental_mutator",
+        "--instrumentation_includes=com.example.**",
+        "--custom_hook_includes=com.example.**",
+        # TODO: Investigate whether we can automatically exclude protos.
+        "--instrumentation_excludes=com.example.SimpleProto*",
+        "--custom_hook_excludes=com.example.SimpleProto*",
+    ],
+    target_class = "com.example.ExperimentalMutatorFuzzer",
+    verify_crash_reproducer = False,
+    deps = [
+        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
+        "//tests/src/test/proto:simple_java_proto",
+    ],
+)

--- a/tests/src/test/java/com/example/ExperimentalMutatorFuzzer.java
+++ b/tests/src/test/java/com/example/ExperimentalMutatorFuzzer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.code_intelligence.jazzer.mutation.annotation.InRange;
+import com.code_intelligence.jazzer.mutation.annotation.NotNull;
+
+public class ExperimentalMutatorFuzzer {
+  public static void fuzzerTestOneInput(
+      @InRange(max = -42) short num, @NotNull SimpleProto.MyProto proto) {
+    if (num > -42) {
+      throw new IllegalArgumentException();
+    }
+
+    if (proto.getNumber() == 12345678) {
+      if (proto.getMessage().getText().contains("Hello, proto!")) {
+        throw new FuzzerSecurityIssueMedium("Dangerous proto");
+      }
+    }
+  }
+}

--- a/tests/src/test/proto/BUILD.bazel
+++ b/tests/src/test/proto/BUILD.bazel
@@ -1,0 +1,10 @@
+proto_library(
+    name = "simple_proto",
+    srcs = ["simple_proto.proto"],
+)
+
+java_proto_library(
+    name = "simple_java_proto",
+    visibility = ["//tests:__pkg__"],
+    deps = [":simple_proto"],
+)

--- a/tests/src/test/proto/simple_proto.proto
+++ b/tests/src/test/proto/simple_proto.proto
@@ -1,0 +1,29 @@
+// Copyright 2023 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package com.example;
+
+option java_package = "com.example";
+
+message MyProto {
+  uint64 number = 1;
+  MySubProto message = 2;
+}
+
+message MySubProto {
+  string text = 1;
+}
+


### PR DESCRIPTION
The mutator can be enabled via the `--experimental_mutator` flag and, if disabled, should not add any measurable overhead.

The integration is highly unoptimized with many redundant copies. As follow-up work, this should be properly benchmarked and improved where necessary.