### PR TITLE
Add `WithUtf8Length` annotation and support for it

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/WithUtf8Length.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/WithUtf8Length.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.annotation;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * An annotation that applies to {@link String} to set limits around the number of <strong>UTF-8
+ * bytes</strong> in the string. <p> Due to the fact that our String mutator is backed by the byte
+ * array mutator, it's difficult to know how many characters we'll get from the byte array we get
+ * from libfuzzer. Rather than reuse {@link WithLength} for strings which may give the impression
+ * that {@link String#length()} will return a value between {@code min} and {@code max}, we use this
+ * annotation to help make clear that the string consists of between
+ * {@code min} and {@code max} UTF-8 bytes, not necessarily characters.
+ */
+@Target(TYPE_USE)
+@Retention(RUNTIME)
+@AppliesTo(String.class)
+public @interface WithUtf8Length {
+  int min() default 0;
+
+  int max() default 1000;
+}

--- a/src/main/java/com/code_intelligence/jazzer/mutation/support/TypeSupport.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/support/TypeSupport.java
@@ -25,6 +25,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 
 import com.code_intelligence.jazzer.mutation.annotation.NotNull;
+import com.code_intelligence.jazzer.mutation.annotation.WithLength;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Inherited;
 import java.lang.reflect.AnnotatedArrayType;
@@ -184,6 +185,56 @@ public final class TypeSupport {
 
   public static AnnotatedType notNull(AnnotatedType type) {
     return withExtraAnnotations(type, NOT_NULL);
+  }
+
+  /**
+   * Constructs an anonymous WithLength class that can be applied as an annotation to {@code type}
+   * with the given
+   * {@code min} and {@code max} values.
+   * @param type
+   * @param min
+   * @param max
+   * @return {@code type} with a `WithLength` annotation applied to it
+   */
+  public static AnnotatedType withLength(AnnotatedType type, int min, int max) {
+    WithLength withLength = withLengthImplementation(min, max);
+    return withExtraAnnotations(type, withLength);
+  }
+
+  private static WithLength withLengthImplementation(int min, int max) {
+    return new WithLength() {
+      @Override
+      public int min() {
+        return min;
+      }
+
+      @Override
+      public int max() {
+        return max;
+      }
+
+      @Override
+      public Class<? extends Annotation> annotationType() {
+        return WithLength.class;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+        if (!(o instanceof WithLength)) {
+          return false;
+        }
+        WithLength other = (WithLength) o;
+        return this.min() == other.min() && this.max() == other.max();
+      }
+
+      @Override
+      public int hashCode() {
+        int hash = 0;
+        hash += ("min".hashCode() * 127) ^ Integer.valueOf(this.min()).hashCode();
+        hash += ("max".hashCode() * 127) ^ Integer.valueOf(this.max()).hashCode();
+        return hash;
+      }
+    };
   }
 
   public static AnnotatedParameterizedType withTypeArguments(

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/lang/StringMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/lang/StringMutatorTest.java
@@ -18,17 +18,32 @@ package com.code_intelligence.jazzer.mutation.mutator.lang;
 
 import static com.code_intelligence.jazzer.mutation.mutator.lang.StringMutatorFactory.fixUpAscii;
 import static com.code_intelligence.jazzer.mutation.mutator.lang.StringMutatorFactory.fixUpUtf8;
+import static com.code_intelligence.jazzer.mutation.support.TestSupport.mockPseudoRandom;
 import static com.google.common.truth.Truth.assertThat;
 
+import com.code_intelligence.jazzer.mutation.annotation.NotNull;
+import com.code_intelligence.jazzer.mutation.annotation.WithUtf8Length;
+import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
+import com.code_intelligence.jazzer.mutation.mutator.libfuzzer.LibFuzzerMutator;
 import com.code_intelligence.jazzer.mutation.support.RandomSupport;
+import com.code_intelligence.jazzer.mutation.support.TestSupport.MockPseudoRandom;
+import com.code_intelligence.jazzer.mutation.support.TypeHolder;
 import com.google.protobuf.ByteString;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.SplittableRandom;
-import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.RepetitionInfo;
+import org.junit.jupiter.api.*;
 
 class StringMutatorTest {
+  /**
+   * Some tests may set {@link LibFuzzerMutator#MOCK_SIZE_KEY} which can interfere with other tests
+   * unless cleared.
+   */
+  @AfterEach
+  void cleanMockSize() {
+    System.clearProperty(LibFuzzerMutator.MOCK_SIZE_KEY);
+  }
+
   @RepeatedTest(10)
   void testFixAscii_randomInputFixed(RepetitionInfo info) {
     SplittableRandom random = new SplittableRandom(
@@ -87,6 +102,87 @@ class StringMutatorTest {
       fixUpUtf8(copy);
       assertThat(copy).isEqualTo(validUtf8);
     }
+  }
+
+  @Test
+  void testMinLengthInit() {
+    SerializingMutator<String> mutator =
+        (SerializingMutator<String>) LangMutators.newFactory().createOrThrow(
+            new TypeHolder<@NotNull @WithUtf8Length(min = 10) String>() {}.annotatedType());
+    assertThat(mutator.toString()).isEqualTo("String");
+
+    try (MockPseudoRandom prng = mockPseudoRandom(5)) {
+      // mock prng should throw an assert error when given a lower value than min
+      Assertions.assertThrows(AssertionError.class, () -> { String s = mutator.init(prng); });
+    }
+  }
+
+  @Test
+  void testMaxLengthInit() {
+    SerializingMutator<String> mutator =
+        (SerializingMutator<String>) LangMutators.newFactory().createOrThrow(
+            new TypeHolder<@NotNull @WithUtf8Length(max = 50) String>() {}.annotatedType());
+    assertThat(mutator.toString()).isEqualTo("String");
+
+    try (MockPseudoRandom prng = mockPseudoRandom(60)) {
+      // mock prng should throw an assert error when given a value higher than max
+      Assertions.assertThrows(AssertionError.class, () -> { String s = mutator.init(prng); });
+    }
+  }
+
+  @Test
+  void testMinLengthMutate() {
+    SerializingMutator<String> mutator =
+        (SerializingMutator<String>) LangMutators.newFactory().createOrThrow(
+            new TypeHolder<@NotNull @WithUtf8Length(min = 10) String>() {}.annotatedType());
+    assertThat(mutator.toString()).isEqualTo("String");
+
+    String s;
+    try (MockPseudoRandom prng = mockPseudoRandom(10, "foobarbazf".getBytes())) {
+      s = mutator.init(prng);
+    }
+    assertThat(s).isEqualTo("foobarbazf");
+
+    System.setProperty(LibFuzzerMutator.MOCK_SIZE_KEY, "5");
+    try (MockPseudoRandom prng = mockPseudoRandom()) {
+      s = mutator.mutate(s, prng);
+    }
+    assertThat(s).isEqualTo("gqrff\0\0\0\0\0");
+  }
+
+  @Test
+  void testMaxLengthMutate() {
+    SerializingMutator<String> mutator =
+        (SerializingMutator<String>) LangMutators.newFactory().createOrThrow(
+            new TypeHolder<@NotNull @WithUtf8Length(max = 15) String>() {}.annotatedType());
+    assertThat(mutator.toString()).isEqualTo("String");
+
+    String s;
+    try (MockPseudoRandom prng = mockPseudoRandom(10, "foobarbazf".getBytes())) {
+      s = mutator.init(prng);
+    }
+    assertThat(s).isEqualTo("foobarbazf");
+
+    System.setProperty(LibFuzzerMutator.MOCK_SIZE_KEY, "20");
+    try (MockPseudoRandom prng = mockPseudoRandom()) {
+      Assertions.assertThrows(
+          ArrayIndexOutOfBoundsException.class, () -> { String s2 = mutator.mutate(s, prng); });
+    }
+  }
+
+  @Test
+  void testMultibyteCharacters() {
+    SerializingMutator<String> mutator =
+        (SerializingMutator<String>) LangMutators.newFactory().createOrThrow(
+            new TypeHolder<@NotNull @WithUtf8Length(min = 10) String>() {}.annotatedType());
+    assertThat(mutator.toString()).isEqualTo("String");
+
+    String s;
+    try (MockPseudoRandom prng = mockPseudoRandom(10, "foobarÖÖ".getBytes())) {
+      s = mutator.init(prng);
+    }
+    assertThat(s).hasLength(8);
+    assertThat(s).isEqualTo("foobarÖÖ");
   }
 
   private static boolean isValidUtf8(byte[] data) {


### PR DESCRIPTION
This adds a new annotation `WithUtf8Length` which can apply to strings to limit the maximum and minimum number of UTF-8 bytes that go into them by creating a `WithLength` annotation of the same `min` and `max` values and applying that to the underlying byte array mutator.
