### PR TITLE
Replace `@DescriptorSource` with `@WithDefaultInstance`

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto/WithDefaultInstance.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto/WithDefaultInstance.java
@@ -21,20 +21,23 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import com.code_intelligence.jazzer.mutation.annotation.AppliesTo;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /**
- * Provides a {@link com.google.protobuf.Descriptors.Descriptor} to use as the base for mutations
- * of the annotated {@link DynamicMessage} or {@link DynamicMessage.Builder}.
+ * Provides a default instance to use as the base for mutations of the annotated {@link Message} or
+ * {@link DynamicMessage.Builder}.
  */
 @Target(TYPE_USE)
 @Retention(RUNTIME)
-@AppliesTo({DynamicMessage.class, DynamicMessage.Builder.class})
-public @interface DescriptorSource {
+@AppliesTo(subClassesOf = {Message.class, Message.Builder.class})
+public @interface WithDefaultInstance {
   /**
-   * The fully qualified name of a static final field (e.g. {@code com.example.MyClass#MY_FIELD} of
-   * type * {@link com.google.protobuf.Descriptors.Descriptor} that mutations should be based on.
+   * The fully qualified name of a static method (e.g.
+   * {@code com.example.MyClass#getDefaultInstance}) with return type assignable to
+   * {@link com.google.protobuf.Message}, which returns a default instance that mutations should be
+   * based on.
    */
   String value();
 }

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorFactory.java
@@ -45,7 +45,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 import com.code_intelligence.jazzer.mutation.annotation.proto.AnySource;
-import com.code_intelligence.jazzer.mutation.annotation.proto.DescriptorSource;
+import com.code_intelligence.jazzer.mutation.annotation.proto.WithDefaultInstance;
 import com.code_intelligence.jazzer.mutation.api.ChainedMutatorFactory;
 import com.code_intelligence.jazzer.mutation.api.InPlaceMutator;
 import com.code_intelligence.jazzer.mutation.api.MutatorFactory;
@@ -348,21 +348,20 @@ public final class BuilderMutatorFactory extends MutatorFactory {
   @Override
   public Optional<SerializingMutator<?>> tryCreate(AnnotatedType type, MutatorFactory factory) {
     return asSubclassOrEmpty(type, Builder.class).flatMap(builderClass -> {
-      // Handled by a custom mutator factory for message fields that is created in
-      // withDescriptorDependentMutatorFactoryIfNeeded. BuilderMutatorFactory only handles proper
-      // subclasses, which correspond to generated message types.
-      if (builderClass == Message.Builder.class) {
-        return Optional.empty();
-      }
-
       Message defaultInstance;
-      if (builderClass == DynamicMessage.Builder.class) {
-        DescriptorSource descriptorSource = type.getAnnotation(DescriptorSource.class);
-        if (descriptorSource == null) {
-          throw new IllegalArgumentException(
-              "To mutate a dynamic message, add a @DescriptorSource annotation specifying the fully qualified method name of a static method returning a Descriptor");
-        }
-        defaultInstance = getDefaultInstance(descriptorSource);
+      WithDefaultInstance withDefaultInstance = type.getAnnotation(WithDefaultInstance.class);
+      if (withDefaultInstance != null) {
+        defaultInstance = getDefaultInstance(withDefaultInstance);
+      } else if (builderClass == DynamicMessage.Builder.class) {
+        throw new IllegalArgumentException(
+            "To mutate a dynamic message, add a @WithDefaultInstance annotation specifying the"
+            + " fully qualified method name of a static method returning a default instance");
+      } else if (builderClass == Message.Builder.class) {
+        // Handled by a custom mutator factory for message fields that is created in
+        // withDescriptorDependentMutatorFactoryIfNeeded. Without @WithDefaultInstance,
+        // BuilderMutatorFactory only handles proper subclasses, which correspond to generated
+        // message types.
+        return Optional.empty();
       } else {
         defaultInstance =
             getDefaultInstance((Class<? extends Message>) builderClass.getEnclosingClass());

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -20,7 +20,6 @@ import static com.code_intelligence.jazzer.mutation.mutator.Mutators.validateAnn
 import static com.code_intelligence.jazzer.mutation.support.InputStreamSupport.extendWithZeros;
 import static com.code_intelligence.jazzer.mutation.support.Preconditions.require;
 import static com.code_intelligence.jazzer.mutation.support.TestSupport.anyPseudoRandom;
-import static com.code_intelligence.jazzer.mutation.support.TestSupport.asMap;
 import static com.code_intelligence.jazzer.mutation.support.TypeSupport.asAnnotatedType;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
@@ -38,7 +37,7 @@ import com.code_intelligence.jazzer.mutation.annotation.InRange;
 import com.code_intelligence.jazzer.mutation.annotation.NotNull;
 import com.code_intelligence.jazzer.mutation.annotation.WithSize;
 import com.code_intelligence.jazzer.mutation.annotation.proto.AnySource;
-import com.code_intelligence.jazzer.mutation.annotation.proto.DescriptorSource;
+import com.code_intelligence.jazzer.mutation.annotation.proto.WithDefaultInstance;
 import com.code_intelligence.jazzer.mutation.api.PseudoRandom;
 import com.code_intelligence.jazzer.mutation.api.Serializer;
 import com.code_intelligence.jazzer.mutation.api.SerializingMutator;
@@ -94,12 +93,14 @@ public class StressTest {
   private static final int NUM_MUTATE_PER_INIT = 100;
   private static final double MANY_DISTINCT_ELEMENTS_RATIO = 0.5;
 
-  @SuppressWarnings("unused")
-  static final Descriptor TEST_PROTOBUF_DESCRIPTOR = TestProtobuf.getDescriptor();
-
   private enum TestEnumTwo { A, B }
 
   private enum TestEnumThree { A, B, C }
+
+  @SuppressWarnings("unused")
+  static Message getTestProtobufDefaultInstance() {
+    return TestProtobuf.getDefaultInstance();
+  }
 
   public static Stream<Arguments> stressTestCases() {
     return Stream.of(arguments(asAnnotatedType(boolean.class), "Boolean", exactly(false, true),
@@ -305,9 +306,9 @@ public class StressTest {
             "{Builder.Nullable<Boolean>, Builder.Nullable<Integer>, Builder.Nullable<Integer>, Builder.Nullable<Long>, Builder.Nullable<Long>, Builder.Nullable<Float>, Builder.Nullable<Double>, Builder.Nullable<String>, Builder.Nullable<Enum<Enum>>, WithoutInit(Builder.Nullable<{Builder.Nullable<Integer>, Builder via List<Integer>, WithoutInit(Builder.Nullable<(cycle) -> Message>)} -> Message>), Builder via List<Boolean>, Builder via List<Integer>, Builder via List<Integer>, Builder via List<Long>, Builder via List<Long>, Builder via List<Float>, Builder via List<Double>, Builder via List<String>, Builder via List<Enum<Enum>>, WithoutInit(Builder via List<(cycle) -> Message>), Builder.Map<Integer,Integer>, Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<{<empty>} -> Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> | Builder.Nullable<Integer>} -> Message",
             manyDistinctElements(), manyDistinctElements()),
         arguments(
-            new TypeHolder<@NotNull @DescriptorSource(
-                "com.code_intelligence.jazzer.mutation.mutator.StressTest#TEST_PROTOBUF_DESCRIPTOR")
-                DynamicMessage>() {
+            new TypeHolder<@NotNull @WithDefaultInstance(
+                "com.code_intelligence.jazzer.mutation.mutator.StressTest#getTestProtobufDefaultInstance")
+                Message>() {
             }.annotatedType(),
             "{Builder.Nullable<Boolean>, Builder.Nullable<Integer>, Builder.Nullable<Integer>, Builder.Nullable<Long>, Builder.Nullable<Long>, Builder.Nullable<Float>, Builder.Nullable<Double>, Builder.Nullable<String>, Builder.Nullable<Enum<Enum>>, WithoutInit(Builder.Nullable<{Builder.Nullable<Integer>, Builder via List<Integer>, WithoutInit(Builder.Nullable<(cycle) -> Message>)} -> Message>), Builder via List<Boolean>, Builder via List<Integer>, Builder via List<Integer>, Builder via List<Long>, Builder via List<Long>, Builder via List<Float>, Builder via List<Double>, Builder via List<String>, Builder via List<Enum<Enum>>, WithoutInit(Builder via List<(cycle) -> Message>), Builder.Map<Integer,Integer>, Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<{<empty>} -> Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> | Builder.Nullable<Integer>} -> Message",
             manyDistinctElements(), manyDistinctElements()),

--- a/tests/src/test/java/com/example/ExperimentalMutatorDynamicProtoFuzzer.java
+++ b/tests/src/test/java/com/example/ExperimentalMutatorDynamicProtoFuzzer.java
@@ -18,7 +18,7 @@ package com.example;
 
 import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium;
 import com.code_intelligence.jazzer.mutation.annotation.NotNull;
-import com.code_intelligence.jazzer.mutation.annotation.proto.DescriptorSource;
+import com.code_intelligence.jazzer.mutation.annotation.proto.WithDefaultInstance;
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type;
@@ -28,20 +28,20 @@ import com.google.protobuf.Descriptors.DescriptorValidationException;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.DynamicMessage;
+import com.google.protobuf.Message;
 
 public class ExperimentalMutatorDynamicProtoFuzzer {
-  private static final Descriptor DESCRIPTOR = makeDescriptor();
-  private static final FieldDescriptor I32 = DESCRIPTOR.findFieldByName("i32");
-  private static final FieldDescriptor STR = DESCRIPTOR.findFieldByName("str");
-
-  public static void fuzzerTestOneInput(@NotNull @DescriptorSource(
-      "com.example.ExperimentalMutatorDynamicProtoFuzzer#DESCRIPTOR") DynamicMessage proto) {
+  public static void fuzzerTestOneInput(@NotNull @WithDefaultInstance(
+      "com.example.ExperimentalMutatorDynamicProtoFuzzer#getDefaultInstance") Message proto) {
+    FieldDescriptor I32 = proto.getDescriptorForType().findFieldByName("i32");
+    FieldDescriptor STR = proto.getDescriptorForType().findFieldByName("str");
     if (proto.getField(I32).equals(1234) && proto.getField(STR).equals("abcd")) {
       throw new FuzzerSecurityIssueMedium("Secret proto is found!");
     }
   }
 
-  private static Descriptor makeDescriptor() {
+  @SuppressWarnings("unused")
+  private static DynamicMessage getDefaultInstance() {
     DescriptorProto myMessage =
         DescriptorProto.newBuilder()
             .setName("my_message")
@@ -55,8 +55,8 @@ public class ExperimentalMutatorDynamicProtoFuzzer {
                                    .addMessageType(myMessage)
                                    .build();
     try {
-      return FileDescriptor.buildFrom(file, new FileDescriptor[0])
-          .findMessageTypeByName("my_message");
+      return DynamicMessage.getDefaultInstance(FileDescriptor.buildFrom(file, new FileDescriptor[0])
+                                                   .findMessageTypeByName("my_message"));
     } catch (DescriptorValidationException e) {
       throw new IllegalStateException(e);
     }


### PR DESCRIPTION
A default instance is a more direct representation of a protobuf base message and getting it via a method allows for more flexible use, e.g., by making the choice of proto type dependent on command-line arguments.