### PR TITLE
Add a test to verify the findings directory

### DIFF
--- a/examples/junit/src/test/java/com/example/ThrowingFuzzTest.java
+++ b/examples/junit/src/test/java/com/example/ThrowingFuzzTest.java
@@ -1,0 +1,25 @@
+// Copyright 2023 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+
+public class ThrowingFuzzTest {
+  @FuzzTest
+  public void throwingFuzz(FuzzedDataProvider ignored) {
+    throw new IllegalStateException("This is a test.");
+  }
+}

--- a/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -221,3 +221,24 @@ java_test(
         "@maven//:org_junit_platform_junit_platform_testkit",
     ],
 )
+
+java_test(
+    name = "FindingsBaseDirTest",
+    srcs = ["FindingsBaseDirTest.java"],
+    env = {
+        "JAZZER_FUZZ": "1",
+    },
+    test_class = "com.code_intelligence.jazzer.junit.FindingsBaseDirTest",
+    runtime_deps = [
+        "//examples/junit/src/test/java/com/example:ExampleFuzzTests_deploy.jar",
+        "@maven//:org_junit_jupiter_junit_jupiter_engine",
+    ],
+    deps = [
+        "//src/main/java/com/code_intelligence/jazzer/api:hooks",
+        "@maven//:com_google_truth_extensions_truth_java8_extension",
+        "@maven//:com_google_truth_truth",
+        "@maven//:junit_junit",
+        "@maven//:org_junit_platform_junit_platform_engine",
+        "@maven//:org_junit_platform_junit_platform_testkit",
+    ],
+)

--- a/src/test/java/com/code_intelligence/jazzer/junit/FindingsBaseDirTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/junit/FindingsBaseDirTest.java
@@ -1,0 +1,83 @@
+// Copyright 2023 Code Intelligence GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.code_intelligence.jazzer.junit;
+
+import static com.google.common.truth.Truth8.assertThat;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+import static org.junit.platform.testkit.engine.EventConditions.container;
+import static org.junit.platform.testkit.engine.EventConditions.event;
+import static org.junit.platform.testkit.engine.EventConditions.finishedSuccessfully;
+import static org.junit.platform.testkit.engine.EventConditions.type;
+import static org.junit.platform.testkit.engine.EventConditions.uniqueIdSubstrings;
+import static org.junit.platform.testkit.engine.EventType.FINISHED;
+import static org.junit.platform.testkit.engine.EventType.REPORTING_ENTRY_PUBLISHED;
+import static org.junit.platform.testkit.engine.EventType.STARTED;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.platform.testkit.engine.EngineExecutionResults;
+import org.junit.platform.testkit.engine.EngineTestKit;
+import org.junit.rules.TemporaryFolder;
+
+public class FindingsBaseDirTest {
+  private static final String ENGINE = "engine:junit-jupiter";
+  private static final String CLAZZ = "class:com.example.ThrowingFuzzTest";
+  private static final String INPUTS_FUZZ =
+      "test-template:throwingFuzz(com.code_intelligence.jazzer.api.FuzzedDataProvider)";
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+
+  private Path baseDir;
+
+  @Before
+  public void setup() {
+    baseDir = temp.getRoot().toPath();
+  }
+
+  @Test
+  public void fuzzingEnabledNoFindingsDir() throws IOException {
+    assumeFalse(System.getenv("JAZZER_FUZZ").isEmpty());
+
+    EngineExecutionResults results =
+        EngineTestKit.engine("junit-jupiter")
+            .selectors(selectClass("com.example.ThrowingFuzzTest"))
+            .configurationParameter("jazzer.internal.basedir", baseDir.toAbsolutePath().toString())
+            .execute();
+
+    results.containerEvents().assertEventsMatchExactly(event(type(STARTED), container(ENGINE)),
+        event(type(STARTED), container(uniqueIdSubstrings(ENGINE, CLAZZ))),
+        event(type(STARTED), container(uniqueIdSubstrings(ENGINE, CLAZZ, INPUTS_FUZZ))),
+        // Warning because the inputs directory hasn't been found in the source tree.
+        event(type(REPORTING_ENTRY_PUBLISHED),
+            container(uniqueIdSubstrings(ENGINE, CLAZZ, INPUTS_FUZZ))),
+        event(type(FINISHED), container(uniqueIdSubstrings(ENGINE, CLAZZ, INPUTS_FUZZ)),
+            finishedSuccessfully()),
+        event(type(FINISHED), container(uniqueIdSubstrings(ENGINE, CLAZZ)), finishedSuccessfully()),
+        event(type(FINISHED), container(ENGINE), finishedSuccessfully()));
+
+    // Crash should be emitted into the base directory, as no findings dir available.
+    try (Stream<Path> baseDirFiles = Files.list(baseDir)) {
+      Stream<Path> crashFiles =
+          baseDirFiles.filter(f -> f.getFileName().toString().startsWith("crash-"));
+      assertThat(crashFiles).hasSize(1);
+    }
+  }
+}


### PR DESCRIPTION
Add a test that verifies that crash files are created in the base directory in case no test resource directory is present.