### PR TITLE
mutator: Set required fields to defaults when reading incomplete proto

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorFactory.java
@@ -245,7 +245,26 @@ public final class BuilderMutatorFactory extends MutatorFactory {
         // We never want the fuzz test to see unknown fields and our mutations should never produce
         // them.
         builder.setUnknownFields(UnknownFieldSet.getDefaultInstance());
+        // Required fields may not have been set at this point. We set them to default values to
+        // prevent an exception when built.
+        forceInitialized(builder);
         return builder;
+      }
+
+      private void forceInitialized(Builder builder) {
+        if (builder.isInitialized()) {
+          return;
+        }
+        for (FieldDescriptor field : builder.getDescriptorForType().getFields()) {
+          if (!field.isRequired()) {
+            continue;
+          }
+          if (field.getJavaType() == JavaType.MESSAGE) {
+            forceInitialized(builder.getFieldBuilder(field));
+          } else if (!builder.hasField(field)) {
+            builder.setField(field, field.getDefaultValue());
+          }
+        }
       }
 
       @Override

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto2.proto
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto2.proto
@@ -139,3 +139,23 @@ message TestProtobuf {
   message EmptyMessage {}
   optional EmptyMessage empty_message = 101;
 }
+
+message OriginalSubmessage2 {
+  required int32 numeric_field = 1;
+}
+
+message OriginalMessage2 {
+  required OriginalSubmessage2 message_field = 1;
+  required bool bool_field = 2;
+}
+
+message ExtendedSubmessage2 {
+  required int32 numeric_field = 1;
+  required OriginalSubmessage2 message_field = 2;
+}
+
+message ExtendedMessage2 {
+  required ExtendedSubmessage2 message_field = 1;
+  required bool bool_field = 2;
+  required float float_field = 3;
+}


### PR DESCRIPTION
A proto message deserialized from bytes can be incomplete, which results in an error when building it if required fields are missing. To prevent this, walk the proto and initialize all unset required fields to defaults recursively.