### PR TITLE
mutation: Use chunk-based mutation approach for Map 

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorFactory.java
@@ -65,9 +65,10 @@ final class ListMutatorFactory extends MutatorFactory {
       this.elementMutator = elementMutator;
       this.minSize = minSize;
       this.maxSize = maxSize;
-      require(maxSize >= 1, "WithSize#max needs to be greater than 0");
+      require(maxSize >= 1, format("WithSize#max=%d needs to be greater than 0", maxSize));
+      require(minSize >= 0, format("WithSize#min=%d needs to be positive", minSize));
       require(minSize <= maxSize,
-          format("WithSize#min %d needs to be smaller or equal than WithSize#max %d", minSize,
+          format("WithSize#min=%d needs to be smaller or equal than WithSize#max=%d", minSize,
               maxSize));
     }
 

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer/LibFuzzerMutator.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer/LibFuzzerMutator.java
@@ -77,7 +77,7 @@ public final class LibFuzzerMutator {
 
   private static int defaultMutateMock(byte[] buffer, int size) {
     String newSizeProp = System.getProperty(MOCK_SIZE_KEY);
-    int newSize = (buffer.length + size) / 2;
+    int newSize = Math.min(buffer.length, size + 1);
     if (newSizeProp != null) {
       newSize = Integer.parseUnsignedInt(newSizeProp);
     }

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/BUILD.bazel
@@ -9,10 +9,9 @@ java_test_suite(
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
-        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
         "//src/test/java/com/code_intelligence/jazzer/mutation/support:test_support",
-        "@com_google_protobuf//java/core",
     ],
 )

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/ChunkMutationsTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/ChunkMutationsTest.java
@@ -16,14 +16,25 @@
 
 package com.code_intelligence.jazzer.mutation.mutator.collection;
 
+import static com.code_intelligence.jazzer.mutation.support.TestSupport.asMap;
+import static com.code_intelligence.jazzer.mutation.support.TestSupport.asMutableList;
 import static com.code_intelligence.jazzer.mutation.support.TestSupport.mockInitializer;
 import static com.code_intelligence.jazzer.mutation.support.TestSupport.mockMutator;
 import static com.code_intelligence.jazzer.mutation.support.TestSupport.mockPseudoRandom;
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
+import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
 import com.code_intelligence.jazzer.mutation.support.TestSupport.MockPseudoRandom;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
@@ -54,6 +65,54 @@ class ChunkMutationsTest {
   }
 
   @Test
+  void testInsertRandomChunkSet() {
+    Set<Integer> set = Stream.of(1, 2, 3, 4, 5, 6).collect(toCollection(LinkedHashSet::new));
+
+    Queue<Integer> initReturnValues =
+        Stream.of(7, 7, 7, 8, 9, 9).collect(toCollection(ArrayDeque::new));
+    boolean result;
+    try (MockPseudoRandom prng = mockPseudoRandom(3)) {
+      result = ChunkMutations.insertRandomChunk(
+          set, set::add, 10, mockInitializer(initReturnValues::remove, v -> v), prng);
+    }
+    assertThat(result).isTrue();
+    assertThat(set).containsExactly(1, 2, 3, 4, 5, 6, 7, 8, 9).inOrder();
+  }
+
+  @Test
+  void testInsertRandomChunkSet_largeChunk() {
+    Set<Integer> set = Stream.of(1, 2, 3, 4, 5, 6).collect(toCollection(LinkedHashSet::new));
+
+    Queue<Integer> initReturnValues =
+        IntStream.rangeClosed(1, 10000).boxed().collect(toCollection(ArrayDeque::new));
+    boolean result;
+    try (MockPseudoRandom prng = mockPseudoRandom(9994)) {
+      result = ChunkMutations.insertRandomChunk(
+          set, set::add, 10000, mockInitializer(initReturnValues::remove, v -> v), prng);
+    }
+    assertThat(result).isTrue();
+    assertThat(set)
+        .containsExactlyElementsIn(IntStream.rangeClosed(1, 10000).boxed().toArray())
+        .inOrder();
+  }
+
+  @Test
+  void testInsertRandomChunkSet_failsToConstructDistinctValues() {
+    Set<Integer> set = Stream.of(1, 2, 3, 4, 5, 6).collect(toCollection(LinkedHashSet::new));
+
+    Queue<Integer> initReturnValues =
+        Stream.concat(Stream.of(7, 7, 7, 8), Stream.generate(() -> 7).limit(1000))
+            .collect(toCollection(ArrayDeque::new));
+    boolean result;
+    try (MockPseudoRandom prng = mockPseudoRandom(3)) {
+      result = ChunkMutations.insertRandomChunk(
+          set, set::add, 10, mockInitializer(initReturnValues::remove, v -> v), prng);
+    }
+    assertThat(result).isFalse();
+    assertThat(set).containsExactly(1, 2, 3, 4, 5, 6, 7, 8).inOrder();
+  }
+
+  @Test
   void testMutateChunk() {
     List<Integer> list = Stream.of(1, 2, 3, 4, 5, 6).collect(toList());
 
@@ -61,5 +120,118 @@ class ChunkMutationsTest {
       ChunkMutations.mutateRandomChunk(list, mockMutator(1, i -> 2 * i), prng);
     }
     assertThat(list).containsExactly(1, 2, 3, 8, 10, 6).inOrder();
+  }
+
+  @Test
+  void testMutateRandomValuesChunk() {
+    Map<Integer, Integer> map = asMap(1, 10, 2, 20, 3, 30, 4, 40, 5, 50, 6, 60);
+
+    try (MockPseudoRandom prng = mockPseudoRandom(2, 3)) {
+      ChunkMutations.mutateRandomValuesChunk(map, mockMutator(1, i -> 2 * i), prng);
+    }
+    assertThat(map).containsExactly(1, 10, 2, 20, 3, 30, 4, 80, 5, 100, 6, 60).inOrder();
+  }
+
+  @Test
+  void testMutateRandomKeysChunk() {
+    Map<List<Integer>, Integer> map = asMap(asMutableList(1), 10, asMutableList(2), 20,
+        asMutableList(3), 30, asMutableList(4), 40, asMutableList(5), 50, asMutableList(6), 60);
+    SerializingMutator<List<Integer>> keyMutator = mockMutator(null, list -> {
+      List<Integer> newList = list.stream().map(i -> i + 1).collect(toList());
+      list.clear();
+      return newList;
+    }, ArrayList::new);
+
+    try (MockPseudoRandom prng = mockPseudoRandom(2, 3)) {
+      boolean result = ChunkMutations.mutateRandomKeysChunk(map, keyMutator, prng);
+      assertThat(result).isTrue();
+    }
+    assertThat(map)
+        .containsExactly(asMutableList(1), 10, asMutableList(2), 20, asMutableList(3), 30,
+            asMutableList(6), 60, asMutableList(7), 40, asMutableList(8), 50)
+        .inOrder();
+  }
+
+  @Test
+  void testMutateRandomKeysChunk_failsToConstructSomeDistinctKeys() {
+    Map<List<Integer>, Integer> map = asMap(asMutableList(1), 10, asMutableList(2), 20,
+        asMutableList(3), 30, asMutableList(4), 40, asMutableList(5), 50, asMutableList(6), 60);
+    SerializingMutator<List<Integer>> keyMutator = mockMutator(null, list -> {
+      list.clear();
+      List<Integer> newList = new ArrayList<>();
+      newList.add(7);
+      return newList;
+    }, ArrayList::new);
+
+    try (MockPseudoRandom prng = mockPseudoRandom(2, 3)) {
+      boolean result = ChunkMutations.mutateRandomKeysChunk(map, keyMutator, prng);
+      assertThat(result).isTrue();
+    }
+    assertThat(map)
+        .containsExactly(asMutableList(1), 10, asMutableList(2), 20, asMutableList(3), 30,
+            asMutableList(5), 50, asMutableList(6), 60, asMutableList(7), 40)
+        .inOrder();
+  }
+
+  @Test
+  void testMutateRandomKeysChunk_failsToConstructAnyDistinctKeys() {
+    Map<List<Integer>, Integer> map = asMap(asMutableList(1), 10, asMutableList(2), 20,
+        asMutableList(3), 30, asMutableList(4), 40, asMutableList(5), 50, asMutableList(6), 60);
+    SerializingMutator<List<Integer>> keyMutator = mockMutator(null, list -> {
+      list.clear();
+      List<Integer> newList = new ArrayList<>();
+      newList.add(1);
+      return newList;
+    }, ArrayList::new);
+
+    try (MockPseudoRandom prng = mockPseudoRandom(2, 3)) {
+      boolean result = ChunkMutations.mutateRandomKeysChunk(map, keyMutator, prng);
+      assertThat(result).isFalse();
+    }
+    assertThat(map)
+        .containsExactly(asMutableList(1), 10, asMutableList(2), 20, asMutableList(3), 30,
+            asMutableList(4), 40, asMutableList(5), 50, asMutableList(6), 60)
+        .inOrder();
+  }
+
+  @Test
+  void testMutateRandomKeysChunk_nullKeyAndValue() {
+    Map<List<Integer>, Integer> map = asMap(asMutableList(1), 10, asMutableList(2), 20,
+        asMutableList(3), 30, asMutableList(4), null, null, 50, asMutableList(6), 60);
+    SerializingMutator<List<Integer>> keyMutator = mockMutator(null, list -> {
+      if (list != null) {
+        List<Integer> newList = list.stream().map(i -> i + 1).collect(toList());
+        list.clear();
+        return newList;
+      } else {
+        return asMutableList(10);
+      }
+    }, list -> list != null ? new ArrayList<>(list) : null);
+
+    try (MockPseudoRandom prng = mockPseudoRandom(2, 3)) {
+      boolean result = ChunkMutations.mutateRandomKeysChunk(map, keyMutator, prng);
+      assertThat(result).isTrue();
+    }
+    assertThat(map)
+        .containsExactly(asMutableList(1), 10, asMutableList(2), 20, asMutableList(3), 30,
+            asMutableList(6), 60, asMutableList(5), null, asMutableList(10), 50)
+        .inOrder();
+  }
+
+  @Test
+  void testMutateRandomKeysChunk_mutateKeyToNull() {
+    Map<List<Integer>, Integer> map = asMap(asMutableList(1), 10, asMutableList(2), 20,
+        asMutableList(3), 30, asMutableList(4), 40, asMutableList(5), 50, asMutableList(6), 60);
+    SerializingMutator<List<Integer>> keyMutator =
+        mockMutator(null, list -> null, list -> list != null ? new ArrayList<>(list) : null);
+
+    try (MockPseudoRandom prng = mockPseudoRandom(1, 3)) {
+      boolean result = ChunkMutations.mutateRandomKeysChunk(map, keyMutator, prng);
+      assertThat(result).isTrue();
+    }
+    assertThat(map)
+        .containsExactly(asMutableList(1), 10, asMutableList(2), 20, asMutableList(3), 30,
+            asMutableList(5), 50, asMutableList(6), 60, null, 40)
+        .inOrder();
   }
 }

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/ListMutatorTest.java
@@ -21,21 +21,21 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.code_intelligence.jazzer.mutation.annotation.NotNull;
 import com.code_intelligence.jazzer.mutation.annotation.WithSize;
+import com.code_intelligence.jazzer.mutation.api.ChainedMutatorFactory;
 import com.code_intelligence.jazzer.mutation.api.MutatorFactory;
 import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
-import com.code_intelligence.jazzer.mutation.mutator.Mutators;
+import com.code_intelligence.jazzer.mutation.mutator.lang.LangMutators;
 import com.code_intelligence.jazzer.mutation.support.TestSupport.MockPseudoRandom;
 import com.code_intelligence.jazzer.mutation.support.TypeHolder;
 import java.lang.reflect.AnnotatedType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ListMutatorTest {
-  public static final MutatorFactory FACTORY = Mutators.newFactory();
+  public static final MutatorFactory FACTORY =
+      new ChainedMutatorFactory(LangMutators.newFactory(), CollectionMutators.newFactory());
 
   @Test
   void testInit() {

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/MapMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/collection/MapMutatorTest.java
@@ -21,9 +21,10 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.code_intelligence.jazzer.mutation.annotation.NotNull;
 import com.code_intelligence.jazzer.mutation.annotation.WithSize;
+import com.code_intelligence.jazzer.mutation.api.ChainedMutatorFactory;
 import com.code_intelligence.jazzer.mutation.api.MutatorFactory;
 import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
-import com.code_intelligence.jazzer.mutation.mutator.Mutators;
+import com.code_intelligence.jazzer.mutation.mutator.lang.LangMutators;
 import com.code_intelligence.jazzer.mutation.support.TestSupport.MockPseudoRandom;
 import com.code_intelligence.jazzer.mutation.support.TypeHolder;
 import java.lang.reflect.AnnotatedType;
@@ -32,7 +33,8 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("unchecked")
 class MapMutatorTest {
-  public static final MutatorFactory FACTORY = Mutators.newFactory();
+  public static final MutatorFactory FACTORY =
+      new ChainedMutatorFactory(LangMutators.newFactory(), CollectionMutators.newFactory());
 
   @Test
   void mapWithMutableKeysAndValues() {


### PR DESCRIPTION
The previous Map mutator performed both single element as well as chunk
mutations, which isn't necessary now that we can bias chunks towards
being small.

The old implementation didn't check that `initInPlace` and `read` obeyed
the specified `minSize`. Since non-zero `minSize`s can be problematic in
`read`, they are not supported for now.

There were also a few issues with key mutations: Instead of retrying key
creation separately for each key, which can result in a large amount of
wasted attempts if the key set is almost saturated, all such attempts
now share a single failure counter. Keys are now properly detached
before being mutated, which is necessary if map keys are mutable.

The fallback to value mutation if key mutation failed also didn't
behave correctly: It called `setValue` on a newly allocated `Map.Entry`,
which is a noop.