### PR TITLE
Ignore JetBrains classes during instrumentation

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -181,7 +181,10 @@ class RuntimeInstrumentor(
             .acceptClasses(className)
             .scan()
             .use {
-                it.getClassInfo(className).resource.load()
+                it.getClassInfo(className)?.resource?.load() ?: run {
+                    Log.warn("Failed to load bytecode of class $className")
+                    return null
+                }
             }
         val (instrumentedBytecode, duration) = measureTimedValue {
             try {

--- a/src/main/java/com/code_intelligence/jazzer/junit/AgentConfigurator.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/AgentConfigurator.java
@@ -65,7 +65,7 @@ class AgentConfigurator {
     // Do not hook common IDE and JUnit classes and their dependencies.
     System.setProperty("jazzer.custom_hook_excludes",
         String.join(File.pathSeparator, "com.google.testing.junit.**", "com.intellij.**",
-            "io.github.classgraph.**", "junit.framework.**", "net.bytebuddy.**",
+            "org.jetbrains.**", "io.github.classgraph.**", "junit.framework.**", "net.bytebuddy.**",
             "org.apiguardian.**", "org.assertj.core.**", "org.hamcrest.**", "org.junit.**",
             "org.opentest4j.**", "org.mockito.**", "org.apache.maven.**", "org.gradle.**"));
   }

--- a/src/main/java/com/code_intelligence/jazzer/utils/ClassNameGlobber.kt
+++ b/src/main/java/com/code_intelligence/jazzer/utils/ClassNameGlobber.kt
@@ -48,6 +48,7 @@ private val BASE_EXCLUDED_CLASS_NAME_GLOBS = listOf(
     "org.junit.**", // dependency of @FuzzTest
     "org.mockito.**", // can cause instrumentation cycles
     "net.bytebuddy.**", // ignore Byte Buddy, though it's probably shaded
+    "org.jetbrains.**", // ignore JetBrains products (coverage agent)
 ) + if (IS_BAZEL_COVERAGE_RUN) ADDITIONAL_EXCLUDED_NAME_GLOBS_FOR_BAZEL_COVERAGE else listOf()
 
 class ClassNameGlobber(includes: List<String>, excludes: List<String>) {


### PR DESCRIPTION
Some JetBrains products interact badly with Jazzer's agent / instrumentation, e.g. their coverage agent. It's reasonable to ignore all JetBrains classes.