### PR TITLE
junit: Use marker arguments to signal start of fuzzing

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
@@ -110,7 +110,11 @@ java_library(
     runtime_deps = select({
         "@platforms//os:windows": [],
         "//conditions:default": ["//src/main/native/com/code_intelligence/jazzer:jazzer_preload"],
-    }),
+    }) + [
+        # Only used by JUnit, but including it here means we don't need to shade ASM in
+        # jazzer-junit.
+        "//src/main/java/com/code_intelligence/jazzer/utils:unsafe_utils",
+    ],
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/driver",
         "//src/main/java/com/code_intelligence/jazzer/utils:log",

--- a/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -77,6 +77,9 @@ java_library(
     srcs = ["Utils.java"],
     visibility = ["//src/test/java/com/code_intelligence/jazzer/junit:__pkg__"],
     deps = [
+        "//src/main/java/com/code_intelligence/jazzer/utils:unsafe_provider",
+        "//src/main/java/com/code_intelligence/jazzer/utils:unsafe_utils",
         "@maven//:org_junit_jupiter_junit_jupiter_api",
+        "@maven//:org_junit_jupiter_junit_jupiter_params",
     ],
 )

--- a/src/main/java/com/code_intelligence/jazzer/junit/Utils.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/Utils.java
@@ -14,18 +14,33 @@
 
 package com.code_intelligence.jazzer.junit;
 
