### PR TITLE
tests: Speed up fuzzed_data_provider_test

### DIFF
--- a/launcher/fuzzed_data_provider_test.cpp
+++ b/launcher/fuzzed_data_provider_test.cpp
@@ -49,7 +49,7 @@ class FuzzedDataProviderTest : public ::testing::Test {
 
 std::unique_ptr<JVM> FuzzedDataProviderTest::jvm_ = nullptr;
 
-constexpr std::size_t kValidModifiedUtf8NumRuns = 10000;
+constexpr std::size_t kValidModifiedUtf8NumRuns = 1000;
 constexpr std::size_t kValidModifiedUtf8NumBytes = 100000;
 constexpr uint32_t kValidModifiedUtf8Seed = 0x12345678;
 


### PR DESCRIPTION
We aren't going to make any changes to the UTF-8 fixup routine in `FuzzedDataProvider` and the test is fully deterministic, so we can reduce the number of runs to prevent frequent timeouts on macOS.