### PR TITLE
bazel: Use a hermetic Java toolchain compiling for Java 8

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,8 +22,17 @@ build --incompatible_enable_cc_toolchain_resolution
 build:ci --features=layering_check
 
 # Java
+# Always build for Java 8, even with a newer JDK. This ensures that all
+# artifacts we release are compatible with Java 8 runtimes.
+# Note: We would like to use --release, but can't due to
+#  https://bugs.openjdk.org/browse/JDK-8214165.
+build --javacopt=-target --javacopt=8
 build --java_language_version=8
 build --tool_java_language_version=8
+# Use a hermetic JDK to compile Java code, which also means that contributors
+# don't need to install a JDK to compile Jazzer.
+build --java_runtime_version=remotejdk_17
+build --tool_java_runtime_version=remotejdk_17
 # Speed up Java compilation by removing indirect deps from the compile classpath.
 build --experimental_java_classpath=bazel
 
@@ -46,8 +55,6 @@ run:windows --noincompatible_strict_action_env
 # Workaround for https://github.com/bazelbuild/bazel/issues/13944, which breaks external Java
 # dependencies on M1 Macs without Rosetta.
 build:macos --extra_toolchains=//bazel/toolchains:java_non_prebuilt_definition
-build:macos --java_runtime_version=11
-build:macos --tool_java_runtime_version=11
 
 # Toolchain
 # Since the toolchain is conditional on OS and architecture, set it on the particular GitHub Action.
@@ -68,7 +75,6 @@ build:ci --repo_env=BAZEL_USE_XCODE_TOOLCHAIN=1
 
 # Maven publishing (local only, requires GPG signature)
 build:maven --stamp
-build:maven --java_runtime_version=local_jdk_8
 
 # Docker images
 common:docker --config=toolchain

--- a/.bazelrc
+++ b/.bazelrc
@@ -73,9 +73,6 @@ build:ci --remote_timeout=3600
 # fail when requested to cross-compile.
 build:ci --repo_env=BAZEL_USE_XCODE_TOOLCHAIN=1
 
-# Maven publishing (local only, requires GPG signature)
-build:maven --stamp
-
 # Docker images
 common:docker --config=toolchain
 common:docker --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,6 @@ jobs:
         shell: bash
         run: |
           echo "build --announce_rc" >> .bazelrc
-          echo "build --config=maven" >> .bazelrc
           echo "build:linux --config=toolchain" >> .bazelrc
           echo "build:linux --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux" >> .bazelrc
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,6 @@
 Jazzer has the following dependencies when being built from source:
 
 * [Bazelisk](https://github.com/bazelbuild/bazelisk) or the version of Bazel specified in [`.bazelversion`](.bazelversion)
-* JDK 8 to 19 (e.g. [OpenJDK](https://openjdk.java.net/))
 * One of the following C++ compilers:
   * [Clang](https://clang.llvm.org/) 9.0+ (clang-cl on Windows)
   * Xcode (Xcode.app is required, not just the developer tools)
@@ -71,7 +70,6 @@ Requires an account on [Sonatype](https://issues.sonatype.org) with access to th
 4. Create a GitHub release and upload the contents of the `jazzer_releases` artifact from the workflow run.
 5. Check out the tag locally and, with the YubiKey plugged in, run `bazel run //deploy` with the following environment variables to upload the Maven artifacts:
     * `JAZZER_JAR_PATH`: local path of the multi-architecture `jazzer.jar` contained in the `jazzer` artifact of the "Release" workflow
-    * `JAVA_HOME`: path to a JDK 8
     * `MAVEN_USER`: username on https://oss.sonatype.org
     * `MAVEN_PASSWORD`: password on https://oss.sonatype.org
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -32,12 +32,6 @@ JAZZER_COORDINATES=$1
   fail "Set JAZZER_JAR_PATH to the absolute path of jazzer.jar obtained from the release GitHub Actions workflow"
 [ ! -f "${JAZZER_JAR_PATH}" ] && \
   fail "JAZZER_JAR_PATH does not exist at '$JAZZER_JAR_PATH'"
-[ -z "${JAVA_HOME+x}" ] && \
-  fail "Set JAVA_HOME to a JDK 8"
-JAVA_VERSION=$("$JAVA_HOME"/bin/java -version 2>&1 | head -1 | cut -d'"' -f2)
-[ "1" -eq "$(echo "$JAVA_VERSION" | cut -d'.' -f1)" ] &&
-  [ "8" -eq "$(echo "$JAVA_VERSION" | cut -d'.' -f2)" ] || \
-  fail "JAVA_HOME ('$JAVA_HOME') must point to a JDK 8, is: $JAVA_VERSION"
 
 MAVEN_REPO=https://oss.sonatype.org/service/local/staging/deploy/maven2
 

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -37,18 +37,18 @@ MAVEN_REPO=https://oss.sonatype.org/service/local/staging/deploy/maven2
 
 # The Jazzer jar itself bundles native libraries for multiple architectures and thus can't be built
 # on the local machine. It is obtained from CI and passed in via JAZZER_JAR_PATH.
-bazel build --config=maven //deploy:jazzer-docs //deploy:jazzer-sources //deploy:jazzer-pom
+bazel build //deploy:jazzer-docs //deploy:jazzer-sources //deploy:jazzer-pom
 
-JAZZER_DOCS_PATH=$PWD/$(bazel cquery --config=maven --output=files //deploy:jazzer-docs)
-JAZZER_SOURCES_PATH=$PWD/$(bazel cquery --config=maven --output=files //deploy:jazzer-sources)
-JAZZER_POM_PATH=$PWD/$(bazel cquery --config=maven --output=files //deploy:jazzer-pom)
+JAZZER_DOCS_PATH=$PWD/$(bazel cquery --output=files //deploy:jazzer-docs)
+JAZZER_SOURCES_PATH=$PWD/$(bazel cquery --output=files //deploy:jazzer-sources)
+JAZZER_POM_PATH=$PWD/$(bazel cquery --output=files //deploy:jazzer-pom)
 
-bazel run --config=maven --define "maven_repo=${MAVEN_REPO}" --define "maven_user=${MAVEN_USER}" \
+bazel run --define "maven_repo=${MAVEN_REPO}" --define "maven_user=${MAVEN_USER}" \
   --define "maven_password=${MAVEN_PASSWORD}" --define gpg_sign=true \
   //deploy:jazzer-api.publish
-bazel run --config=maven @rules_jvm_external//private/tools/java/rules/jvm/external/maven:MavenPublisher -- \
+bazel run @rules_jvm_external//private/tools/java/rules/jvm/external/maven:MavenPublisher -- \
   "$MAVEN_REPO" true "$MAVEN_USER" "$MAVEN_PASSWORD" "$JAZZER_COORDINATES" \
   "$JAZZER_POM_PATH" "$JAZZER_JAR_PATH" "$JAZZER_SOURCES_PATH" "$JAZZER_DOCS_PATH"
-bazel run --config=maven --define "maven_repo=${MAVEN_REPO}" --define "maven_user=${MAVEN_USER}" \
+bazel run --define "maven_repo=${MAVEN_REPO}" --define "maven_user=${MAVEN_USER}" \
   --define "maven_password=${MAVEN_PASSWORD}" --define gpg_sign=true \
   //deploy:jazzer-junit.publish


### PR DESCRIPTION
This simplifies the setup for contributors as well as the release process. Since we can't use `--release 8`, we still need to check compatibility with Java 8 runtime libraries in our CI, which still uses the local JDK 8 to run tests against.

Also removes stamping from Maven builds as we already have the version number baked in.