### PR TITLE
mutator: Fix computation of oneof subfield index

### DIFF
--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/BUILD.bazel
@@ -10,6 +10,7 @@ java_junit5_test(
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
+        "//src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto:proto2_java_proto",
         "//src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto:proto3_java_proto",
         "//src/test/java/com/code_intelligence/jazzer/mutation/support:test_support",
     ],

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -38,6 +38,7 @@ import com.code_intelligence.jazzer.mutation.api.PseudoRandom;
 import com.code_intelligence.jazzer.mutation.api.Serializer;
 import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
 import com.code_intelligence.jazzer.mutation.support.TypeHolder;
+import com.code_intelligence.jazzer.protobuf.Proto2.TestProtobuf;
 import com.code_intelligence.jazzer.protobuf.Proto3.BytesField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.DoubleField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.EnumField3;
@@ -66,7 +67,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -239,7 +239,10 @@ public class StressTest {
             "{Builder.Float} -> Message", manyDistinctElements(), distinctElementsRatio(0.99)),
         arguments(new TypeHolder<@NotNull RepeatedFloatField3>() {}.annotatedType(),
             "{Builder via List<Float>} -> Message", manyDistinctElements(),
-            distinctElementsRatio(0.99)));
+            distinctElementsRatio(0.99), emptyList()),
+        arguments(new TypeHolder<@NotNull TestProtobuf>() {}.annotatedType(),
+            "{Builder.Nullable<Boolean>, Builder.Nullable<Integer>, Builder.Nullable<Integer>, Builder.Nullable<Long>, Builder.Nullable<Long>, Builder.Nullable<Float>, Builder.Nullable<Double>, Builder.Nullable<String>, Builder.Nullable<Enum<Enum>>, Builder.Nullable<{Builder.Nullable<Integer>, Builder via List<Integer>} -> Message>, Builder via List<Boolean>, Builder via List<Integer>, Builder via List<Integer>, Builder via List<Long>, Builder via List<Long>, Builder via List<Float>, Builder via List<Double>, Builder via List<String>, Builder via List<Enum<Enum>>, Builder via List<(cycle) -> Message>, Builder.Map<Integer,Integer>, Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<{<empty>} -> Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> | Builder.Nullable<Integer>} -> Message",
+            manyDistinctElements(), manyDistinctElements()));
   }
 
   @SafeVarargs
@@ -333,6 +336,8 @@ public class StressTest {
     SerializingMutator mutator = Mutators.newFactory().createOrThrow(type);
     assertThat(mutator.toString()).isEqualTo(mutatorTree);
 
+    boolean mayPerformNoopMutations = mutatorTree.contains("FixedValue(");
+
     PseudoRandom rng = anyPseudoRandom();
 
     List<Object> initValues = new ArrayList<>();
@@ -348,7 +353,9 @@ public class StressTest {
       for (int mutation = 0; mutation < NUM_MUTATE_PER_INIT; mutation++) {
         Object detachedOldValue = mutator.detach(value);
         value = mutator.mutate(value, rng);
-        assertThat(value).isNotEqualTo(detachedOldValue);
+        if (!mayPerformNoopMutations) {
+          assertThat(value).isNotEqualTo(detachedOldValue);
+        }
 
         testReadWriteRoundtrip(mutator, value);
         testReadWriteExclusiveRoundtrip(mutator, value);

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto2.proto
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto2.proto
@@ -74,3 +74,58 @@ optional bytes some_field = 1;
 message StringField2 {
 optional string some_field = 1;
 }
+
+// Taken from
+// https://github.com/google/fuzztest/blob/c5fde4baee6134c84d4f2b618def9f60c7505151/fuzztest/internal/test_protobuf.proto#L24
+message TestSubProtobuf {
+  optional int32 subproto_i32 = 1;
+  repeated int32 subproto_rep_i32 = 2 [packed = true];
+}
+
+message TestProtobuf {
+  enum Enum {
+    Label1 = 0;
+    Label2 = 1;
+    Label3 = 2;
+    Label4 = 3;
+    Label5 = 4;
+  }
+
+  optional bool b = 1;
+  optional int32 i32 = 2;
+  optional uint32 u32 = 3;
+  optional int64 i64 = 4;
+  optional uint64 u64 = 5;
+  optional float f = 6;
+  optional double d = 7;
+  optional string str = 8;
+  optional Enum e = 9;
+  optional TestSubProtobuf subproto = 10;
+
+  repeated bool rep_b = 11;
+  repeated int32 rep_i32 = 12;
+  repeated uint32 rep_u32 = 13;
+  repeated int64 rep_i64 = 14;
+  repeated uint64 rep_u64 = 15;
+  repeated float rep_f = 16;
+  repeated double rep_d = 17;
+  repeated string rep_str = 18;
+  repeated Enum rep_e = 19;
+  repeated TestSubProtobuf rep_subproto = 20;
+
+  oneof oneof_field {
+    int32 oneof_i32 = 21;
+    int64 oneof_i64 = 22;
+    uint32 oneof_u32 = 24;
+  }
+
+  map<int32, int32> map_field = 25;
+
+  // Special cases
+  enum EnumOneLabel {
+    OnlyLabel = 17;
+  }
+  optional EnumOneLabel enum_one_label = 100;
+  message EmptyMessage {}
+  optional EmptyMessage empty_message = 101;
+}


### PR DESCRIPTION
The index obtained from the field descriptor was the index in the whole message, not necessarily the index in the oneof.