### PR TITLE
mutation: Do not initialize recursive proto fields

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/combinator/MutatorCombinators.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/combinator/MutatorCombinators.java
@@ -311,6 +311,29 @@ public final class MutatorCombinators {
   }
 
   /**
+   * @return a mutator that behaves identically to the provided one except that its {@link
+   * InPlaceMutator#initInPlace(Object, PseudoRandom)} is a no-op
+   */
+  public static <T> InPlaceMutator<T> withoutInit(InPlaceMutator<T> mutator) {
+    return new InPlaceMutator<T>() {
+      @Override
+      public void initInPlace(T reference, PseudoRandom prng) {
+        // Intentionally left empty.
+      }
+
+      @Override
+      public String toDebugString(Predicate<Debuggable> isInCycle) {
+        return "WithoutInit(" + mutator.toDebugString(isInCycle) + ")";
+      }
+
+      @Override
+      public void mutateInPlace(T reference, PseudoRandom prng) {
+        mutator.mutateInPlace(reference, prng);
+      }
+    };
+  }
+
+  /**
    * Constructs a mutator that always returns the provided fixed value.
    *
    * <p>Note: This mutator explicitly breaks the contract of the init and mutate methods. Use

--- a/src/main/java/com/code_intelligence/jazzer/mutation/support/TypeSupport.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/support/TypeSupport.java
@@ -39,6 +39,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.*;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -430,6 +431,25 @@ public final class TypeSupport {
       return Optional.empty();
     }
     return Optional.of(Collections.unmodifiableList(Arrays.asList(typeArguments)));
+  }
+
+  /**
+   * Whether {@code root} is contained in a directed cycle in the directed graph rooted at it and
+   * defined by the given {@code successors} function.
+   */
+  public static <T> boolean containedInDirectedCycle(T root, Function<T, Stream<T>> successors) {
+    HashSet<T> traversed = new HashSet<>();
+    ArrayDeque<T> toTraverse = new ArrayDeque<>();
+    toTraverse.addLast(root);
+    T currentNode;
+    while ((currentNode = toTraverse.pollLast()) != null) {
+      if (traversed.add(currentNode)) {
+        successors.apply(currentNode).forEachOrdered(toTraverse::addLast);
+      } else if (currentNode.equals(root)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static class AugmentedArrayType

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto3Test.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto3Test.java
@@ -359,40 +359,24 @@ class BuilderMutatorProto3Test {
         (InPlaceMutator<RecursiveMessageField3.Builder>) FACTORY.createInPlaceOrThrow(
             new TypeHolder<RecursiveMessageField3.@NotNull Builder>() {}.annotatedType());
     assertThat(mutator.toString())
-        .isEqualTo("{Builder.Boolean, Builder.Nullable<(cycle) -> Message>}");
+        .isEqualTo("{Builder.Boolean, WithoutInit(Builder.Nullable<(cycle) -> Message>)}");
     RecursiveMessageField3.Builder builder = RecursiveMessageField3.newBuilder();
 
     try (MockPseudoRandom prng = mockPseudoRandom(
              // boolean
-             true,
-             // message field is not null
-             false,
-             // nested boolean,
-             false,
-             // nested message field is not set
              true)) {
       mutator.initInPlace(builder, prng);
     }
-    // Nested message field is *not* set explicitly and implicitly equal to the
-    // default instance.
+
     assertThat(builder.build())
-        .isEqualTo(RecursiveMessageField3.newBuilder()
-                       .setSomeField(true)
-                       .setMessageField(RecursiveMessageField3.newBuilder())
-                       .build());
-    assertThat(builder.getMessageFieldBuilder().hasMessageField()).isFalse();
+        .isEqualTo(RecursiveMessageField3.newBuilder().setSomeField(true).build());
+    assertThat(builder.hasMessageField()).isFalse();
 
     try (MockPseudoRandom prng = mockPseudoRandom(
-             // mutate message field
+             // mutate message field (causes init to non-null)
              1,
-             // mutate message field as not null
-             false,
-             // mutate message field
-             1,
-             // nested boolean,
-             false,
-             // nested message field is null
-             true)) {
+             // bool field in message field
+             false)) {
       mutator.mutateInPlace(builder, prng);
     }
     // Nested message field *is* set explicitly and implicitly equal to the default
@@ -400,10 +384,32 @@ class BuilderMutatorProto3Test {
     assertThat(builder.build())
         .isEqualTo(RecursiveMessageField3.newBuilder()
                        .setSomeField(true)
-                       .setMessageField(RecursiveMessageField3.newBuilder().setMessageField(
-                           RecursiveMessageField3.newBuilder()))
+                       .setMessageField(RecursiveMessageField3.newBuilder().setSomeField(false))
                        .build());
+    assertThat(builder.hasMessageField()).isTrue();
+    assertThat(builder.getMessageField().hasMessageField()).isFalse();
+
+    try (MockPseudoRandom prng = mockPseudoRandom(
+             // mutate message field
+             1,
+             //  message field as not null
+             false,
+             // mutate message field
+             1,
+             // nested boolean,
+             true)) {
+      mutator.mutateInPlace(builder, prng);
+    }
+    assertThat(builder.build())
+        .isEqualTo(RecursiveMessageField3.newBuilder()
+                       .setSomeField(true)
+                       .setMessageField(
+                           RecursiveMessageField3.newBuilder().setSomeField(false).setMessageField(
+                               RecursiveMessageField3.newBuilder().setSomeField(true)))
+                       .build());
+    assertThat(builder.hasMessageField()).isTrue();
     assertThat(builder.getMessageField().hasMessageField()).isTrue();
+    assertThat(builder.getMessageField().getMessageField().hasMessageField()).isFalse();
   }
 
   @Test

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto2.proto
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto2.proto
@@ -75,11 +75,20 @@ message StringField2 {
 optional string some_field = 1;
 }
 
+message Parent {
+  optional Child child = 1;
+}
+
+message Child {
+  optional Parent parent = 1;
+}
+
 // Taken from
 // https://github.com/google/fuzztest/blob/c5fde4baee6134c84d4f2b618def9f60c7505151/fuzztest/internal/test_protobuf.proto#L24
 message TestSubProtobuf {
   optional int32 subproto_i32 = 1;
   repeated int32 subproto_rep_i32 = 2 [packed = true];
+  optional TestProtobuf parent = 3;
 }
 
 message TestProtobuf {


### PR DESCRIPTION
When recursive proto fields are initialized, the resulting messages have an expected nesting depth on the order of the inverse of the frequency with which a nullable value is non-null, which tends to run into StackOverflowErrors quickly.

This is fixed by checking whether a given proto field is recursive and if so, only initializing it "layer by layer" in mutations rather than all at once during initialization.