### PR TITLE
mutator: fix a rare test case

### DIFF
--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -456,6 +456,7 @@ public class StressTest {
       testReadWriteExclusiveRoundtrip(mutator, fixedValue);
 
       initValues.add(mutator.detach(value));
+      value = fixFloatingPointsForProtos(value);
 
       for (int mutation = 0; mutation < NUM_MUTATE_PER_INIT; mutation++) {
         Object detachedOldValue = mutator.detach(value);


### PR DESCRIPTION
The rare case happens for proto float/double fields that are initiated with -0.0/-0.0f; detached to 0.0/0.0f; and mutated back to -0.0/-0.0f. This previously caused a rare random failure of the StressTest.java.