### PR TITLE
Patch: update instrumentation order to fix coverage

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -214,12 +214,9 @@ class RuntimeInstrumentor(
         }
         return ClassInstrumentor(internalClassName, bytecode).run {
             if (fullInstrumentation) {
-                // Hook instrumentation must be performed after data flow tracing as the injected
-                // bytecode would trigger the GEP callbacks for byte[]. Coverage instrumentation
-                // must be performed after hook instrumentation as the injected bytecode would
-                // trigger the GEP callbacks for ByteBuffer.
-                traceDataFlow(instrumentationTypes)
-                hooks(includedHooks + customHooks, classWithHooksEnabledField)
+                // Coverage instrumentation must be performed before any other code updates
+                // or there will be additional coverage points injected if there are any call is inserted
+                // and JaCoCo will produce a broken coverage report.
                 coverageIdSynchronizer.withIdForClass(internalClassName) { firstId ->
                     coverage(firstId).also { actualNumEdgeIds ->
                         CoverageRecorder.recordInstrumentedClass(
@@ -230,6 +227,10 @@ class RuntimeInstrumentor(
                         )
                     }
                 }
+                // Hook instrumentation must be performed after data flow tracing as the injected
+                // bytecode would trigger the GEP callbacks for byte[].
+                traceDataFlow(instrumentationTypes)
+                hooks(includedHooks + customHooks, classWithHooksEnabledField)
             } else {
                 hooks(customHooks, classWithHooksEnabledField)
             }

--- a/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -215,7 +215,7 @@ class RuntimeInstrumentor(
         return ClassInstrumentor(internalClassName, bytecode).run {
             if (fullInstrumentation) {
                 // Coverage instrumentation must be performed before any other code updates
-                // or there will be additional coverage points injected if there are any call is inserted
+                // or there will be additional coverage points injected if any calls are inserted
                 // and JaCoCo will produce a broken coverage report.
                 coverageIdSynchronizer.withIdForClass(internalClassName) { firstId ->
                     coverage(firstId).also { actualNumEdgeIds ->

--- a/tests/src/test/java/com/example/CoverageFuzzer.java
+++ b/tests/src/test/java/com/example/CoverageFuzzer.java
@@ -171,7 +171,7 @@ public final class CoverageFuzzer {
     assertEquals(7, countHits(coverageFuzzerCoverage.getProbes()));
 
     assertEquals("com/example/CoverageFuzzer$ClassToCover", classToCoverCoverage.getName());
-    assertEquals(11, countHits(classToCoverCoverage.getProbes()));
+    assertEquals(10, countHits(classToCoverCoverage.getProbes()));
   }
 
   private static int countHits(boolean[] probes) {


### PR DESCRIPTION


Reason:
JaCoCo produces wrong coverage because the coverage instrumentation happens after the hooks are set.
This instrumentation should follow the JaCoCo algorithm but in fact they produce different results.
Both algorithms inject control points into the end of each BB where the INVOKE happens.
BBs where there are no INVOKEs are not marked.
Let's check the case: BBs originally did not have any INVOKE but hooks are injected traceCmp callback.
CoverageRecorder happily adds a control point into such a BB but JaCoCo will never know about this.
As the result, all points after the mentioned will be misplaced in JaCoCo coverage.

Sample for test:

package com.example;

import java.util.Random;

public class Junit5Example1 {

    public static boolean earlyReturn = false;

    public static boolean logic(String input) {
        long random = new Random(42).nextLong();
        boolean cmp = input.startsWith("magicstring" + random);
        if (earlyReturn) {
            return true;
        }
        if (cmp
                && input.length() > 35
                && input.charAt(35) == 'C') {
            mustNeverBeCalled();
        }
        return true;
    }

    private static void mustNeverBeCalled() {
        throw new Error("mustNeverBeCalled has been called");
    }
}

All the lines after if (earlyReturn) will be colored wrongly because this BB will have an additional coverage point after traceCmp.
[wrong.Junit5Example1.java.zip](https://github.com/CodeIntelligenceTesting/jazzer/files/11234087/wrong.Junit5Example1.java.zip)
[right.Junit5Example1.java.zip](https://github.com/CodeIntelligenceTesting/jazzer/files/11234088/right.Junit5Example1.java.zip)
