### PR TITLE
mutation: Improve ListMutator

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/api/PseudoRandom.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/api/PseudoRandom.java
@@ -102,6 +102,18 @@ public interface PseudoRandom {
   double closedRange(double lowerInclusive, double upperInclusive);
 
   /**
+   * @return a random value in the closed range [0, upperInclusive] that is heavily biased towards
+   *     being small
+   */
+  int closedRangeBiasedTowardsSmall(int upperInclusive);
+
+  /**
+   * @return a random value in the closed range [lowerInclusive, upperInclusive] that is heavily
+   *     biased towards being small
+   */
+  int closedRangeBiasedTowardsSmall(int lowerInclusive, int upperInclusive);
+
+  /**
    * Fills the given array with random bytes.
    */
   void bytes(byte[] bytes);

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/ChunkMutations.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/ChunkMutations.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.mutator.collection;
+
+import com.code_intelligence.jazzer.mutation.api.PseudoRandom;
+import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
+import com.code_intelligence.jazzer.mutation.support.Preconditions;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+// Based on (Apache-2.0)
+// https://github.com/google/fuzztest/blob/f81257ed70ec7b9c191b633588cb6e39c42da5e4/fuzztest/internal/domains/container_mutation_helpers.h
+final class ChunkMutations {
+  private ChunkMutations() {}
+
+  static <T> void deleteRandomChunk(List<T> list, int minSize, PseudoRandom prng) {
+    int oldSize = list.size();
+    Preconditions.require(oldSize > minSize);
+
+    int minFinalSize = Math.max(minSize, oldSize / 2);
+    int chunkSize = prng.closedRangeBiasedTowardsSmall(1, oldSize - minFinalSize);
+    int chunkOffset = prng.closedRange(0, oldSize - chunkSize);
+
+    list.subList(chunkOffset, chunkOffset + chunkSize).clear();
+  }
+
+  static <T> void insertRandomChunk(
+      List<T> list, int maxSize, SerializingMutator<T> elementMutator, PseudoRandom prng) {
+    int oldSize = list.size();
+    Preconditions.require(oldSize < maxSize);
+
+    int chunkSize = prng.closedRangeBiasedTowardsSmall(1, maxSize - oldSize);
+    int chunkOffset = prng.closedRange(0, oldSize);
+
+    T baseElement = elementMutator.init(prng);
+    T[] chunk = (T[]) new Object[chunkSize];
+    for (int i = 0; i < chunk.length; i++) {
+      chunk[i] = elementMutator.detach(baseElement);
+    }
+    // ArrayList#addAll relies on Collection#toArray, but Arrays#asList returns a List whose
+    // toArray() always makes a copy. We avoid this by using a custom list implementation.
+    list.addAll(chunkOffset, new ArraySharingList<>(chunk));
+  }
+
+  static <T> void mutateRandomChunk(
+      List<T> list, SerializingMutator<T> mutator, PseudoRandom prng) {
+    int oldSize = list.size();
+    int chunkSize = prng.closedRangeBiasedTowardsSmall(1, oldSize);
+    int chunkOffset = prng.closedRange(0, oldSize - chunkSize);
+
+    for (int i = chunkOffset; i < chunkOffset + chunkSize; i++) {
+      list.set(i, mutator.mutate(list.get(i), prng));
+    }
+  }
+
+  public enum MutationAction {
+    DELETE_CHUNK,
+    INSERT_CHUNK,
+    MUTATE_CHUNK;
+
+    public static MutationAction pickRandomAction(
+        Collection<?> c, int minSize, int maxSize, PseudoRandom prng) {
+      List<MutationAction> actions = new ArrayList<>();
+      if (c.size() > minSize) {
+        actions.add(DELETE_CHUNK);
+      }
+      if (c.size() < maxSize) {
+        actions.add(INSERT_CHUNK);
+      }
+      if (!c.isEmpty()) {
+        actions.add(MUTATE_CHUNK);
+      }
+      return prng.pickIn(actions);
+    }
+  }
+
+  private static final class ArraySharingList<T> extends AbstractList<T> {
+    private final T[] array;
+
+    ArraySharingList(T[] array) {
+      this.array = array;
+    }
+
+    @Override
+    public T get(int i) {
+      return array[i];
+    }
+
+    @Override
+    public int size() {
+      return array.length;
+    }
+
+    @Override
+    public Object[] toArray() {
+      return array;
+    }
+  }
+}

--- a/src/test/java/com/code_intelligence/jazzer/mutation/ArgumentsMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/ArgumentsMutatorTest.java
@@ -80,17 +80,21 @@ class ArgumentsMutatorTest {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first argument
              0,
-             // outer list not null
+             // Nullable mutator
              false,
-             // outer list mutate element
-             false,
-             // outer list mutate first element
+             // Action mutate in outer list
+             2,
+             // Mutate one element,
+             1,
+             // index to get to inner list
              0,
-             // inner list not null
+             // Nullable mutator
              false,
-             // inner list mutate element
-             false,
-             // inner list mutate first element
+             // Action mutate inner list
+             2,
+             // Mutate one element,
+             1,
+             // index to get boolean value
              0)) {
       mutator.mutate(prng);
     }
