### PR TITLE
mutator: Add AnySource annotation

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto/AnySource.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto/AnySource.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.annotation.proto;
+
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import com.code_intelligence.jazzer.mutation.annotation.AppliesTo;
+import com.google.protobuf.Message;
+import com.google.protobuf.Message.Builder;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Controls the mutations of {@link com.google.protobuf.Any} fields in messages of the annotated
+ * type as well as its recursive message fields.
+ */
+@Target(TYPE_USE)
+@Retention(RUNTIME)
+@AppliesTo(subClassesOf = {Message.class, Builder.class})
+public @interface AnySource {
+  /**
+   * A non-empty list of {@link Message}s to use for {@link com.google.protobuf.Any} fields.
+   */
+  Class<? extends Message>[] value();
+}

--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto/BUILD.bazel
@@ -1,0 +1,21 @@
+java_library(
+    name = "proto",
+    srcs = glob(["*.java"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        ":protobuf_runtime_compile_only",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
+    ],
+)
+
+java_library(
+    name = "protobuf_runtime_compile_only",
+    # The proto mutator factory detects the presence of Protobuf at runtime and disables itself if
+    # it isn't found. Without something else bringing in the Protobuf runtime, there is no point in
+    # supporting proto mutations.
+    neverlink = True,
+    visibility = ["//src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto:__pkg__"],
+    exports = [
+        "@com_google_protobuf_protobuf_java//jar",
+    ],
+)

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BUILD.bazel
@@ -6,21 +6,11 @@ java_library(
         "//src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto:__pkg__",
     ],
     deps = [
-        ":protobuf_runtime_compile_only",
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto:protobuf_runtime_compile_only",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
         "//src/main/java/com/code_intelligence/jazzer/mutation/combinator",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
-    ],
-)
-
-java_library(
-    name = "protobuf_runtime_compile_only",
-    # The proto mutator factory detects the presence of Protobuf at runtime and disables itself if
-    # it isn't found. Without something else bringing in the Protobuf runtime, there is no point in
-    # supporting proto mutations.
-    neverlink = True,
-    exports = [
-        "@com_google_protobuf_protobuf_java//jar",
     ],
 )

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorFactory.java
@@ -168,26 +168,6 @@ public final class BuilderMutatorFactory extends MutatorFactory {
     }
   }
 
