### PR TITLE
driver: Do not prepare for a subprocess for `-fork=0`

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/Jazzer.java
+++ b/src/main/java/com/code_intelligence/jazzer/Jazzer.java
@@ -97,8 +97,10 @@ public class Jazzer {
       // In LibFuzzer's fork mode, the subprocesses created continuously by the main libFuzzer
       // process do not create further subprocesses. Creating a wrapper script for each subprocess
       // is an unnecessary overhead.
-      final boolean spawnsSubprocesses = args.stream().anyMatch(
-          arg -> arg.startsWith("-fork=") || arg.startsWith("-jobs=") || arg.startsWith("-merge="));
+      final boolean spawnsSubprocesses = args.stream().anyMatch(arg
+          -> (arg.startsWith("-fork=") && !arg.equals("-fork=0"))
+              || (arg.startsWith("-jobs=") && !arg.equals("-jobs=0"))
+              || (arg.startsWith("-merge=") && !arg.equals("-merge=0")));
       // argv0 is printed by libFuzzer during reproduction, so have it contain "jazzer".
       String arg0 = spawnsSubprocesses ? prepareArgv0(new HashMap<>()) : "jazzer";
       args = Stream.concat(Stream.of(arg0), args.stream()).collect(toList());


### PR DESCRIPTION
`-fork=0` and similar flags disable the respective libFuzzer modes and thus should not lead Jazzer to prepare for being run in a subprocess, e.g., not set `-seed`.

Fixes #756 