@@ -108,17 +112,21 @@ class ArgumentsMutatorTest {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first argument
              0,
-             // outer list not null
+             // Nullable mutator
              false,
-             // outer list mutate element
-             false,
-             // outer list mutate first element
+             // Action mutate in outer list
+             2,
+             // Mutate one element,
+             1,
+             // index to get to inner list
              0,
-             // inner list not null
+             // Nullable mutator
              false,
-             // inner list mutate element
-             false,
-             // inner list mutate first element
+             // Action mutate inner list
+             2,
+             // Mutate one element,
+             1,
+             // index to get boolean value
              0)) {
       mutator.mutate(prng);
     }
@@ -178,17 +186,21 @@ class ArgumentsMutatorTest {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first argument
              0,
-             // outer list not null
+             // Nullable mutator
              false,
-             // outer list mutate element
-             false,
-             // outer list mutate first element
+             // Action mutate in outer list
+             2,
+             // Mutate one element,
+             1,
+             // index to get to inner list
              0,
-             // inner list not null
+             // Nullable mutator
              false,
-             // inner list mutate element
-             false,
-             // inner list mutate first element
+             // Action mutate inner list
+             2,
+             // Mutate one element,
+             1,
+             // index to get boolean value
              0)) {
       mutator.mutate(prng);
     }
