### PR TITLE
hooks: Add equals-hook for Clojure (clojure.lang.Util.equiv)

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
@@ -99,6 +99,15 @@ final public class TraceCmpHooks {
     }
   }
 
+  @MethodHook(type = HookType.AFTER, targetClassName = "clojure.lang.Util", targetMethod = "equiv")
+  public static void genericStaticEquals(
+      MethodHandle method, Object thisObject, Object[] arguments, int hookId, Boolean areEqual) {
+    if (!areEqual && arguments.length == 2 && arguments[0] != null && arguments[1] != null
+        && arguments[1].getClass() == arguments[0].getClass()) {
+      TraceDataFlowNativeCallbacks.traceGenericCmp(arguments[0], arguments[1], hookId);
+    }
+  }
+
   @MethodHook(
       type = HookType.AFTER, targetClassName = "java.lang.String", targetMethod = "compareTo")
   @MethodHook(type = HookType.AFTER, targetClassName = "java.lang.String",


### PR DESCRIPTION
I could have reused `assertEquals` [[L]](https://github.com/CodeIntelligenceTesting/jazzer/blob/3869b7395de165e94093379e83adf6e978871cb7/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java#L584). But since this is not an assertion-hook, I decided to write a new function in proximity to `genericEquals` [[L]](https://github.com/CodeIntelligenceTesting/jazzer/blob/3869b7395de165e94093379e83adf6e978871cb7/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java#L94).

~Also I'm not totally sure, what the meaning of the `Boolean areEqual` parameter is? (In `assertEquals` it is called `Object alwaysNull` and in the [ExampleHook](https://github.com/CodeIntelligenceTesting/jazzer/blob/main/examples/src/main/java/com/example/ExampleFuzzerHooks.java) it's not defined at all …~ Ah, I found the documentation in [the MethodHook documentation](https://codeintelligencetesting.github.io/jazzer-docs/jazzer-api/com/code_intelligence/jazzer/api/MethodHook.html)