### PR TITLE
bazel: Run all formatters with Bazel

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -92,3 +92,8 @@ coverage --repo_env=GCOV=llvm-profdata
 # Instrument all source files of non-test targets matching at least one of these regexes.
 coverage --instrumentation_filter=^//src/main[:/],^//sanitizers/src/main[:/]
 coverage --test_tag_filters=-no-coverage
+
+# Hide all non-structured output in scripts.
+# https://github.com/bazelbuild/bazel/issues/4867#issuecomment-830402410
+common:quiet --ui_event_filters=-info,-stderr
+common:quiet --noshow_progress

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -29,7 +29,6 @@ jobs:
           sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
           sudo apt-get install clang-format-14
           go install github.com/google/addlicense@latest
-          go install github.com/bazelbuild/buildtools/buildifier@latest
 
       - name: Run format.sh and print changes
         env:

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -17,15 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Go environment
-        uses: actions/setup-go@v3
-        with:
-          go-version: 'stable'
-
-      - name: Install formatters
-        run: |
-          go install github.com/google/addlicense@latest
-
       - name: Run format.sh and print changes
         env:
           CI: 1

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -28,11 +28,12 @@ jobs:
           sudo apt-get install software-properties-common
           sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
           sudo apt-get install clang-format-14
-          curl -sSLO https://github.com/pinterest/ktlint/releases/download/0.48.0/ktlint && chmod a+x ktlint && sudo mv ktlint /usr/bin/ktlint
           go install github.com/google/addlicense@latest
           go install github.com/bazelbuild/buildtools/buildifier@latest
 
       - name: Run format.sh and print changes
+        env:
+          CI: 1
         run: |
           ./format.sh
           clang-format --version

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -24,10 +24,6 @@ jobs:
 
       - name: Install formatters
         run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo apt-get install software-properties-common
-          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
-          sudo apt-get install clang-format-14
           go install github.com/google/addlicense@latest
 
       - name: Run format.sh and print changes
@@ -35,7 +31,6 @@ jobs:
           CI: 1
         run: |
           ./format.sh
-          clang-format --version
           git diff
 
       - name: Check for changes

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -28,6 +28,15 @@ alias(
     actual = "//launcher:jazzer",
 )
 