@@ -206,17 +218,21 @@ class ArgumentsMutatorTest {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first argument
              0,
-             // outer list not null
+             // Nullable mutator
              false,
-             // outer list mutate element
-             false,
-             // outer list mutate first element
+             // Action mutate in outer list
+             2,
+             // Mutate one element,
+             1,
+             // index to get to inner list
              0,
-             // inner list not null
+             // Nullable mutator
              false,
-             // inner list mutate element
-             false,
-             // inner list mutate first element
+             // Action mutate inner list
+             2,
+             // Mutate one element,
+             1,
+             // index to get boolean value
              0)) {
       mutator.mutate(prng);
     }

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/BUILD.bazel
@@ -10,6 +10,7 @@ java_test_suite(
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
         "//src/test/java/com/code_intelligence/jazzer/mutation/support:test_support",
         "@com_google_protobuf//java/core",

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/ChunkMutationsTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/ChunkMutationsTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.mutator.collection;
+
+import static com.code_intelligence.jazzer.mutation.support.TestSupport.mockInitializer;
+import static com.code_intelligence.jazzer.mutation.support.TestSupport.mockMutator;
+import static com.code_intelligence.jazzer.mutation.support.TestSupport.mockPseudoRandom;
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toList;
+
+import com.code_intelligence.jazzer.mutation.support.TestSupport.MockPseudoRandom;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+class ChunkMutationsTest {
+  @Test
+  void testDeleteRandomChunk() {
+    List<Integer> list = Stream.of(1, 2, 3, 4, 5, 6).collect(toList());
+
+    try (MockPseudoRandom prng = mockPseudoRandom(2, 3)) {
+      ChunkMutations.deleteRandomChunk(list, 2, prng);
+    }
+    assertThat(list).containsExactly(1, 2, 3, 6).inOrder();
+  }
+
+  @Test
+  void testInsertRandomChunk() {
+    List<String> list = Stream.of("1", "2", "3", "4", "5", "6").collect(toList());
+
+    try (MockPseudoRandom prng = mockPseudoRandom(2, 3)) {
+      ChunkMutations.insertRandomChunk(list, 10, mockInitializer(() -> "7", String::new), prng);
+    }
+    assertThat(list).containsExactly("1", "2", "3", "7", "7", "4", "5", "6").inOrder();
+    String firstNewValue = list.get(3);
+    String secondNewValue = list.get(4);
+    assertThat(firstNewValue).isEqualTo(secondNewValue);
+    // Verify that the individual new elements were detached.
+    assertThat(firstNewValue).isNotSameInstanceAs(secondNewValue);
+  }
+
+  @Test
+  void testMutateChunk() {
+    List<Integer> list = Stream.of(1, 2, 3, 4, 5, 6).collect(toList());
+
+    try (MockPseudoRandom prng = mockPseudoRandom(2, 3)) {
+      ChunkMutations.mutateRandomChunk(list, mockMutator(1, i -> 2 * i), prng);
+    }
+    assertThat(list).containsExactly(1, 2, 3, 8, 10, 6).inOrder();
+  }
+}

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.mutation.mutator.collection;
+
+import static com.code_intelligence.jazzer.mutation.support.TestSupport.mockPseudoRandom;
+import static com.google.common.truth.Truth.assertThat;
+
+import com.code_intelligence.jazzer.mutation.annotation.NotNull;
+import com.code_intelligence.jazzer.mutation.annotation.WithSize;
+import com.code_intelligence.jazzer.mutation.api.MutatorFactory;
+import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
+import com.code_intelligence.jazzer.mutation.mutator.Mutators;
+import com.code_intelligence.jazzer.mutation.support.TestSupport.MockPseudoRandom;
+import com.code_intelligence.jazzer.mutation.support.TypeHolder;
+import java.lang.reflect.AnnotatedType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ListMutatorTest {
+  public static final MutatorFactory FACTORY = Mutators.newFactory();
+
+  @Test
+  void testInit() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    assertThat(mutator.toString()).isEqualTo("List<Integer>");
+
+    List<Integer> list;
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // targetSize
+             1,
+             // elementMutator.init
+             1)) {
+      list = mutator.init(prng);
+    }
+    assertThat(list).containsExactly(0);
+  }
+
+  @Test
+  void testInitMaxSize() {
+    AnnotatedType type =
+        new TypeHolder<@NotNull @WithSize(min = 2, max = 3) List<@NotNull Integer>>(){}
+            .annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    assertThat(mutator.toString()).isEqualTo("List<Integer>");
+    List<Integer> list;
+    try (MockPseudoRandom prng = mockPseudoRandom(2, 4, 42L, 4, 43L)) {
+      list = mutator.init(prng);
+    }
+
+    assertThat(list).containsExactly(42, 43);
+  }
+
+  @Test
+  void testRemoveSingleElement() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             0,
+             // number of elements to remove
+             1,
+             // index to remove
+             2)) {
+      list = mutator.mutate(list, prng);
+    }
+    assertThat(list).containsExactly(1, 2, 4, 5, 6, 7, 8, 9);
+  }
+
+  @Test
+  void testRemoveChunk() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             0,
+             // chunk size
+             2,
+             // chunk offset
+             3)) {
+      list = mutator.mutate(list, prng);
+    }
+
+    assertThat(list).containsExactly(1, 2, 3, 6, 7, 8, 9);
+  }
+
+  @Test
+  void testAddSingleElement() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             1,
+             // add single element,
+             1,
+             // offset,
+             9,
+             // Integral initImpl sentinel value
+             4,
+             // value
+             42L)) {
+      list = mutator.mutate(list, prng);
+    }
+
+    assertThat(list).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9, 42);
+  }
+
+  @Test
+  void testAddChunk() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             1,
+             // chunkSize
+             2,
+             // chunkOffset
+             3,
+             // Integral initImpl
+             4,
+             // val
+             42L)) {
+      list = mutator.mutate(list, prng);
+    }
+    assertThat(list).containsExactly(1, 2, 3, 42, 42, 4, 5, 6, 7, 8, 9);
+  }
+
+  @Test
+  void testChangeSingleElement() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             2,
+             // number of elements to mutate
+             1,
+             // first index to mutate at
+             2,
+             // mutation choice based on `IntegralMutatorFactory`
+             // 2 == closedRange
+             2,
+             // value
+             55L)) {
+      list = mutator.mutate(list, prng);
+    }
+    assertThat(list).containsExactly(1, 2, 55, 4, 5, 6, 7, 8, 9);
+  }
+
+  @Test
+  void testChangeChunk() {
+    AnnotatedType type = new TypeHolder<@NotNull List<@NotNull Integer>>() {}.annotatedType();
+
+    SerializingMutator<@NotNull List<@NotNull Integer>> mutator =
+        (SerializingMutator<@NotNull List<@NotNull Integer>>) FACTORY.createOrThrow(type);
+
+    List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11));
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // action
+             2,
+             // number of elements to mutate
+             2,
+             // first index to mutate at
+             5,
+             // mutation: 0 == bitflip
+             0,
+             // shift constant
+             13,
+             // and again
+             0, 12)) {
+      list = mutator.mutate(list, prng);
+    }
+    assertThat(list).containsExactly(1, 2, 3, 4, 5, 8198, 4103, 8, 9, 10, 11);
+  }
+}

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto2Test.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto2Test.java
@@ -131,7 +131,13 @@ class BuilderMutatorProto2Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate the list itself by duplicating an entry
+             // mutate the list itself by adding an entry
+             1,
+             // add a single element
+             1,
+             // add the element at the end
+             1,
+             // value to add
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -140,14 +146,17 @@ class BuilderMutatorProto2Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate a list element,
-             false,
-             // mutate the second element,
+             // mutate the list itself by changing an entry
+             2,
+             // mutate a single element
+             1,
+             // mutate the second element
              1)) {
       mutator.mutateInPlace(builder, prng);
     }
     assertThat(builder.getSomeFieldList()).containsExactly(true, false).inOrder();
   }
