### PR TITLE
Improve list mutator

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorFactory.java
@@ -16,34 +16,45 @@
 
 package com.code_intelligence.jazzer.mutation.mutator.collection;
 
+import static com.code_intelligence.jazzer.mutation.support.Preconditions.require;
 import static com.code_intelligence.jazzer.mutation.support.TypeSupport.parameterTypeIfParameterized;
 import static java.lang.Math.min;
+import static java.lang.String.format;
 
+import com.code_intelligence.jazzer.mutation.annotation.WithSize;
 import com.code_intelligence.jazzer.mutation.api.Debuggable;
 import com.code_intelligence.jazzer.mutation.api.MutatorFactory;
 import com.code_intelligence.jazzer.mutation.api.PseudoRandom;
 import com.code_intelligence.jazzer.mutation.api.SerializingInPlaceMutator;
 import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
+import com.code_intelligence.jazzer.mutation.support.MutationAction;
+import com.code_intelligence.jazzer.mutation.support.RandomSupport;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.AnnotatedType;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Optional;
 import java.util.RandomAccess;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 final class ListMutatorFactory extends MutatorFactory {
   @Override
   public Optional<SerializingMutator<?>> tryCreate(AnnotatedType type, MutatorFactory factory) {
+    Optional<WithSize> withSize = Optional.ofNullable(type.getAnnotation(WithSize.class));
+    int minSize = withSize.map(WithSize::min).orElse(ListMutator.DEFAULT_MIN_SIZE);
+    int maxSize = withSize.map(WithSize::max).orElse(ListMutator.DEFAULT_MAX_SIZE);
     return parameterTypeIfParameterized(type, List.class)
         .flatMap(factory::tryCreate)
-        .map(elementMutator
-            -> new ListMutator<>(
-                elementMutator, ListMutator.DEFAULT_MIN_SIZE, ListMutator.DEFAULT_MAX_SIZE));
+        .map(elementMutator -> new ListMutator<>(elementMutator, minSize, maxSize));
   }
 
   private static final class ListMutator<T> extends SerializingInPlaceMutator<List<T>> {
@@ -58,17 +69,21 @@ final class ListMutatorFactory extends MutatorFactory {
       this.elementMutator = elementMutator;
       this.minSize = minSize;
       this.maxSize = maxSize;
+      require(maxSize >= 1, "WithSize#max needs to be greater than 0");
+      require(minSize <= maxSize,
+          format("WithSize#min %d needs to be smaller or equal than WithSize#max %d", minSize,
+              maxSize));
     }
 
     @Override
     public List<T> read(DataInputStream in) throws IOException {
-      int size = Math.max(in.readInt(), 0);
+      int size = RandomSupport.clamp(in.readInt(), minSize, maxSize);
       ArrayList<T> list = new ArrayList<>(size);
       for (int i = 0; i < size; i++) {
         list.add(elementMutator.read(in));
       }
-      // Wrap in an immutable view for additional protection against accidental mutation in fuzz
-      // tests.
+      // Wrap in an immutable view for additional protection against accidental
+      // mutation in fuzz tests.
       return toImmutableListView(list);
     }
 
@@ -82,8 +97,8 @@ final class ListMutatorFactory extends MutatorFactory {
 
     @Override
     protected List<T> makeDefaultInstance() {
-      // Wrap in an immutable view for additional protection against accidental mutation in fuzz
-      // tests.
+      // Wrap in an immutable view for additional protection against accidental
+      // mutation in fuzz tests.
       return toImmutableListView(new ArrayList<>(maxInitialSize()));
     }
 
@@ -97,18 +112,73 @@ final class ListMutatorFactory extends MutatorFactory {
       }
     }
 
+    private void eraseRandomChunk(List<T> list, PseudoRandom prng, int minSize) {
+      int minFinalSize = Math.max(minSize, list.size() / 2);
+      int chunkSize;
+      if (minFinalSize + 1 == list.size()) {
+        chunkSize = 1;
+      } else {
+        chunkSize = prng.closedRange(1, list.size() - minFinalSize);
+      }
+      int chunkOffset = prng.closedRange(0, list.size() - chunkSize);
+      list.subList(chunkOffset, chunkOffset + chunkSize).clear();
+    }
+
+    private void insertRandomChunk(List<T> list, PseudoRandom prng, int maxSize) {
+      // Enforces slower growth for smaller lists and lists that are close to
+      // `maxSize`.
+      int chunkSize = prng.closedRange(1, Math.min(maxSize - list.size(), list.size()));
+      int chunkOffset = prng.indexIn(list);
+      List<T> tmpAddList = Stream.generate(() -> elementMutator.init(prng))
+                               .limit(chunkSize)
+                               .collect(Collectors.toList());
+      list.addAll(chunkOffset, tmpAddList);
+    }
+
+    private void changeRandomChunk(List<T> list, PseudoRandom prng) {
+      int chunkOffset = prng.indexIn(list);
+      // Muatate at most 10% of the original list
+      int chunkSize = Math.min(
+          prng.closedRange(1, list.size() - chunkOffset), (int) Math.ceil(list.size() / 10.0));
+      ListIterator<T> iterator = list.listIterator(chunkOffset);
+      int elementsChanged = 0;
+      while (iterator.hasNext() && elementsChanged < chunkSize) {
+        T element = iterator.next();
+        T mutatedElement = elementMutator.mutate(element, prng);
+        iterator.set(mutatedElement);
+        elementsChanged++;
+      }
+    }
+
     @Override
     public void mutateInPlace(List<T> reference, PseudoRandom prng) {
       List<T> list = underlyingMutableList(reference);
       if (list.isEmpty()) {
+        // Early return
         list.add(elementMutator.init(prng));
-      } else if (!prng.trueInOneOutOf(4)) {
-        int i = prng.indexIn(list);
-        list.set(i, elementMutator.mutate(list.get(i), prng));
-      } else if (list.size() < maxSize) {
-        list.add(list.get(list.size() - 1)); // TODO: Create deep copy or init new entry.
-      } else if (list.size() > minSize) {
-        list.remove(list.size() - 1);
+        return;
+      }
+      List<MutationAction> actions = MutationAction.getPossibleActions(list, minSize, maxSize);
+      switch (actions.get(prng.indexIn(actions))) {
+        case SHRINK:
+          list.remove(prng.indexIn(list));
+          return;
+        case SHRINK_CHUNK:
+          eraseRandomChunk(list, prng, minSize);
+          return;
+        case GROW:
+          list.add(elementMutator.init(prng));
+          return;
+        case GROW_CHUNK:
+          insertRandomChunk(list, prng, maxSize);
+          return;
+        case CHANGE:
+          int i = prng.indexIn(list);
+          list.set(i, elementMutator.mutate(list.get(i), prng));
+          return;
+        case CHANGE_CHUNK:
+          changeRandomChunk(list, prng);
+          return;
       }
     }
 
@@ -134,11 +204,12 @@ final class ListMutatorFactory extends MutatorFactory {
 
     private List<T> underlyingMutableList(List<T> value) {
       if (value instanceof ImmutableListView<?>) {
-        // An immutable list view created by us, so we know how to get back at the mutable list.
+        // An immutable list view created by us, so we know how to get back at the
+        // mutable list.
         return ((ImmutableListView<T>) value).asMutableList();
       } else {
-        // Any kind of list created by someone else (for example using us as a general purpose
-        // InPlaceMutator), so assume it is mutable.
+        // Any kind of list created by someone else (for example using us as a general
+        // purpose InPlaceMutator), so assume it is mutable.
         return value;
       }
     }

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/IntegralMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/IntegralMutatorFactory.java
@@ -261,7 +261,8 @@ final class IntegralMutatorFactory extends MutatorFactory {
             value = prng.closedRange(minValue, maxValue);
             break;
           case 3:
-            // TODO: Replace this with a structure-aware dictionary/TORC search similar to fuzztest.
+            // TODO: Replace this with a structure-aware dictionary/TORC search similar to
+            // fuzztest.
             value = forceInRange(mutateWithLibFuzzer(value));
             break;
         }
@@ -271,11 +272,9 @@ final class IntegralMutatorFactory extends MutatorFactory {
 
     @ForOverride protected abstract long mutateWithLibFuzzer(long value);
 
-    /**
-     * Force value into the closed interval [minValue, maxValue] while preserving as many of its
-     * bits as possible (e.g. so that mutations that apply to the raw byte representation still have
-     * a good chance to actually mutate the value). Clamping would not have this property.
-     */
+    // Force value into the closed interval [minValue, maxValue] while preserving as many of its
+    // bits as possible (e.g. so that mutations that apply to the raw byte representation still have
+    // a good chance to actually mutate the value). Clamping would not have this property.
     protected final long forceInRange(long value) {
       // Fast path for the common case.
       if (value >= minValue && value <= maxValue) {
@@ -315,11 +314,11 @@ final class IntegralMutatorFactory extends MutatorFactory {
       if (maxValue / 2 - minValue / 2 <= RANDOM_WALK_RANGE) {
         value = prng.closedRange(minValue, maxValue);
       } else {
-        // At this point we know that (using non-wrapping arithmetic):
-        // RANDOM_WALK_RANGE < maxValue/2 - minValue/2 <= Long.MAX_VALUE/2 - minValue/2, hence
-        // minValue/2 + RANDOM_WALK_RANGE < Long.MAX_VALUE/2, hence
-        // minValue + 2*RANDOM_WALK_RANGE < Long.MAX_VALUE.
-        // In particular, minValue + RANDOM_WALK_RANGE can't overflow, likewise for maxValue.
+        // At this point we know that (using non-wrapping arithmetic): RANDOM_WALK_RANGE <
+        // maxValue/2 - minValue/2 <= Long.MAX_VALUE/2 - minValue/2 hence minValue/2 +
+        // RANDOM_WALK_RANGE < Long.MAX_VALUE/2, hence minValue + 2*RANDOM_WALK_RANGE <
+        // Long.MAX_VALUE. In particular, minValue + RANDOM_WALK_RANGE can't overflow, likewise for
+        // maxValue.
         long lower = minValue;
         if (value > lower + RANDOM_WALK_RANGE) {
           lower = value - RANDOM_WALK_RANGE;

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderAdapters.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderAdapters.java
@@ -43,9 +43,17 @@ final class BuilderAdapters {
       }
 
       @Override
-      public boolean add(U u) {
-        builder.addRepeatedField(field, u);
+      public boolean add(U element) {
+        builder.addRepeatedField(field, element);
         return true;
+      }
+
+      @Override
+      public void add(int index, U element) {
+        // TODO: Simply appending and ignoring the index is not perfect
+        // but it works. A future revision should try making this a proper
+        // append at the given index.
+        builder.addRepeatedField(field, element);
       }
 
       @Override

--- a/src/main/java/com/code_intelligence/jazzer/mutation/support/MutationAction.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/support/MutationAction.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.support;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public enum MutationAction {
+  SHRINK,
+  SHRINK_CHUNK,
+  GROW,
+  GROW_CHUNK,
+  CHANGE,
+  CHANGE_CHUNK;
+
+  public static List<MutationAction> getPossibleActions(Collection<?> c, int minSize, int maxSize) {
+    List<MutationAction> actions = new ArrayList<>();
+    if (c.size() > minSize) {
+      actions.add(SHRINK);
+      actions.add(SHRINK_CHUNK);
+    }
+    if (c.size() < maxSize) {
+      actions.add(GROW);
+      actions.add(GROW_CHUNK);
+    }
+    if (!c.isEmpty()) {
+      actions.add(CHANGE);
+      actions.add(CHANGE_CHUNK);
+    }
+    return actions;
+  }
+}

--- a/src/test/java/com/code_intelligence/jazzer/mutation/ArgumentsMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/ArgumentsMutatorTest.java
@@ -83,17 +83,17 @@ class ArgumentsMutatorTest {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first argument
              0,
-             // outer list not null
+             // Nullable mutator
              false,
-             // outer list mutate element
-             false,
-             // outer list mutate first element
+             // Action mutate in outer list
+             4,
+             // index to get to inner list
              0,
-             // inner list not null
+             // Nullable mutator
              false,
-             // inner list mutate element
-             false,
-             // inner list mutate first element
+             // Action mutate inner list
+             4,
+             // index to get boolean value
              0)) {
       mutator.mutate(prng);
     }
@@ -111,17 +111,17 @@ class ArgumentsMutatorTest {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first argument
              0,
-             // outer list not null
+             // Nullable mutator
              false,
-             // outer list mutate element
-             false,
-             // outer list mutate first element
+             // Action mutate in outer list
+             4,
+             // index to get to inner list
              0,
-             // inner list not null
+             // Nullable mutator
              false,
-             // inner list mutate element
-             false,
-             // inner list mutate first element
+             // Action mutate inner list
+             4,
+             // index to get boolean value
              0)) {
       mutator.mutate(prng);
     }
@@ -182,17 +182,17 @@ class ArgumentsMutatorTest {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first argument
              0,
-             // outer list not null
+             // Nullable mutator
              false,
-             // outer list mutate element
-             false,
-             // outer list mutate first element
+             // Action mutate in outer list
+             4,
+             // index to get to inner list
              0,
-             // inner list not null
+             // Nullable mutator
              false,
-             // inner list mutate element
-             false,
-             // inner list mutate first element
+             // Action mutate inner list
+             4,
+             // index to get boolean value
              0)) {
       mutator.mutate(prng);
     }
@@ -211,17 +211,17 @@ class ArgumentsMutatorTest {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first argument
              0,
-             // outer list not null
+             // Nullable mutator
              false,
-             // outer list mutate element
-             false,
-             // outer list mutate first element
+             // Action mutate in outer list
+             4,
+             // index to get to inner list
              0,
-             // inner list not null
+             // Nullable mutator
              false,
-             // inner list mutate element
-             false,
-             // inner list mutate first element
+             // Action mutate inner list
+             4,
+             // index to get boolean value
              0)) {
       mutator.mutate(prng);
     }

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.mutator.collection;
+
+import static com.code_intelligence.jazzer.mutation.support.TestSupport.mockPseudoRandom;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.code_intelligence.jazzer.mutation.annotation.NotNull;
+import com.code_intelligence.jazzer.mutation.annotation.WithSize;
+import com.code_intelligence.jazzer.mutation.api.MutatorFactory;
+import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
+import com.code_intelligence.jazzer.mutation.mutator.Mutators;
+import com.code_intelligence.jazzer.mutation.support.TestSupport.MockPseudoRandom;
+import com.code_intelligence.jazzer.mutation.support.TypeHolder;
+import java.lang.reflect.AnnotatedType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ListMutatorTest {
+  public static final MutatorFactory FACTORY = Mutators.newFactory();
+
+  @Test
+  void testInit() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    assertThat(mutator.toString()).isEqualTo("List<Integer>");
+
+    List<Integer> list;
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // targetSize
+             1,
+             // elementMutator.init
+             1)) {
+      list = mutator.init(prng);
+    }
+    assertThat(list).containsExactly(0);
+  }
+
+  @Test
+  void testInitMaxSize() {
+    AnnotatedType type =
+        new TypeHolder<@NotNull @WithSize(min = 2, max = 3) List<@NotNull Integer>>(){}
+            .annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    assertThat(mutator.toString()).isEqualTo("List<Integer>");
+    List<Integer> list;
+    try (MockPseudoRandom prng = mockPseudoRandom(2, 4, 42L, 4, 43L)) {
+      list = mutator.init(prng);
+    }
+
+    assertThat(list).containsExactly(42, 43);
+  }
+
+  @Test
+  void testRemoveSingleElement() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             0,
+             // index to remove
+             2)) {
+      list = mutator.mutate(list, prng);
+    }
+    assertThat(list).containsExactly(1, 2, 4, 5, 6, 7, 8, 9);
+  }
+
+  @Test
+  void testRemoveChunk() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             1,
+             // chunk size
+             2,
+             // chunk offset
+             3)) {
+      list = mutator.mutate(list, prng);
+    }
+
+    assertThat(list).containsExactly(1, 2, 3, 6, 7, 8, 9);
+  }
+
+  @Test
+  void testAddSingleElement() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             2,
+             // Integral initImpl sentinel value
+             4,
+             // value
+             42L)) {
+      list = mutator.mutate(list, prng);
+    }
+
+    assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 42);
+  }
+
+  @Test
+  void testAddChunk() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             3,
+             // chunkSize
+             2,
+             // chunkOffset
+             3,
+             // Integral initImpl
+             4,
+             // val
+             42L,
+             // same same
+             4, 43L)) {
+      list = mutator.mutate(list, prng);
+    }
+    assertThat(list).containsExactly(1, 2, 3, 42, 43, 4, 5, 6, 7, 8, 9);
+  }
+
+  @Test
+  void testChangeSingleElement() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             4,
+             // index to change
+             2,
+             // mutation choice based on `IntegralMutatorFactory`
+             // 2 == closedRange
+             2,
+             // value
+             55L)) {
+      list = mutator.mutate(list, prng);
+    }
+    assertThat(list).containsExactly(1, 2, 55, 4, 5, 6, 7, 8, 9);
+  }
+
+  @Test
+  void testChangeChunk() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             5,
+             // change offset
+             5,
+             // changes, ignored defaults to 2 due to list size
+             3,
+             // mutation: 0 == bitflip
+             0,
+             // shift constant
+             13,
+             // and again
+             0, 12)) {
+      list = mutator.mutate(list, prng);
+    }
+    assertThat(list).containsExactly(1, 2, 3, 4, 5, 8198, 4103, 8, 9, 10, 11);
+  }
+}

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto2Test.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto2Test.java
@@ -131,7 +131,9 @@ class BuilderMutatorProto2Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate the list itself by duplicating an entry
+             // mutate the list itself by adding an entry
+             2,
+             // value to add
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -140,14 +142,15 @@ class BuilderMutatorProto2Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate a list element,
-             false,
-             // mutate the second element,
+             // mutate the list itself by changing an entry
+             4,
+             // mutate the second element
              1)) {
       mutator.mutateInPlace(builder, prng);
     }
     assertThat(builder.getSomeFieldList()).containsExactly(true, false).inOrder();
   }
