### PR TITLE
driver: Simplify agent installation

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/driver/Driver.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/Driver.java
@@ -108,7 +108,11 @@ public class Driver {
       args.add(getDefaultRssLimitMbArg());
     }
 
-    // Do not modify properties beyond this point, loading Opt locks in their values.
+    // Do not modify properties beyond this point, loading Opt locks in their values. The agent will
+    // cause Opt to be loaded again, this time in the bootstrap class loader, but since all its
+    // fields are immutable that should not cause confusion.
+    AgentInstaller.install(Opt.hooks);
+
     if (!Opt.instrumentOnly.isEmpty()) {
       boolean instrumentationSuccess = OfflineInstrumentor.instrumentJars(Opt.instrumentOnly);
       if (!instrumentationSuccess) {
@@ -120,7 +124,6 @@ public class Driver {
     Driver.class.getClassLoader().setDefaultAssertionStatus(true);
 
     if (!Opt.autofuzz.isEmpty()) {
-      AgentInstaller.install(Opt.hooks);
       FuzzTargetHolder.fuzzTarget = FuzzTargetHolder.AUTOFUZZ_FUZZ_TARGET;
       return FuzzTargetRunner.startLibFuzzer(args);
     }
@@ -138,9 +141,6 @@ public class Driver {
       }
     }
 
-    // Installing the agent after the following "findFuzzTarget" leads to an asan error
-    // in it on "Class.forName(targetClassName)", but only during native fuzzing.
-    AgentInstaller.install(Opt.hooks);
     FuzzTargetHolder.fuzzTarget = FuzzTargetFinder.findFuzzTarget(targetClassName);
     return FuzzTargetRunner.startLibFuzzer(args);
   }

--- a/src/main/java/com/code_intelligence/jazzer/driver/OfflineInstrumentor.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/OfflineInstrumentor.java
@@ -45,8 +45,6 @@ public class OfflineInstrumentor {
    * @return a boolean representing the success status
    */
   public static boolean instrumentJars(List<String> jarLists) {
-    AgentInstaller.install(Opt.hooks);
-
     // Clear Opt.dumpClassesDir before adding new instrumented classes
     File dumpClassesDir = new File(Opt.dumpClassesDir);
     if (dumpClassesDir.exists()) {


### PR DESCRIPTION
The agent is now installed in a single place rather than three different ones. In addition, it's installed right on the line with the first access to `Opt`, making it more clear that options aren't modified between the two loads of that class.