### PR TITLE
junit: Add transitive dependency on launcher

### DIFF
--- a/examples/junit/src/test/java/com/example/BUILD.bazel
+++ b/examples/junit/src/test/java/com/example/BUILD.bazel
@@ -84,6 +84,27 @@ java_fuzz_target_test(
     ],
 )
 
+java_fuzz_target_test(
+    name = "KeepGoingFuzzTest",
+    srcs = ["KeepGoingFuzzTest.java"],
+    allowed_findings = ["java.lang.IllegalArgumentException"],
+    expect_crash = False,
+    fuzzer_args = [
+        "--instrumentation_includes=com.example.**",
+        "--custom_hook_includes=com.example.**",
+        "--keep_going=3",
+        "-runs=10",
+    ],
+    target_class = "com.example.KeepGoingFuzzTest",
+    runtime_deps = [
+        ":junit_runtime",
+    ],
+    deps = [
+        "//src/main/java/com/code_intelligence/jazzer/junit:fuzz_test",
+        "@maven//:org_junit_jupiter_junit_jupiter_api",
+    ],
+)
+
 # Verifies that fuzzer command-line arguments are honored for @FuzzTests.
 java_fuzz_target_test(
     name = "CommandLineFuzzTest",

--- a/examples/junit/src/test/java/com/example/KeepGoingFuzzTest.java
+++ b/examples/junit/src/test/java/com/example/KeepGoingFuzzTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 
-package com.code_intelligence.jazzer.driver.junit;
+package com.example;
 
-public final class ExitCodeException extends Exception {
-  public final int exitCode;
+import com.code_intelligence.jazzer.junit.FuzzTest;
 
-  public ExitCodeException(String message, int exitCode) {
-    super(message);
-    this.exitCode = exitCode;
+public class KeepGoingFuzzTest {
+  private static int counter = 0;
+
+  @FuzzTest
+  public void keepGoingFuzzTest(byte[] ignored) {
+    counter++;
+    if (counter == 1) {
+      throw new IllegalArgumentException("error1");
+    }
+    if (counter == 2) {
+      throw new IllegalArgumentException("error2");
+    }
   }
 }

--- a/src/main/java/com/code_intelligence/jazzer/driver/Driver.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/Driver.java
@@ -117,12 +117,10 @@ public class Driver {
       exit(0);
     }
 
-    if (!isAndroid) {
-      AgentInstaller.install(Opt.hooks);
-    }
     Driver.class.getClassLoader().setDefaultAssertionStatus(true);
 
     if (!Opt.autofuzz.isEmpty()) {
+      AgentInstaller.install(Opt.hooks);
       FuzzTargetHolder.fuzzTarget = FuzzTargetHolder.AUTOFUZZ_FUZZ_TARGET;
       return FuzzTargetRunner.startLibFuzzer(args);
     }
@@ -140,6 +138,9 @@ public class Driver {
       }
     }
 
+    // Installing the agent after the following "findFuzzTarget" leads to an asan error
+    // in it on "Class.forName(targetClassName)", but only during native fuzzing.
+    AgentInstaller.install(Opt.hooks);
     FuzzTargetHolder.fuzzTarget = FuzzTargetFinder.findFuzzTarget(targetClassName);
     return FuzzTargetRunner.startLibFuzzer(args);
   }

--- a/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -51,7 +51,6 @@ java_jni_library(
     native_libs = [
         "//src/main/native/com/code_intelligence/jazzer/driver:jazzer_driver",
     ],
-    visibility = ["//src/test/java/com/code_intelligence/jazzer/junit:__pkg__"],
     deps = [
         ":utils",
         "//src/main/java/com/code_intelligence/jazzer/api",
@@ -66,6 +65,7 @@ java_jni_library(
 java_library(
     name = "utils",
     srcs = ["Utils.java"],
+    visibility = ["//src/test/java/com/code_intelligence/jazzer/junit:__pkg__"],
     deps = [
         "@maven//:org_junit_jupiter_junit_jupiter_api",
     ],

--- a/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -29,6 +29,12 @@ java_library(
     visibility = [
         "//examples/junit/src/test/java/com/example:__pkg__",
     ],
+    runtime_deps = [
+        # The JUnit launcher that is part of the Jazzer driver needs this on the classpath
+        # to run an @FuzzTest with JUnit. This will also result in a transitive dependency
+        # in the generated pom file.
+        "@maven//:org_junit_platform_junit_platform_launcher",
+    ],
     deps = [
         ":agent_configurator",
         ":fuzz_test_executor",

--- a/src/main/java/com/code_intelligence/jazzer/junit/Utils.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/Utils.java
@@ -18,6 +18,7 @@ import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -115,5 +116,15 @@ class Utils {
    */
   static boolean permissivelyParseBoolean(String value) {
     return value.equalsIgnoreCase("true") || value.equals("1") || value.equalsIgnoreCase("yes");
+  }
+
+  /**
+   * Convert the string to ISO 8601 (https://en.wikipedia.org/wiki/ISO_8601#Durations).
+   * We do not allow for duration units longer than hours, so we can always prepend PT.
+   */
+  static long durationStringToSeconds(String duration) {
+    String isoDuration =
+        "PT" + duration.replace("sec", "s").replace("min", "m").replace("hr", "h").replace(" ", "");
+    return Duration.parse(isoDuration).getSeconds();
   }
 }

--- a/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -1,8 +1,8 @@
 java_test(
-    name = "FuzzTestExecutorTest",
-    srcs = ["FuzzTestExecutorTest.java"],
+    name = "UtilsTest",
+    srcs = ["UtilsTest.java"],
     deps = [
-        "//src/main/java/com/code_intelligence/jazzer/junit:fuzz_test_executor",
+        "//src/main/java/com/code_intelligence/jazzer/junit:utils",
         "@maven//:com_google_truth_truth",
     ],
 )

--- a/src/test/java/com/code_intelligence/jazzer/junit/UtilsTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/junit/UtilsTest.java
@@ -14,12 +14,12 @@
 
 package com.code_intelligence.jazzer.junit;
 
-import static com.code_intelligence.jazzer.junit.FuzzTestExecutor.durationStringToSeconds;
+import static com.code_intelligence.jazzer.junit.Utils.durationStringToSeconds;
 import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
 
-public class FuzzTestExecutorTest {
+public class UtilsTest {
   @Test
   public void testDurationStringToSeconds() {
     assertThat(durationStringToSeconds("1m")).isEqualTo(60);


### PR DESCRIPTION
The transitive dependency on `org.junit.platform:junit-platform-launcher` removes the need to specify it manually in every project.