+
   @Test
   void testMessageField() {
     InPlaceMutator<MessageField2.Builder> mutator =
@@ -214,7 +217,11 @@ class BuilderMutatorProto2Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate the list itself by duplicating an entry
+             // mutate the list itself by adding an entry
+             2,
+             // Nullable mutator init
+             false,
+             // duplicate entry
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -244,7 +251,9 @@ class BuilderMutatorProto2Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate the list itself by duplicating an entry
+             // mutate the list itself by adding an entry
+             2,
+             // value to add
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -256,11 +265,11 @@ class BuilderMutatorProto2Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate a list element
-             false,
-             // mutate the second element
+             // change an entry
+             4,
+             // mutate the second element,
              1,
-             // mutate the first field
+             // mutate the first element
              0)) {
       mutator.mutateInPlace(builder, prng);
     }

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto3Test.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto3Test.java
@@ -141,8 +141,8 @@ class BuilderMutatorProto3Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate operation
-             false,
+             // change an entry
+             4,
              // mutate to first enum field
              0,
              // mutate to first enum value
@@ -221,7 +221,9 @@ class BuilderMutatorProto3Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate the list itself by duplicating an entry
+             // mutate the list itself by adding an element
+             2,
+             // value to add
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -230,8 +232,8 @@ class BuilderMutatorProto3Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate a list element,
-             false,
+             // mutate the list itself by changing an entry
+             4,
              // mutate the second element,
              1)) {
       mutator.mutateInPlace(builder, prng);
@@ -305,7 +307,9 @@ class BuilderMutatorProto3Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate the list itself by duplicating an entry
+             // mutate the list itself by adding an entry
+             2,
+             // value to add
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -317,11 +321,11 @@ class BuilderMutatorProto3Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate a list element
-             false,
-             // mutate the second element
+             // change an entry
+             4,
+             // mutate the second element,
              1,
-             // mutate the first field
+             // mutate the first element
              0)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -351,7 +355,8 @@ class BuilderMutatorProto3Test {
              true)) {
       mutator.initInPlace(builder, prng);
     }
