### PR TITLE
launcher: Use actual executable path instead of `argv[0]`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -18,6 +18,7 @@ pkg_tar(
         "@platforms//os:windows": ".\\",
         "//conditions:default": "./",
     }),
+    visibility = ["//tests:__pkg__"],
 )
 
 alias(

--- a/launcher/fuzzed_data_provider_test.cpp
+++ b/launcher/fuzzed_data_provider_test.cpp
@@ -39,7 +39,7 @@ class FuzzedDataProviderTest : public ::testing::Test {
     FLAGS_cp = Runfiles::CreateForTest()->Rlocation(
         "jazzer/launcher/testdata/fuzz_target_mocks_deploy.jar");
 
-    jvm_ = std::make_unique<JVM>("test_executable");
+    jvm_ = std::make_unique<JVM>();
   }
 
   static void TearDownTestCase() { jvm_.reset(nullptr); }

--- a/launcher/jazzer_main.cpp
+++ b/launcher/jazzer_main.cpp
@@ -104,6 +104,6 @@ int main(int argc, char **argv) {
     }
   }
 
-  StartLibFuzzer(std::unique_ptr<jazzer::JVM>(new jazzer::JVM(argv[0])),
+  StartLibFuzzer(std::unique_ptr<jazzer::JVM>(new jazzer::JVM()),
                  std::vector<std::string>(argv + 1, argv + argc));
 }

--- a/launcher/jvm_tooling.h
+++ b/launcher/jvm_tooling.h
@@ -40,7 +40,7 @@ class JVM {
  public:
   // Creates a JVM instance with default options + options that were provided as
   // command line flags.
-  explicit JVM(const std::string &executable_path);
+  explicit JVM();
 
   // Destroy the running JVM instance.
   ~JVM();

--- a/launcher/jvm_tooling_test.cpp
+++ b/launcher/jvm_tooling_test.cpp
@@ -39,7 +39,7 @@ class JvmToolingTest : public ::testing::Test {
     FLAGS_cp = Runfiles::CreateForTest()->Rlocation(
         "jazzer/launcher/testdata/fuzz_target_mocks_deploy.jar");
 
-    jvm_ = std::unique_ptr<JVM>(new JVM("test_executable"));
+    jvm_ = std::unique_ptr<JVM>(new JVM());
   }
 
   static void TearDownTestCase() { jvm_.reset(nullptr); }

--- a/src/main/java/com/code_intelligence/jazzer/Jazzer.java
+++ b/src/main/java/com/code_intelligence/jazzer/Jazzer.java
@@ -98,8 +98,8 @@ public class Jazzer {
       // is an unnecessary overhead.
       final boolean spawnsSubprocesses = args.stream().anyMatch(
           arg -> arg.startsWith("-fork=") || arg.startsWith("-jobs=") || arg.startsWith("-merge="));
-      String arg0 = spawnsSubprocesses ? prepareArgv0(new HashMap<>())
-                                       : "unused_report_a_bug_if_you_see_this";
+      // argv0 is printed by libFuzzer during reproduction, so have it contain "jazzer".
+      String arg0 = spawnsSubprocesses ? prepareArgv0(new HashMap<>()) : "jazzer";
       args = Stream.concat(Stream.of(arg0), args.stream()).collect(toList());
       exit(Driver.start(args, spawnsSubprocesses));
     }
@@ -234,6 +234,8 @@ public class Jazzer {
     String invocation = env.isEmpty() ? command : env + " " + command;
     String launcherContent = String.format(launcherTemplate, invocation);
 
+    // argv0 is printed by libFuzzer during reproduction, so have the launcher basename contain
+    // "jazzer".
     Path launcher;
     if (isAndroid()) {
       launcher = Files.createTempFile(

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -445,3 +445,13 @@ java_fuzz_target_test(
         "//tests/src/test/proto:simple_java_proto",
     ],
 )
+
+sh_test(
+    name = "jazzer_from_path_test",
+    srcs = ["src/test/shell/jazzer_from_path_test.sh"],
+    args = ["$(rlocationpath //:jazzer_release)"],
+    data = [
+        "//:jazzer_release",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)

--- a/tests/src/test/shell/jazzer_from_path_test.sh
+++ b/tests/src/test/shell/jazzer_from_path_test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2022 Code Intelligence GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify that the Jazzer launcher finds the jar when executed from PATH.
+
+
+# --- begin runfiles.bash initialization v3 ---
+# Copy-pasted from the Bazel Bash runfiles library v3.
+set -uo pipefail; set +e; f=bazel_tools/tools/bash/runfiles/runfiles.bash
+source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$0.runfiles/$f" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^$f " "$0.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo>&2 "ERROR: cannot find $f"; exit 1; }; f=; set -e
+# --- end runfiles.bash initialization v3 ---
+
+# Unpack the release archive to a temporary directory.
+jazzer_release="$(rlocation "$1")"
+tmp="$(mktemp -d)"
+trap 'rm -r "$tmp"' EXIT
+# GNU tar on Windows requires --force-local to support colons in archives names,
+# macOS tar does not support it.
+tar -xzf "$jazzer_release" -C "$tmp" --force-local || tar -xzf "$jazzer_release" -C "$tmp"
+
+# Add the Jazzer launcher to PATH first so that it is picked over host Jazzer
+# installations.
+PATH="$tmp:$PATH"
+export PATH
+
+jazzer --version


### PR DESCRIPTION
When Jazzer is executed from `PATH`, `argv[0]` will just be `jazzer`, which we can't find `jazzer_standalone.jar` relative to.

Also fix `argv[0]` in the case where no shell launcher is generated.

Fixes #641 