### PR TITLE
map mutator improvements

### DIFF
--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/MapMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/MapMutatorTest.java
@@ -61,34 +61,22 @@ class MapMutatorTest {
     assertThat(map).hasSize(1);
     assertThat(map.get("Key")).isEqualTo("Value");
 
-    // Add new entry
+    // Add new entry with a map size of 1
     try (MockPseudoRandom prng = mockPseudoRandom(
-             // Add new entry
-             true,
-             // New key size
-             3,
-             // Key value
-             "New".getBytes(),
-             // New value size
-             3,
-             // Value value
-             "New".getBytes())) {
+             // mutate entry, prng.choice()
+             true)) {
       map = mutator.mutate(map, prng);
     }
-    assertThat(map).hasSize(2);
-    assertThat(map.get("New")).isEqualTo("New");
+    assertThat(map).hasSize(1);
+    assertThat(map.get("New")).isEqualTo(null);
 
     // Mutate "New" entry
     try (MockPseudoRandom prng = mockPseudoRandom(
              // Mutate entry
-             false,
-             // Index
-             1,
-             // Mutate value
-             false)) {
+             true)) {
       map = mutator.mutate(map, prng);
     }
-    assertThat(map).hasSize(2);
+    assertThat(map).hasSize(1);
     assertThat(map.get("New")).isNotEqualTo("New");
   }
 
@@ -131,7 +119,7 @@ class MapMutatorTest {
     // Add new entry
     try (MockPseudoRandom prng = mockPseudoRandom(
              // Add new entry
-             true,
+             0,
              // New key size
              3,
              // Key value
@@ -147,14 +135,110 @@ class MapMutatorTest {
 
     // Remove one as max size reached
     try (MockPseudoRandom prng = mockPseudoRandom(
-             // Add new entry
-             true,
-             // "Index" to remove
+             // Remove an entry
+             0,
+             // skip keys
              1)) {
       map = mutator.mutate(map, prng);
     }
     assertThat(map).hasSize(2);
     assertThat(map).containsKey("Key1");
     assertThat(map).containsKey("New");
+  }
+
+  @Test
+  void mapMutateChunks() {
+    AnnotatedType type = new TypeHolder<@NotNull @WithSize(
+        min = 2, max = 6) Map<@NotNull String, @NotNull String>>(){}
+                             .annotatedType();
+    SerializingMutator<Map<String, String>> mutator =
+        (SerializingMutator<Map<String, String>>) FACTORY.createOrThrow(type);
+    assertThat(mutator.toString()).isEqualTo("Map<String,String>");
+
+    // Initialize new map with min size
+    Map<String, String> map;
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // Initial map size
+             2,
+             // Key 1 size
+             4,
+             // Key 1 value
+             "Key1".getBytes(),
+             // Value size
+             6,
+             // Value value
+             "Value1".getBytes(),
+             // Key 2 size
+             4,
+             // Key 2 value
+             "Key2".getBytes(),
+             // Value size
+             6,
+             // Value value
+             "Value2".getBytes())) {
+      map = mutator.init(prng);
+    }
+    assertThat(map).hasSize(2);
+    assertThat(map).containsEntry("Key1", "Value1");
+    assertThat(map).containsEntry("Key2", "Value2");
+
+    // Add 2 new entries
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // grow chunk
+             1,
+             // ChunkSize
+             2,
+             // Key 3 size
+             4,
+             // Key 3 value
+             "Key3".getBytes(),
+             // Value size
+             6,
+             // Value value
+             "Value3".getBytes(),
+             // Key 4 size
+             4,
+             // Key 4 value
+             "Key4".getBytes(),
+             // Value size
+             6,
+             // Value value
+             "Value4".getBytes())) {
+      map = mutator.mutate(map, prng);
+    }
+    assertThat(map).hasSize(4);
+    assertThat(map).containsEntry("Key1", "Value1");
+    assertThat(map).containsEntry("Key2", "Value2");
+    assertThat(map).containsEntry("Key3", "Value3");
+    assertThat(map).containsEntry("Key4", "Value4");
+
+    // Mutate 2 entries
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // change chunk
+             5,
+             // ChunkOffset
+             2,
+             // ChunkSize (ignored)
+             2,
+             // mutateElement
+             true)) {
+      map = mutator.mutate(map, prng);
+    }
+    assertThat(map).hasSize(4);
+    assertThat(map).containsEntry("Key1", "Value1");
+    assertThat(map).containsEntry("Key2", "Value2");
+    assertThat(map.keySet().toArray()[3]).isNotEqualTo("Key4");
+
+    // Delete 2 entries
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // shrink chunk
+             1,
+             // ChunkSize
+             2,
+             // ChunkOffset
+             1)) {
+      map = mutator.mutate(map, prng);
+    }
+    assertThat(map).hasSize(2);
   }
 }


### PR DESCRIPTION
This changes the map size handling similar to what was done in #675 to prevent the oscillation around `maxSize` by doing a fair random pick of the mutation operator