### PR TITLE
mutator: Use shorter initial sizes for byte arrays

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/ByteArrayMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/ByteArrayMutatorFactory.java
@@ -93,10 +93,23 @@ final class ByteArrayMutatorFactory extends MutatorFactory {
 
     @Override
     public byte[] init(PseudoRandom prng) {
-      int len = prng.closedRange(minLength, maxLength);
+      int len = prng.closedRange(minInitialSize(), maxInitialSize());
       byte[] bytes = new byte[len];
       prng.bytes(bytes);
       return bytes;
+    }
+
+    private int minInitialSize() {
+      return minLength;
+    }
+
+    private int maxInitialSize() {
+      // Allow some variation in length, but keep the initial elements well within reach of each
+      // other via a single mutation based on a Table of Recent Compares (ToRC) entry, which is
+      // currently limited to 64 bytes.
+      // Compared to List<T>, byte arrays can't result in recursive type hierarchies and thus don't
+      // to limit their expected initial size to be <= 1.
+      return Math.min(minLength + 16, maxLength);
     }
 
     @Override

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -108,7 +108,8 @@ public class StressTest {
             new TypeHolder<@NotNull Map<@NotNull String, @NotNull String>>() {}.annotatedType(),
             "Map<String,String>", distinctElementsRatio(0.45), distinctElementsRatio(0.45)),
         arguments(new TypeHolder<Map<@NotNull String, @NotNull String>>() {}.annotatedType(),
-            "Nullable<Map<String,String>>", manyDistinctElements(), manyDistinctElements()),
+            "Nullable<Map<String,String>>", distinctElementsRatio(0.48),
+            distinctElementsRatio(0.48)),
         arguments(
             new TypeHolder<@WithSize(
                 min = 1, max = 3) @NotNull Map<@NotNull Integer, @NotNull Integer>>() {
@@ -225,7 +226,7 @@ public class StressTest {
                 EnumFieldRepeated3.newBuilder().addSomeField(TestEnumRepeated.VAL2).build()),
             manyDistinctElements()),
         arguments(new TypeHolder<@NotNull MapField3>() {}.annotatedType(),
-            "{Builder.Map<Integer,String>} -> Message", distinctElementsRatio(0.49),
+            "{Builder.Map<Integer,String>} -> Message", distinctElementsRatio(0.475),
             manyDistinctElements()),
         arguments(new TypeHolder<@NotNull MessageMapField3>() {}.annotatedType(),
             "{Builder.Map<String,{Builder.Map<Integer,String>} -> Message>} -> Message",

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BUILD.bazel
@@ -20,7 +20,10 @@ proto_library(
 java_proto_library(
     name = "proto2_java_proto",
     testonly = True,
-    visibility = ["//src/test/java/com/code_intelligence/jazzer/mutation/mutator:__pkg__"],
+    visibility = [
+        "//src/test/java/com/code_intelligence/jazzer/mutation/mutator:__pkg__",
+        "//tests:__pkg__",
+    ],
     deps = [":proto2_proto"],
 )
 

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -437,12 +437,37 @@ java_fuzz_target_test(
         # TODO: Investigate whether we can automatically exclude protos.
         "--instrumentation_excludes=com.example.SimpleProto*",
         "--custom_hook_excludes=com.example.SimpleProto*",
+        # Limit runs to catch regressions in mutator efficiency and speed up test runs.
+        "-runs=40000",
     ],
     target_class = "com.example.ExperimentalMutatorFuzzer",
     verify_crash_reproducer = False,
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//tests/src/test/proto:simple_java_proto",
+    ],
+)
+
+java_fuzz_target_test(
+    name = "ExperimentalMutatorComplexProtoFuzzer",
+    srcs = ["src/test/java/com/example/ExperimentalMutatorComplexProtoFuzzer.java"],
+    allowed_findings = ["com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium"],
+    fuzzer_args = [
+        "--experimental_mutator",
+        "--instrumentation_includes=com.example.**",
+        "--custom_hook_includes=com.example.**",
+    ] + select({
+        # Limit runs to catch regressions in mutator efficiency and speed up test runs.
+        "@platforms//os:linux": ["-runs=40000"],
+        # TODO: Investigate why this test takes far more runs on macOS, with Windows also being
+        #       significantly worse than Linux.
+        "//conditions:default": ["-runs=1200000"],
+    }),
+    target_class = "com.example.ExperimentalMutatorComplexProtoFuzzer",
+    verify_crash_reproducer = False,
+    deps = [
+        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
+        "//src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto:proto2_java_proto",
     ],
 )
 

--- a/tests/src/test/java/com/example/ExperimentalMutatorComplexProtoFuzzer.java
+++ b/tests/src/test/java/com/example/ExperimentalMutatorComplexProtoFuzzer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
+import com.code_intelligence.jazzer.mutation.annotation.InRange;
+import com.code_intelligence.jazzer.mutation.annotation.NotNull;
+import com.code_intelligence.jazzer.protobuf.Proto2.TestProtobuf;
+
+public class ExperimentalMutatorComplexProtoFuzzer {
+  public static void fuzzerTestOneInput(@NotNull TestProtobuf proto) {
+    if (proto.getI32() == 1234 && proto.getStr().equals("abcd")) {
+      throw new FuzzerSecurityIssueMedium("Secret proto is found!");
+    }
+  }
+}


### PR DESCRIPTION
Without this change, the simple new fuzz test fails to find the planted bug. With this change, it finds it in less than 20,000 runs.