-  private static <T extends Builder> Message getDefaultInstance(Class<T> builderClass) {
-    Class<?> messageClass = builderClass.getEnclosingClass();
-    Method getDefaultInstance;
-    try {
-      getDefaultInstance = messageClass.getMethod("getDefaultInstance");
-      check(Modifier.isStatic(getDefaultInstance.getModifiers()));
-    } catch (NoSuchMethodException e) {
-      throw new IllegalStateException(
-          format("Message class for builder type %s does not have a getDefaultInstance method",
-              builderClass),
-          e);
-    }
-    try {
-      return (Message) getDefaultInstance.invoke(null);
-    } catch (IllegalAccessException | InvocationTargetException e) {
-      throw new IllegalStateException(
-          format(getDefaultInstance + " isn't accessible or threw an exception"), e);
-    }
-  }
-
   private static Serializer<Builder> makeBuilderSerializer(Message defaultInstance) {
     return new Serializer<Builder>() {
       @Override

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/BUILD.bazel
@@ -16,11 +16,13 @@ java_junit5_test(
     tags = ["cpu:" + str(TEST_PARALLELISM)],
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
         "//src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto:proto2_java_proto",
         "//src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto:proto3_java_proto",
         "//src/test/java/com/code_intelligence/jazzer/mutation/support:test_support",
+        "@com_google_protobuf_protobuf_java//jar",
     ],
 )

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -34,11 +34,13 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import com.code_intelligence.jazzer.mutation.annotation.InRange;
 import com.code_intelligence.jazzer.mutation.annotation.NotNull;
 import com.code_intelligence.jazzer.mutation.annotation.WithSize;
+import com.code_intelligence.jazzer.mutation.annotation.proto.AnySource;
 import com.code_intelligence.jazzer.mutation.api.PseudoRandom;
 import com.code_intelligence.jazzer.mutation.api.Serializer;
 import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
 import com.code_intelligence.jazzer.mutation.support.TypeHolder;
 import com.code_intelligence.jazzer.protobuf.Proto2.TestProtobuf;
+import com.code_intelligence.jazzer.protobuf.Proto3.AnyField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.BytesField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.DoubleField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.EnumField3;
@@ -48,13 +50,16 @@ import com.code_intelligence.jazzer.protobuf.Proto3.EnumFieldRepeated3.TestEnumR
 import com.code_intelligence.jazzer.protobuf.Proto3.FloatField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.IntegralField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.MapField3;
+import com.code_intelligence.jazzer.protobuf.Proto3.MessageField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.MessageMapField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.OptionalPrimitiveField3;
+import com.code_intelligence.jazzer.protobuf.Proto3.PrimitiveField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedDoubleField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedFloatField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedIntegralField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedRecursiveMessageField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.StringField3;
+import com.google.protobuf.Any;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -243,7 +248,56 @@ public class StressTest {
             distinctElementsRatio(0.99), emptyList()),
         arguments(new TypeHolder<@NotNull TestProtobuf>() {}.annotatedType(),
             "{Builder.Nullable<Boolean>, Builder.Nullable<Integer>, Builder.Nullable<Integer>, Builder.Nullable<Long>, Builder.Nullable<Long>, Builder.Nullable<Float>, Builder.Nullable<Double>, Builder.Nullable<String>, Builder.Nullable<Enum<Enum>>, Builder.Nullable<{Builder.Nullable<Integer>, Builder via List<Integer>} -> Message>, Builder via List<Boolean>, Builder via List<Integer>, Builder via List<Integer>, Builder via List<Long>, Builder via List<Long>, Builder via List<Float>, Builder via List<Double>, Builder via List<String>, Builder via List<Enum<Enum>>, Builder via List<(cycle) -> Message>, Builder.Map<Integer,Integer>, Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<{<empty>} -> Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> | Builder.Nullable<Integer>} -> Message",
-            manyDistinctElements(), manyDistinctElements()));
+            manyDistinctElements(), manyDistinctElements()),
+        arguments(
+            new TypeHolder<@NotNull @AnySource(
+                {PrimitiveField3.class, MessageField3.class}) AnyField3>() {
+            }.annotatedType(),
+            "{Builder.Nullable<Builder.{Builder.Boolean} -> Message | Builder.{Builder.Nullable<(cycle) -> Message>} -> Message -> Message>} -> Message",
+            exactly(AnyField3.getDefaultInstance(),
+                AnyField3.newBuilder()
+                    .setSomeField(Any.pack(PrimitiveField3.getDefaultInstance()))
+                    .build(),
+                AnyField3.newBuilder()
+                    .setSomeField(Any.pack(PrimitiveField3.newBuilder().setSomeField(true).build()))
+                    .build(),
+                AnyField3.newBuilder()
+                    .setSomeField(Any.pack(MessageField3.getDefaultInstance()))
+                    .build(),
+                AnyField3.newBuilder()
+                    .setSomeField(
+                        Any.pack(MessageField3.newBuilder()
+                                     .setMessageField(PrimitiveField3.getDefaultInstance())
+                                     .build()))
+                    .build(),
+                AnyField3.newBuilder()
+                    .setSomeField(Any.pack(
+                        MessageField3.newBuilder()
+                            .setMessageField(PrimitiveField3.newBuilder().setSomeField(true))
+                            .build()))
+                    .build()),
+            exactly(AnyField3.getDefaultInstance(),
+                AnyField3.newBuilder()
+                    .setSomeField(Any.pack(PrimitiveField3.getDefaultInstance()))
+                    .build(),
+                AnyField3.newBuilder()
+                    .setSomeField(Any.pack(PrimitiveField3.newBuilder().setSomeField(true).build()))
+                    .build(),
+                AnyField3.newBuilder()
+                    .setSomeField(Any.pack(MessageField3.getDefaultInstance()))
+                    .build(),
+                AnyField3.newBuilder()
+                    .setSomeField(
+                        Any.pack(MessageField3.newBuilder()
+                                     .setMessageField(PrimitiveField3.getDefaultInstance())
+                                     .build()))
+                    .build(),
+                AnyField3.newBuilder()
+                    .setSomeField(Any.pack(
+                        MessageField3.newBuilder()
+                            .setMessageField(PrimitiveField3.newBuilder().setSomeField(true))
+                            .build()))
+                    .build())));
   }
 
   @SafeVarargs

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BUILD.bazel
@@ -3,6 +3,9 @@ load("@contrib_rules_jvm//java:defs.bzl", "java_test_suite")
 proto_library(
     name = "proto3_proto",
     srcs = ["proto3.proto"],
+    deps = [
+        "@com_google_protobuf//:any_proto",
+    ],
 )
 
 java_proto_library(
@@ -36,6 +39,7 @@ java_test_suite(
         ":proto2_java_proto",
         ":proto3_java_proto",
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang",

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
@@ -14,6 +14,8 @@
 
 syntax = "proto3";
 
+import "google/protobuf/any.proto";
+
 option java_package = "com.code_intelligence.jazzer.protobuf";
 
 message PrimitiveField3 {
@@ -130,3 +132,7 @@ message RepeatedDoubleField3 {
 }
 
 message EmptyMessage3 {}
+
+message AnyField3 {
+  google.protobuf.Any some_field = 1;
+}


### PR DESCRIPTION
The annotation controls the message types used for Any proto fields in (recursive) submessages.

This requires passing the annotation through to message field types as well as extending the mutator cache key to cover the annotation value.