### PR TITLE
Fixed Android build breaks

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -43,7 +43,7 @@ build --experimental_java_classpath=bazel
 build:android_arm --incompatible_enable_android_toolchain_resolution
 build:android_arm --android_platforms=//:android_arm64
 build:android_arm --copt=-D_ANDROID
-build:android_arm --java_runtime_version=8
+build:android_arm --java_runtime_version=local_jdk
 
 # Windows
 # Only compiles with clang on Windows.

--- a/launcher/jvm_tooling.cpp
+++ b/launcher/jvm_tooling.cpp
@@ -71,6 +71,7 @@ std::string getExecutablePath() {
   bool failed = (read_bytes == 0);
 #elif defined(_ANDROID)
   bool failed = true;
+  uint32_t read_bytes = 0;
 #else  // Assume Linux
   ssize_t read_bytes = readlink("/proc/self/exe", buf, sizeof(buf));
   bool failed = (read_bytes == -1);


### PR DESCRIPTION
Using default "local_jdk" for java_runtime_version.

initializing var read_bytes. It will not be used, but for compilation needs to be defined.