### PR TITLE
bazel: Add debug config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -68,6 +68,15 @@ common:toolchain --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 build --test_env=JAZZER_AUTOFUZZ_DEBUG
 build --test_env=JAZZER_REFLECTION_DEBUG
 
+# Interactively debug Jazzer integration tests by passing --config=debug and attaching to port 5005.
+# This is different from --java_debug: It affects the actual inner Jazzer process rather than the
+# outer FuzzTargetTestWrapper.
+test:debug --test_env=JAZZER_DEBUG=1
+test:debug --test_output=streamed
+test:debug --test_strategy=exclusive
+test:debug --test_timeout=9999
+test:debug --nocache_test_results
+
 # CI tests (not using the toolchain to test OSS-Fuzz & local compatibility)
 build:ci --bes_results_url=https://app.buildbuddy.io/invocation/
 build:ci --bes_backend=grpcs://remote.buildbuddy.io

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,11 @@ To run the tests, execute the following command:
 $ bazel test //...
 ```
 
+#### Debugging
+
+If you need to debug an issue that can only be reproduced by an integration test (`java_fuzz_target_test`), you can start Jazzer in debug mode via `--config=debug`.
+The JVM running Jazzer will suspend until a debugger connects on port 5005 (or the port specified via `DEFAULT_JVM_DEBUG_PORT`).
+
 ### Formatting
 
 Run `./format.sh` to format all source files in the way enforced by the "Check formatting" CI job.

--- a/bazel/tools/java/com/code_intelligence/jazzer/tools/FuzzTargetTestWrapper.java
+++ b/bazel/tools/java/com/code_intelligence/jazzer/tools/FuzzTargetTestWrapper.java
@@ -108,6 +108,9 @@ public class FuzzTargetTestWrapper {
       if (hookJarActualPath != null) {
         command.add(String.format("--main_advice_classpath=%s", hookJarActualPath));
       }
+      if (System.getenv("JAZZER_DEBUG") != null) {
+        command.add("--debug");
+      }
     } else {
       command.add(String.format("--cp=%s",
           hookJarActualPath == null


### PR DESCRIPTION
Jazzer integration tests can be debugged by passing `--config=debug` and attaching to the suspended JVM.