### PR TITLE
Fix breakages to android builds due to toolchain issues

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,6 +43,7 @@ build --experimental_java_classpath=bazel
 build:android_arm --incompatible_enable_android_toolchain_resolution
 build:android_arm --android_platforms=//:android_arm64
 build:android_arm --copt=-D_ANDROID
+build:android_arm --java_runtime_version=8
 
 # Windows
 # Only compiles with clang on Windows.

--- a/launcher/jvm_tooling.cpp
+++ b/launcher/jvm_tooling.cpp
@@ -67,6 +67,8 @@ std::string getExecutablePath() {
   if (_NSGetExecutablePath(buf, &buf_size) != 0) {
 #elif defined(_WIN32)
   if (GetModuleFileNameA(NULL, buf, sizeof(buf)) == 0) {
+#elif defined(_ANDROID)
+  if (true) {
 #else  // Assume Linux
   if (readlink("/proc/self/exe", buf, sizeof(buf)) == -1) {
 #endif


### PR DESCRIPTION
See changes in the following files:
- https://github.com/CodeIntelligenceTesting/jazzer/commit/0e9555aecbb39dfdd354728b46c7cec4b5a900bc
- https://github.com/CodeIntelligenceTesting/jazzer/commit/07bd293d2f686a7b8131d2617602a8e5b7640ebc

These broke our build commands:
- bazelisk build launcher/android:jazzer_android --config=android_arm
- bazelisk build src/main/java/com/code_intelligence/jazzer/android:jazzer_standalone_android --config=android_arm