+
   @Test
   void testMessageField() {
     InPlaceMutator<MessageField2.Builder> mutator =
@@ -214,7 +223,15 @@ class BuilderMutatorProto2Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate the list itself by duplicating an entry
+             // mutate the list itself by adding an entry
+             1,
+             // add a single element
+             1,
+             // add the element at the end
+             1,
+             // Nullable mutator init
+             false,
+             // duplicate entry
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -244,7 +261,13 @@ class BuilderMutatorProto2Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate the list itself by duplicating an entry
+             // mutate the list itself by adding an entry
+             1,
+             // add a single element
+             1,
+             // add the element at the end
+             1,
+             // value to add
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -256,11 +279,13 @@ class BuilderMutatorProto2Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate a list element
-             false,
-             // mutate the second element
+             // change an entry
+             2,
+             // mutate a single element
              1,
-             // mutate the first field
+             // mutate the second element,
+             1,
+             // mutate the first element
              0)) {
       mutator.mutateInPlace(builder, prng);
     }

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto3Test.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto3Test.java
@@ -145,8 +145,10 @@ class BuilderMutatorProto3Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate operation
-             false,
+             // change an entry
+             2,
+             // mutate a single element
+             1,
              // mutate to first enum field
              0,
              // mutate to first enum value
@@ -225,7 +227,13 @@ class BuilderMutatorProto3Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate the list itself by duplicating an entry
+             // mutate the list itself by adding an entry
+             1,
+             // add a single element
+             1,
+             // add the element at the end
+             1,
+             // value to add
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -234,9 +242,11 @@ class BuilderMutatorProto3Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate a list element,
-             false,
-             // mutate the second element,
+             // mutate the list itself by changing an entry
+             2,
+             // mutate a single element
+             1,
+             // mutate the second element
              1)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -309,7 +319,13 @@ class BuilderMutatorProto3Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate the list itself by duplicating an entry
+             // mutate the list itself by adding an entry
+             1,
+             // add a single element
+             1,
+             // add the element at the end
+             1,
+             // value to add
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -321,11 +337,13 @@ class BuilderMutatorProto3Test {
     try (MockPseudoRandom prng = mockPseudoRandom(
              // mutate first field
              0,
-             // mutate a list element
-             false,
-             // mutate the second element
+             // change an entry
+             2,
+             // mutate a single element
              1,
-             // mutate the first field
+             // mutate the second element,
+             1,
+             // mutate the first element
              0)) {
       mutator.mutateInPlace(builder, prng);
     }
@@ -355,7 +373,8 @@ class BuilderMutatorProto3Test {
              true)) {
       mutator.initInPlace(builder, prng);
     }
-    // Nested message field is *not* set explicitly and implicitly equal to the default instance.
+    // Nested message field is *not* set explicitly and implicitly equal to the
+    // default instance.
     assertThat(builder.build())
         .isEqualTo(RecursiveMessageField3.newBuilder()
                        .setSomeField(true)
@@ -376,7 +395,8 @@ class BuilderMutatorProto3Test {
              true)) {
       mutator.mutateInPlace(builder, prng);
     }
-    // Nested message field *is* set explicitly and implicitly equal to the default instance.
+    // Nested message field *is* set explicitly and implicitly equal to the default
+    // instance.
     assertThat(builder.build())
         .isEqualTo(RecursiveMessageField3.newBuilder()
                        .setSomeField(true)


### PR DESCRIPTION
Adds chunk-based mutations to the list mutator mimicking fuzztest's mutation.

The size of the chunks is chosen according to a Zipf distribution, which ensures that chunks tend to be small (and often have length 1), which should result in more stable mutations and also makes separate individual element mutations unnecessary.