+alias(
+    name = "addlicense",
+    actual = select({
+        "@platforms//os:macos": "@addlicense-darwin-universal//file:addlicense",
+        "@platforms//os:linux": "@addlicense-linux-amd64//file:addlicense",
+    }),
+    tags = ["manual"],
+)
+
 BUILDIFIER_EXCLUDE_PATTERNS = [
     "./.git/*",
     "./.ijwb/*",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -51,6 +51,15 @@ buildifier_test(
     workspace = "//:WORKSPACE.bazel",
 )
 
+alias(
+    name = "clang-format",
+    actual = select({
+        "@platforms//os:macos": "@clang-format-15-darwin-x64//file:clang-format",
+        "@platforms//os:linux": "@clang-format-15-linux-x64//file:clang-format",
+    }),
+    tags = ["manual"],
+)
+
 platform(
     name = "android_arm64",
     constraint_values = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,6 @@
+load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//bazel:compat.bzl", "SKIP_ON_WINDOWS")
 
 exports_files(["LICENSE"])
 
@@ -24,6 +26,29 @@ pkg_tar(
 alias(
     name = "jazzer",
     actual = "//launcher:jazzer",
+)
+
+BUILDIFIER_EXCLUDE_PATTERNS = [
+    "./.git/*",
+    "./.ijwb/*",
+    "./.clwb/*",
+]
+
+buildifier(
+    name = "buildifier",
+    diff_command = "diff -u",
+    exclude_patterns = BUILDIFIER_EXCLUDE_PATTERNS,
+    mode = "fix",
+    tags = ["manual"],
+)
+
+buildifier_test(
+    name = "buildifier_test",
+    diff_command = "diff -u",
+    exclude_patterns = BUILDIFIER_EXCLUDE_PATTERNS,
+    no_sandbox = True,
+    target_compatible_with = SKIP_ON_WINDOWS,
+    workspace = "//:WORKSPACE.bazel",
 )
 
 platform(

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,6 @@ $ bazel test //...
 ### Formatting
 
 Run `./format.sh` to format all source files in the way enforced by the "Check formatting" CI job.
-See [check-formatting.yml](.github/workflows/check-formatting.yml) for how to obtain the particular versions of the required formatting tools.
 
 ## Releasing (CI employees only)
 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -227,3 +227,23 @@ bazel_skylib_workspace()
 load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
 
 buildifier_prebuilt_register_toolchains()
+
+http_file(
+    name = "clang-format-15-darwin-x64",
+    downloaded_file_path = "clang-format",
+    executable = True,
+    sha256 = "97116f64d97fb2870b4aa29758bba8fb0fe7f3b1ed8a4bc12faa927ecfdec196",
+    urls = [
+        "https://github.com/angular/clang-format/raw/master/bin/darwin_x64/clang-format",
+    ],
+)
+
+http_file(
+    name = "clang-format-15-linux-x64",
+    downloaded_file_path = "clang-format",
+    executable = True,
+    sha256 = "050c600256e225eabe9608d28f492fe8673c6e7f5deac59c6da973223c764d6c",
+    urls = [
+        "https://github.com/angular/clang-format/raw/master/bin/linux_x64/clang-format",
+    ],
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -206,3 +206,24 @@ android_configure(name = "configure_android_rules")
 load("@configure_android_rules//:android_configure.bzl", "android_workspace")
 
 android_workspace()
+
+http_archive(
+    name = "buildifier_prebuilt",
+    sha256 = "7015c623143084bbdb3d2bb955087deb7cbb8e4806df457f3340d64b6eda876e",
+    strip_prefix = "buildifier-prebuilt-5b6adef925e98f90305d69de6d7ad70dd512c4ee",
+    urls = [
+        "https://github.com/keith/buildifier-prebuilt/archive/5b6adef925e98f90305d69de6d7ad70dd512c4ee.tar.gz",
+    ],
+)
+
+load("@buildifier_prebuilt//:deps.bzl", "buildifier_prebuilt_deps")
+
+buildifier_prebuilt_deps()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
+load("@buildifier_prebuilt//:defs.bzl", "buildifier_prebuilt_register_toolchains")
+
+buildifier_prebuilt_register_toolchains()

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -247,3 +247,23 @@ http_file(
         "https://github.com/angular/clang-format/raw/master/bin/linux_x64/clang-format",
     ],
 )
+
+http_file(
+    name = "addlicense-darwin-universal",
+    downloaded_file_path = "addlicense",
+    executable = True,
+    sha256 = "9c08964e15d6ed0568c4e8a5f861bcc2122498419586fbe87e08add56d18762d",
+    urls = [
+        "https://github.com/CodeIntelligenceTesting/addlicense/releases/download/v1.1.1/addlicense-darwin-universal",
+    ],
+)
+
+http_file(
+    name = "addlicense-linux-amd64",
+    downloaded_file_path = "addlicense",
+    executable = True,
+    sha256 = "521e680ff085f511d760aa139a0e869238ab4c936e89d258ac3432147d9e8be9",
+    urls = [
+        "https://github.com/CodeIntelligenceTesting/addlicense/releases/download/v1.1.1/addlicense-linux-amd64",
+    ],
+)

--- a/bazel/kotlin.bzl
+++ b/bazel/kotlin.bzl
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@io_bazel_rules_kotlin//kotlin:lint.bzl", "ktlint_fix", "ktlint_test")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test")
+load("//bazel:compat.bzl", "SKIP_ON_WINDOWS")
 
 # A kt_jvm_test wrapped in a java_test for Windows compatibility.
 # Workaround for https://github.com/bazelbuild/rules_kotlin/issues/599: rules_kotlin can only create
@@ -48,4 +50,19 @@ def wrapped_kt_jvm_test(
         runtime_deps = [
             ":" + kt_jvm_test_name,
         ],
+    )
+
+def ktlint(name = "ktlint"):
+    ktlint_test(
+        name = name + "_test",
+        srcs = native.glob(["**/*.kt"]),
+        config = Label("//bazel/toolchains:ktlint_config"),
+        target_compatible_with = SKIP_ON_WINDOWS,
+    )
+
+    ktlint_fix(
+        name = name + "_fix",
+        srcs = native.glob(["**/*.kt"]),
+        config = Label("//bazel/toolchains:ktlint_config"),
+        target_compatible_with = SKIP_ON_WINDOWS,
     )

--- a/bazel/toolchains/BUILD.bazel
+++ b/bazel/toolchains/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "NONPREBUILT_TOOLCHAIN_CONFIGURATION", "default_java_toolchain")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain")
+load("@io_bazel_rules_kotlin//kotlin:lint.bzl", "ktlint_config")
 load("@io_bazel_rules_kotlin//kotlin/internal:opts.bzl", "kt_javac_options", "kt_kotlinc_options")
 
 default_java_toolchain(
@@ -22,4 +23,10 @@ define_kt_toolchain(
     jvm_target = "1.8",
     kotlinc_options = ":kotlinc_options",
     language_version = "1.5",
+)
+
+ktlint_config(
+    name = "ktlint_config",
+    editorconfig = "editorconfig.ktlint",
+    visibility = ["//visibility:public"],
 )

--- a/bazel/toolchains/editorconfig.ktlint
+++ b/bazel/toolchains/editorconfig.ktlint
@@ -1,0 +1,2 @@
+[*.kt]
+ktlint_standard_package-name=disabled

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("@fmeum_rules_jni//jni:defs.bzl", "java_jni_library")
 load("//bazel:compat.bzl", "SKIP_ON_MACOS", "SKIP_ON_WINDOWS")
 load("//bazel:fuzz_target.bzl", "java_fuzz_target_test")
+load("//bazel:kotlin.bzl", "ktlint")
 
 java_fuzz_target_test(
     name = "Autofuzz",
@@ -429,3 +430,5 @@ java_binary(
         ":JsonSanitizerDenylistFuzzer_target_deploy.jar",
     ],
 )
+
+ktlint()

--- a/format.sh
+++ b/format.sh
@@ -16,12 +16,14 @@
 
 set -euo pipefail
 
+THIS_DIR="$(pwd -P)"
+
 # C++ & Java
 find -name '*.cpp' -o -name '*.c' -o -name '*.h' -o -name '*.java' | xargs clang-format-14 -i
 
-# Kotlin
-# No need to run in CI as the ktlint_tests will fail if the formatting is wrong.
+# No need to run in CI as these formatters have corresponding Bazel tests.
 if [[ "${CI:-0}" == 0 ]]; then
+    # Kotlin
     # Check which ktlint_tests failed and run the corresponding fix targets. This is much faster than
     # running all ktlint_fix targets when e.g. only a few or no .kt files changed.
     # shellcheck disable=SC2046
@@ -29,11 +31,10 @@ if [[ "${CI:-0}" == 0 ]]; then
     if [[ -n "${TARGETS_TO_RUN}" ]]; then
         echo "$TARGETS_TO_RUN" | xargs -n 1 bazel run --config=quiet
     fi
-fi
 
-# BUILD files
-# go install github.com/bazelbuild/buildtools/buildifier@latest
-buildifier -r .
+    # BUILD files
+    bazel run --config=quiet //:buildifier -- -r "$THIS_DIR"
+fi
 
 # Licence headers
 # go install github.com/google/addlicense@latest

--- a/format.sh
+++ b/format.sh
@@ -18,6 +18,9 @@ set -euo pipefail
 
 THIS_DIR="$(pwd -P)"
 
+# Licence headers
+bazel run --config=quiet //:addlicense -- -c "Code Intelligence GmbH" -ignore '**/third_party/**' -ignore '**/.github/**' "$THIS_DIR"
+
 # C++ & Java
 find "$THIS_DIR" \( -name '*.cpp' -o -name '*.c' -o -name '*.h' -o -name '*.java' \) -print0 | xargs -0 bazel run --config=quiet //:clang-format -- -i
 
@@ -35,7 +38,3 @@ if [[ "${CI:-0}" == 0 ]]; then
     # BUILD files
     bazel run --config=quiet //:buildifier -- -r "$THIS_DIR"
 fi
-
-# Licence headers
-# go install github.com/google/addlicense@latest
-addlicense -c "Code Intelligence GmbH" bazel/ deploy/ docker/ examples/ sanitizers/ src/ tests/ *.bzl

--- a/format.sh
+++ b/format.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 THIS_DIR="$(pwd -P)"
 
 # C++ & Java
-find -name '*.cpp' -o -name '*.c' -o -name '*.h' -o -name '*.java' | xargs clang-format-14 -i
+find "$THIS_DIR" \( -name '*.cpp' -o -name '*.c' -o -name '*.h' -o -name '*.java' \) -print0 | xargs -0 bazel run --config=quiet //:clang-format -- -i
 
 # No need to run in CI as these formatters have corresponding Bazel tests.
 if [[ "${CI:-0}" == 0 ]]; then

--- a/format.sh
+++ b/format.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2023 Code Intelligence GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 set -euo pipefail
 

--- a/launcher/android/AndroidManifest.xml
+++ b/launcher/android/AndroidManifest.xml
@@ -1,3 +1,19 @@
+<!--
+ Copyright 2023 Code Intelligence GmbH
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.code_intelligence.jazzer"
     android:versionCode="1"

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BUILD.bazel
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("//bazel:kotlin.bzl", "ktlint")
 load("//sanitizers:sanitizers.bzl", "SANITIZER_CLASSES")
 
 java_library(
@@ -62,3 +63,5 @@ write_file(
         "}",
     ],
 )
+
+ktlint()

--- a/src/jmh/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
+++ b/src/jmh/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@fmeum_rules_jni//jni:defs.bzl", "java_jni_library")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("//bazel:kotlin.bzl", "ktlint")
 load("//src/jmh/java/com/code_intelligence/jazzer:jmh.bzl", "JMH_TEST_ARGS")
 
 java_binary(
@@ -100,3 +101,5 @@ java_jni_library(
         "@maven//:org_openjdk_jmh_jmh_core",
     ],
 )
+
+ktlint()

--- a/src/main/java/com/code_intelligence/jazzer/agent/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/agent/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("//bazel:kotlin.bzl", "ktlint")
 
 java_library(
     name = "agent_installer",
@@ -32,3 +33,5 @@ kt_jvm_library(
         "@com_github_classgraph_classgraph//:classgraph",
     ],
 )
+
+ktlint()

--- a/src/main/java/com/code_intelligence/jazzer/driver/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/driver/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@fmeum_rules_jni//jni:defs.bzl", "java_jni_library")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("//bazel:kotlin.bzl", "ktlint")
 
 java_library(
     name = "constants",
@@ -166,3 +167,5 @@ java_jni_library(
     visibility = ["//src/main/native/com/code_intelligence/jazzer/driver:__pkg__"],
     deps = [":opt"],
 )
+
+ktlint()

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("//bazel:kotlin.bzl", "ktlint")
 
 kt_jvm_library(
     name = "instrumentor",
@@ -36,3 +37,5 @@ kt_jvm_library(
         "@org_ow2_asm_asm_tree//jar",
     ],
 )
+
+ktlint()

--- a/src/main/java/com/code_intelligence/jazzer/utils/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/utils/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+load("//bazel:kotlin.bzl", "ktlint")
 
 kt_jvm_library(
     name = "utils",
@@ -53,3 +54,5 @@ java_library(
     srcs = ["ZipUtils.java"],
     visibility = ["//visibility:public"],
 )
+
+ktlint()

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:kotlin.bzl", "wrapped_kt_jvm_test")
+load("//bazel:kotlin.bzl", "ktlint", "wrapped_kt_jvm_test")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 kt_jvm_library(
@@ -148,3 +148,5 @@ wrapped_kt_jvm_test(
         "@maven//:junit_junit",
     ],
 )
+
+ktlint()

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -2,6 +2,7 @@ load("@fmeum_rules_jni//jni:defs.bzl", "java_jni_library")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 load("//bazel:compat.bzl", "LINUX_ONLY", "SKIP_ON_MACOS", "SKIP_ON_WINDOWS")
 load("//bazel:fuzz_target.bzl", "java_fuzz_target_test")
+load("//bazel:kotlin.bzl", "ktlint")
 
 java_fuzz_target_test(
     name = "LongStringFuzzer",
@@ -480,3 +481,5 @@ sh_test(
         "@bazel_tools//tools/bash/runfiles",
     ],
 )
+
+ktlint()

--- a/third_party/jacoco_internal.BUILD
+++ b/third_party/jacoco_internal.BUILD
@@ -3,12 +3,12 @@ load("@com_github_johnynek_bazel_jar_jar//:jar_jar.bzl", "jar_jar")
 java_import(
     name = "jacoco_internal",
     jars = ["jacoco_internal_shaded.jar"],
+    visibility = ["//visibility:public"],
     deps = [
         "@org_ow2_asm_asm//jar",
         "@org_ow2_asm_asm_commons//jar",
         "@org_ow2_asm_asm_tree//jar",
     ],
-    visibility = ["//visibility:public"],
 )
 
 jar_jar(
@@ -22,13 +22,13 @@ java_library(
     srcs = glob([
         "org.jacoco.core/src/org/jacoco/core/**/*.java",
     ]),
-    resources = glob([
-        "org.jacoco.core/src/org/jacoco/core/**/*.properties",
-    ]),
     javacopts = [
         "-Xep:EqualsHashCode:OFF",
         "-Xep:ReturnValueIgnored:OFF",
     ],
+    resources = glob([
+        "org.jacoco.core/src/org/jacoco/core/**/*.properties",
+    ]),
     deps = [
         "@org_ow2_asm_asm//jar",
         "@org_ow2_asm_asm_commons//jar",

--- a/third_party/libFuzzer.BUILD
+++ b/third_party/libFuzzer.BUILD
@@ -1,8 +1,11 @@
 cc_library(
     name = "libfuzzer_no_main",
-    srcs = glob([
-        "*.cpp",
-    ], exclude = ["FuzzerMain.cpp"]),
+    srcs = glob(
+        [
+            "*.cpp",
+        ],
+        exclude = ["FuzzerMain.cpp"],
+    ),
     hdrs = glob([
         "*.h",
         "*.def",
@@ -31,7 +34,7 @@ cc_library(
             "-std=c++17",
         ],
     }),
-    alwayslink = True,
     linkstatic = True,
     visibility = ["//visibility:public"],
+    alwayslink = True,
 )


### PR DESCRIPTION
This speeds up the format script and reduces the number of tools developers need to have installed locally.