### PR TITLE
autofuzz: Fix logs for bug detector findings

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/api/AutofuzzInvocationException.java
+++ b/src/main/java/com/code_intelligence/jazzer/api/AutofuzzInvocationException.java
@@ -20,6 +20,10 @@ package com.code_intelligence.jazzer.api;
  * Only used internally.
  */
 public class AutofuzzInvocationException extends RuntimeException {
+  public AutofuzzInvocationException() {
+    super();
+  }
+
   public AutofuzzInvocationException(Throwable cause) {
     super(cause);
   }

--- a/src/main/java/com/code_intelligence/jazzer/autofuzz/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/autofuzz/BUILD.bazel
@@ -11,6 +11,7 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/api",
+        "//src/main/java/com/code_intelligence/jazzer/runtime:jazzer_bootstrap_compile_only",
         "//src/main/java/com/code_intelligence/jazzer/utils",
         "//src/main/java/com/code_intelligence/jazzer/utils:log",
         "//src/main/java/com/code_intelligence/jazzer/utils:simple_glob_matcher",

--- a/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
+++ b/src/main/java/com/code_intelligence/jazzer/autofuzz/Meta.java
@@ -27,6 +27,7 @@ import com.code_intelligence.jazzer.api.Function3;
 import com.code_intelligence.jazzer.api.Function4;
 import com.code_intelligence.jazzer.api.Function5;
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.runtime.HardToCatchError;
 import com.code_intelligence.jazzer.utils.Utils;
 import io.github.classgraph.ClassGraph;
 import io.github.classgraph.ClassInfoList;
@@ -286,6 +287,9 @@ public class Meta {
       // We should ensure that the arguments fed into the method are always valid.
       throw new AutofuzzError(getDebugSummary(method, thisObject, arguments), e);
     } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof HardToCatchError) {
+        throw new AutofuzzInvocationException();
+      }
       throw new AutofuzzInvocationException(e.getCause());
     }
   }
@@ -344,6 +348,9 @@ public class Meta {
       // constructors of abstract classes or private constructors.
       throw new AutofuzzError(getDebugSummary(constructor, null, arguments), e);
     } catch (InvocationTargetException e) {
+      if (e.getCause() instanceof HardToCatchError) {
+        throw new AutofuzzInvocationException();
+      }
       throw new AutofuzzInvocationException(e.getCause());
     }
   }

--- a/src/main/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
@@ -83,6 +83,7 @@ java_library(
     name = "jazzer_bootstrap_compile_only",
     neverlink = True,
     visibility = [
+        "//src/main/java/com/code_intelligence/jazzer/autofuzz:__pkg__",
         "//src/main/java/com/code_intelligence/jazzer/driver:__pkg__",
         "//src/main/java/com/code_intelligence/jazzer/instrumentor:__pkg__",
     ],


### PR DESCRIPTION
Autofuzz tries to print caught exceptions, but this fails in case of bug detector findings, as the thrown exceptions are intentionally hard to catch and rethrow themselves if possible.  Due to this behavior the following line is potentially loged multiple times: `ERROR: Unexpected exception encountered during autofuzz:`

In this case the exceptions are also only used to abort the current invocation, logging of the actual findings is done by different means. So it's save to ignore this kind of exceptions.

Fixes #696 