-    // Nested message field is *not* set explicitly and implicitly equal to the default instance.
+    // Nested message field is *not* set explicitly and implicitly equal to the
+    // default instance.
     assertThat(builder.build())
         .isEqualTo(RecursiveMessageField3.newBuilder()
                        .setSomeField(true)
@@ -372,7 +377,8 @@ class BuilderMutatorProto3Test {
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
-    // Nested message field *is* set explicitly and implicitly equal to the default instance.
+    // Nested message field *is* set explicitly and implicitly equal to the default
+    // instance.
     assertThat(builder.build())
         .isEqualTo(RecursiveMessageField3.newBuilder()
                        .setSomeField(true)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -458,7 +458,7 @@ java_fuzz_target_test(
         "--custom_hook_includes=com.example.**",
     ] + select({
         # Limit runs to catch regressions in mutator efficiency and speed up test runs.
-        "@platforms//os:linux": ["-runs=40000"],
+        "@platforms//os:linux": ["-runs=100000"],
         # TODO: Investigate why this test takes far more runs on macOS, with Windows also being
         #       significantly worse than Linux.
         "//conditions:default": ["-runs=1200000"],


### PR DESCRIPTION
Improves the list mutator in a couple of ways:

* Gets rid of oscillation issues once `maxSize` is reached
* Every mutation is decided by a fair random pick
* Added chunk operations that complement the mutation of single elements