### PR TITLE
Avoids changing the mutator when there's only one.

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/combinator/MutatorCombinators.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/combinator/MutatorCombinators.java
@@ -292,7 +292,7 @@ public final class MutatorCombinators {
         if (currentState == -1) {
           // The value is in an indeterminate state, initialize it.
           initInPlace(reference, prng);
-        } else if (prng.trueInOneOutOf(100)) {
+        } else if (prng.trueInOneOutOf(100) && mutators.length > 1) {
           // Initialize to a different state.
           mutators[prng.otherIndexIn(mutators, currentState)].initInPlace(reference, prng);
         } else {

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -62,6 +62,7 @@ import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedDoubleField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedFloatField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedIntegralField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.RepeatedRecursiveMessageField3;
+import com.code_intelligence.jazzer.protobuf.Proto3.SingleOptionOneOfField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.StringField3;
 import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors.Descriptor;
@@ -363,7 +364,15 @@ public class StressTest {
                         MessageField3.newBuilder()
                             .setMessageField(PrimitiveField3.newBuilder().setSomeField(true))
                             .build()))
-                    .build())));
+                    .build())),
+        arguments(new TypeHolder<@NotNull SingleOptionOneOfField3>() {}.annotatedType(),
+            "{Builder.Nullable<Boolean>} -> Message",
+            exactly(SingleOptionOneOfField3.getDefaultInstance(),
+                SingleOptionOneOfField3.newBuilder().setBoolField(false).build(),
+                SingleOptionOneOfField3.newBuilder().setBoolField(true).build()),
+            exactly(SingleOptionOneOfField3.getDefaultInstance(),
+                SingleOptionOneOfField3.newBuilder().setBoolField(false).build(),
+                SingleOptionOneOfField3.newBuilder().setBoolField(true).build())));
   }
 
   @SafeVarargs

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
@@ -136,3 +136,9 @@ message EmptyMessage3 {}
 message AnyField3 {
   google.protobuf.Any some_field = 1;
 }
+
+message SingleOptionOneOfField3 {
+  oneof oneof_field {
+    bool bool_field = 1;
+  }
+}


### PR DESCRIPTION
Otherwise, it could cause a check failure.