### PR TITLE
sanitizers: Reenable RCE reports for `readObject` calls

### DIFF
--- a/sanitizers/src/test/java/com/example/ObjectInputStreamDeserialization.java
+++ b/sanitizers/src/test/java/com/example/ObjectInputStreamDeserialization.java
@@ -22,7 +22,7 @@ public class ObjectInputStreamDeserialization {
   public static void fuzzerTestOneInput(byte[] data) {
     try {
       ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(data));
-      ois.readObject().toString();
+      ois.readObject();
     } catch (IOException | ClassNotFoundException ignored) {
       // Ignored checked exception.
     } catch (NullPointerException | NegativeArraySizeException ignored) {

--- a/src/main/java/jaz/Zer.java
+++ b/src/main/java/jaz/Zer.java
@@ -348,4 +348,14 @@ public class Zer
     reportFindingIfEnabled();
     return this;
   }
+
+  // readObject calls can directly result in RCE, see https://github.com/frohoff/ysoserial for
+  // examples. Since deserialization doesn't call constructors (see
+  // https://docs.oracle.com/javase/7/docs/platform/serialization/spec/input.html#2971), we emit a
+  // finding right in the readObject method.
+  private void readObject(ObjectInputStream stream) throws IOException, ClassNotFoundException {
+    // Need to read in ourselves to initialize the sanitizer field.
+    stream.defaultReadObject();
+    reportFindingIfEnabled();
+  }
 }


### PR DESCRIPTION
readObject calls can directly result in RCE, see https://github.com/frohoff/ysoserial for examples. Since deserialization doesn't call constructors (see https://docs.oracle.com/javase/7/docs/platform/serialization/spec/input.html#2971), we emit a finding right in the readObject method.