+import static java.util.Arrays.stream;
+import static java.util.Collections.newSetFromMap;
+import static org.junit.jupiter.api.Named.named;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.code_intelligence.jazzer.utils.UnsafeProvider;
+import com.code_intelligence.jazzer.utils.UnsafeUtils;
+import java.lang.invoke.MethodType;
 import java.lang.management.ManagementFactory;
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.IdentityHashMap;
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.jupiter.params.provider.Arguments;
 
 class Utils {
   /**
@@ -127,12 +142,89 @@ class Utils {
   }
 
   /**
-   * Convert the string to ISO 8601 (https://en.wikipedia.org/wiki/ISO_8601#Durations).
-   * We do not allow for duration units longer than hours, so we can always prepend PT.
+   * Convert the string to ISO 8601 (https://en.wikipedia.org/wiki/ISO_8601#Durations). We do not
+   * allow for duration units longer than hours, so we can always prepend PT.
    */
   static long durationStringToSeconds(String duration) {
     String isoDuration =
         "PT" + duration.replace("sec", "s").replace("min", "m").replace("hr", "h").replace(" ", "");
     return Duration.parse(isoDuration).getSeconds();
+  }
+
+  /**
+   * Creates {@link Arguments} for a single invocation of a parameterized test that can be
+   * identified as having been created in this way by {@link #isMarkedInvocation}.
+   *
+   * @param displayName the display name to assign to every argument
+   */
+  static Arguments getMarkedArguments(Method method, String displayName) {
+    return arguments(stream(method.getParameterTypes())
+                         .map(Utils::getMarkedInstance)
+                         // Wrap in named as toString may crash on marked instances.
+                         .map(arg -> named(displayName, arg))
+                         .toArray(Object[] ::new));
+  }
+
+  /**
+   * @return {@code true} if and only if the arguments for this test method invocation were created
+   * with {@link #getMarkedArguments}
+   */
+  static boolean isMarkedInvocation(ReflectiveInvocationContext<Method> invocationContext) {
+    if (invocationContext.getArguments().stream().anyMatch(Utils::isMarkedInstance)) {
+      if (invocationContext.getArguments().stream().allMatch(Utils::isMarkedInstance)) {
+        return true;
+      }
+      throw new IllegalStateException(
+          "Some, but not all arguments were marked in invocation of " + invocationContext);
+    } else {
+      return false;
+    }
+  }
+
+  private static final ClassValue<Object> uniqueInstanceCache = new ClassValue<Object>() {
+    @Override
+    protected Object computeValue(Class<?> clazz) {
+      return makeMarkedInstance(clazz);
+    }
+  };
+  private static final Set<Object> uniqueInstances = newSetFromMap(new IdentityHashMap<>());
+
+  // Visible for testing.
+  static <T> T getMarkedInstance(Class<T> clazz) {
+    // makeMarkedInstance creates new classes, which is expensive and can cause the JVM to run out
+    // of metaspace. We thus cache the marked instances per class.
+    Object instance = uniqueInstanceCache.get(clazz);
+    uniqueInstances.add(instance);
+    return (T) instance;
+  }
+
+  // Visible for testing.
+  static boolean isMarkedInstance(Object instance) {
+    return uniqueInstances.contains(instance);
+  }
+
+  private static Object makeMarkedInstance(Class<?> clazz) {
+    if (clazz == Class.class) {
+      return new Object() {}.getClass();
+    }
+    if (clazz.isArray()) {
+      return Array.newInstance(clazz.getComponentType(), 0);
+    }
+    if (clazz.isInterface()) {
+      return Proxy.newProxyInstance(
+          Utils.class.getClassLoader(), new Class[] {clazz}, (o, method, objects) -> null);
+    }
+
+    if (clazz.isPrimitive()) {
+      clazz = MethodType.methodType(clazz).wrap().returnType();
+    } else if (Modifier.isAbstract(clazz.getModifiers())) {
+      clazz = UnsafeUtils.defineAnonymousConcreteSubclass(clazz);
+    }
+
+    try {
+      return clazz.cast(UnsafeProvider.getUnsafe().allocateInstance(clazz));
+    } catch (InstantiationException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/src/main/java/com/code_intelligence/jazzer/junit/junit_shade_rules
+++ b/src/main/java/com/code_intelligence/jazzer/junit/junit_shade_rules
@@ -1,6 +1,0 @@
-rule com.github.** com.code_intelligence.jazzer.third_party.@0
-rule io.** com.code_intelligence.jazzer.third_party.@0
-rule kotlin.** com.code_intelligence.jazzer.third_party.@0
-rule net.** com.code_intelligence.jazzer.third_party.@0
-rule nonapi.** com.code_intelligence.jazzer.third_party.@0
-rule org.objectweb.** com.code_intelligence.jazzer.third_party.@0

--- a/src/main/java/com/code_intelligence/jazzer/utils/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/utils/BUILD.bazel
@@ -50,6 +50,18 @@ java_library(
 )
 
 java_library(
+    name = "unsafe_utils",
+    srcs = ["UnsafeUtils.java"],
+    visibility = [
+        "//:__subpackages__",
+    ],
+    deps = [
+        ":unsafe_provider",
+        "@org_ow2_asm_asm//jar",
+    ],
+)
+
+java_library(
     name = "zip_utils",
     srcs = ["ZipUtils.java"],
     visibility = ["//visibility:public"],

--- a/src/main/java/com/code_intelligence/jazzer/utils/UnsafeUtils.java
+++ b/src/main/java/com/code_intelligence/jazzer/utils/UnsafeUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.utils;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.Array;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Optional;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+
+public final class UnsafeUtils {
+  /**
+   * Dynamically creates a concrete class implementing the given abstract class.
+   *
+   * <p>The returned class will not be functional and should only be used to construct instances
+   * via {@link sun.misc.Unsafe#allocateInstance(Class)}.
+   */
+  public static <T> Class<? extends T> defineAnonymousConcreteSubclass(Class<T> abstractClass) {
+    if (!Modifier.isAbstract(abstractClass.getModifiers())) {
+      throw new IllegalArgumentException(abstractClass + " is not abstract");
+    }
+
+    ClassWriter cw = new ClassWriter(0);
+    String superClassName = abstractClass.getName().replace('.', '/');
+    // Only the package of the class name matters, the actual name is generated. defineHiddenClass
+    // requires the package of the new class to match the one of the lookup.
+    String className = UnsafeUtils.class.getPackage().getName().replace('.', '/') + "/Anonymous";
+    cw.visit(Opcodes.V1_8, 0, className, null, superClassName, null);
+    cw.visitEnd();
+
+    try {
+      Optional<Method> defineHiddenClass =
+          Arrays.stream(Lookup.class.getMethods())
+              .filter(method -> method.getName().equals("defineHiddenClass"))
+              .findFirst();
+      Optional<Class<?>> classOption =
+          Arrays.stream(Lookup.class.getClasses())
+              .filter(clazz -> clazz.getSimpleName().equals("ClassOption"))
+              .findFirst();
+      // MethodHandles.Lookup#defineHiddenClass is available as of Java 15.
+      // Unsafe#defineAnonymousClass has been removed in Java 17.
+      if (defineHiddenClass.isPresent() && classOption.isPresent()) {
+        return ((MethodHandles.Lookup) defineHiddenClass.get().invoke(MethodHandles.lookup(),
+                    cw.toByteArray(), true, Array.newInstance(classOption.get(), 0)))
+            .lookupClass()
+            .asSubclass(abstractClass);
+      } else {
+        return (Class<? extends T>) UnsafeProvider.getUnsafe()
+            .getClass()
+            .getMethod("defineAnonymousClass", Class.class, byte[].class, Object[].class)
+            .invoke(UnsafeProvider.getUnsafe(), UnsafeUtils.class, cw.toByteArray(), null);
+      }
+    } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private UnsafeUtils() {}
+}

--- a/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@contrib_rules_jvm//java:defs.bzl", "JUNIT5_DEPS", "java_junit5_test")
+
 java_library(
     name = "test-method",
     srcs = ["TestMethod.java"],
@@ -7,12 +9,15 @@ java_library(
     ],
 )
 
-java_test(
+java_junit5_test(
     name = "UtilsTest",
+    size = "small",
     srcs = ["UtilsTest.java"],
-    deps = [
+    deps = JUNIT5_DEPS + [
         "//src/main/java/com/code_intelligence/jazzer/junit:utils",
         "@maven//:com_google_truth_truth",
+        "@maven//:org_junit_jupiter_junit_jupiter_api",
+        "@maven//:org_junit_jupiter_junit_jupiter_params",
     ],
 )
 

--- a/src/test/java/com/code_intelligence/jazzer/junit/UtilsTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/junit/UtilsTest.java
@@ -15,18 +15,87 @@
 package com.code_intelligence.jazzer.junit;
 
 import static com.code_intelligence.jazzer.junit.Utils.durationStringToSeconds;
+import static com.code_intelligence.jazzer.junit.Utils.getMarkedArguments;
+import static com.code_intelligence.jazzer.junit.Utils.getMarkedInstance;
+import static com.code_intelligence.jazzer.junit.Utils.isMarkedInstance;
+import static com.code_intelligence.jazzer.junit.Utils.isMarkedInvocation;
 import static com.google.common.truth.Truth.assertThat;
+import static java.util.Arrays.stream;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
-import org.junit.Test;
+import java.lang.reflect.Method;
+import java.util.AbstractList;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-public class UtilsTest {
+public class UtilsTest implements InvocationInterceptor {
   @Test
-  public void testDurationStringToSeconds() {
+  void testDurationStringToSeconds() {
     assertThat(durationStringToSeconds("1m")).isEqualTo(60);
     assertThat(durationStringToSeconds("1min")).isEqualTo(60);
     assertThat(durationStringToSeconds("1h")).isEqualTo(60 * 60);
     assertThat(durationStringToSeconds("1h   2m 30s")).isEqualTo(60 * 60 + 2 * 60 + 30);
     assertThat(durationStringToSeconds("1hr2min30sec")).isEqualTo(60 * 60 + 2 * 60 + 30);
     assertThat(durationStringToSeconds("1h2m30s")).isEqualTo(60 * 60 + 2 * 60 + 30);
+  }
+
+  @ValueSource(classes = {int.class, Class.class, Object.class, String.class, HashMap.class,
+                   Map.class, int[].class, int[][].class, AbstractMap.class, AbstractList.class})
+  @ParameterizedTest
+  void
+  testMarkedInstances(Class<?> clazz) {
+    Object instance = getMarkedInstance(clazz);
+    if (clazz == int.class) {
+      assertThat(instance).isInstanceOf(Integer.class);
+    } else {
+      assertThat(instance).isInstanceOf(clazz);
+    }
+    assertThat(isMarkedInstance(instance)).isTrue();
+    assertThat(getMarkedInstance(clazz)).isSameInstanceAs(instance);
+  }
+
+  static Stream<Arguments> testWithMarkedNamedParametersSource() {
+    Method testMethod =
+        stream(UtilsTest.class.getDeclaredMethods())
+            .filter(method -> method.getName().equals("testWithMarkedNamedParameters"))
+            .findFirst()
+            .get();
+    return Stream.of(
+        arguments("foo", 0, new HashMap<>(), singletonList(5), UtilsTest.class, new int[] {1}),
+        getMarkedArguments(testMethod, "some name"),
+        arguments("baz", 1, new LinkedHashMap<>(), Arrays.asList(5, 7), String.class, new int[0]),
+        getMarkedArguments(testMethod, "some other name"));
+  }
+
+  @MethodSource("testWithMarkedNamedParametersSource")
+  @ExtendWith(UtilsTest.class)
+  @ParameterizedTest
+  void testWithMarkedNamedParameters(String str, int num, AbstractMap<String, String> map,
+      List<Integer> list, Class<?> clazz, int[] array) {}
+
+  boolean argumentsExpectedToBeMarked = false;
+
+  @Override
+  public void interceptTestTemplateMethod(Invocation<Void> invocation,
+      ReflectiveInvocationContext<Method> invocationContext, ExtensionContext extensionContext)
+      throws Throwable {
+    assertThat(isMarkedInvocation(invocationContext)).isEqualTo(argumentsExpectedToBeMarked);
+    argumentsExpectedToBeMarked = !argumentsExpectedToBeMarked;
+    invocation.proceed();
   }
 }


### PR DESCRIPTION
This is intended to be a pure refactoring that enables us to allow arbitrary `ArgumentsProvider`s to provide arguments for fuzz tests that are picked up in fuzzing mode.