### PR TITLE
Add new ANDROID_ONLY compatibility option

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -51,11 +51,6 @@ build:windows --features=static_link_msvcrt
 test:windows --noincompatible_strict_action_env
 run:windows --noincompatible_strict_action_env
 
-# macOS
-# Workaround for https://github.com/bazelbuild/bazel/issues/13944, which breaks external Java
-# dependencies on M1 Macs without Rosetta.
-build:macos --extra_toolchains=//bazel/toolchains:java_non_prebuilt_definition
-
 # Toolchain
 # Since the toolchain is conditional on OS and architecture, set it on the particular GitHub Action.
 common:toolchain --repo_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1

--- a/.github/workflows/run-all-tests.yml
+++ b/.github/workflows/run-all-tests.yml
@@ -39,7 +39,6 @@ jobs:
           - os: ubuntu-20.04
             arch: "linux"
             cache: "/home/runner/.cache/bazel-disk"
-            bazel_args: "//launcher/android:jazzer_android"
           - os: ubuntu-20.04
             jdk: 20
             # Workaround for https://github.com/bazelbuild/bazel/issues/14502

--- a/bazel/compat.bzl
+++ b/bazel/compat.bzl
@@ -27,6 +27,8 @@ LINUX_ONLY = select({
     "//conditions:default": ["@platforms//:incompatible"],
 })
 
+ANDROID_ONLY = ["@platforms//os:android"]
+
 MULTI_PLATFORM = select({
     "@platforms//os:macos": [
         "//bazel/platforms:macos_arm64",

--- a/launcher/android/BUILD.bazel
+++ b/launcher/android/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:compat.bzl", "SKIP_ON_WINDOWS")
+load("//bazel:compat.bzl", "ANDROID_ONLY", "SKIP_ON_WINDOWS")
 
 android_library(
     name = "jazzer_android_lib",
@@ -7,7 +7,7 @@ android_library(
         "//src/main/java/com/code_intelligence/jazzer/android:jazzer_standalone_android.apk",
     ],
     tags = ["manual"],
-    target_compatible_with = SKIP_ON_WINDOWS,
+    target_compatible_with = ANDROID_ONLY,
 )
 
 android_binary(

--- a/src/main/java/com/code_intelligence/jazzer/Jazzer.java
+++ b/src/main/java/com/code_intelligence/jazzer/Jazzer.java
@@ -99,8 +99,7 @@ public class Jazzer {
     // No native fuzzing has been requested, fuzz in the current process.
     if (!fuzzNative) {
       if (IS_ANDROID) {
-        final String initOptions = getAndroidRuntimeOptions();
-        AndroidRuntime.initialize(initOptions);
+        AndroidRuntime.initialize();
       }
       // We only create a wrapper script if libFuzzer runs in a mode that creates subprocesses.
       // In LibFuzzer's fork mode, the subprocesses created continuously by the main libFuzzer
@@ -482,16 +481,6 @@ public class Jazzer {
 
   private static boolean isPosix() {
     return !IS_ANDROID && FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
-  }
-
-  private static String getAndroidRuntimeOptions() {
-    List<String> validInitOptions = Arrays.asList("use_platform_libs", "use_none", "");
-    String initOptString = Opt.androidInitOptions.get();
-    if (!validInitOptions.contains(initOptString)) {
-      Log.error("Invalid android_init_options set for Android Runtime.");
-      exit(1);
-    }
-    return initOptString;
   }
 
   private static boolean isPosixOrAndroid() {

--- a/src/main/java/com/code_intelligence/jazzer/android/AndroidRuntime.java
+++ b/src/main/java/com/code_intelligence/jazzer/android/AndroidRuntime.java
@@ -14,6 +14,8 @@
 
 package com.code_intelligence.jazzer.android;
 
+import static com.code_intelligence.jazzer.runtime.Constants.IS_ANDROID;
+
 import com.code_intelligence.jazzer.driver.Opt;
 import com.code_intelligence.jazzer.utils.Log;
 import com.github.fmeum.rules_jni.RulesJni;
@@ -23,19 +25,41 @@ import com.github.fmeum.rules_jni.RulesJni;
  */
 public class AndroidRuntime {
   private static final String DO_NOT_INITIALIZE = "use_none";
+  private static final String INIT_JAVA_ART = "use_platform_libs";
   private static final String FUZZ_DIR = "/data/fuzz/";
   private static final String PLATFORM_LIB_DIRS = ":/system/lib64/:/apex/com.android.i18n@1/lib64/";
 
-  public static void initialize(String runtimeLibs) {
-    if (runtimeLibs == null) {
+  static {
+    if (IS_ANDROID) {
+      RulesJni.loadLibrary("jazzer_android_tooling", "/com/code_intelligence/jazzer/driver");
+    }
+  }
+
+  public static void initialize() {
+    if (!IS_ANDROID) {
       return;
     }
 
-    RulesJni.loadLibrary("jazzer_android_tooling", "/com/code_intelligence/jazzer/driver");
-    if (runtimeLibs.equals(DO_NOT_INITIALIZE)) {
-      Log.warn("Android Runtime (ART) is not being initialized for this fuzzer.");
-    } else {
-      registerNatives();
+    String androidInitOptions = Opt.androidInitOptions.get();
+    if (androidInitOptions == null) {
+      return;
+    }
+
+    switch (androidInitOptions) {
+      case INIT_JAVA_ART:
+        registerNatives();
+        break;
+
+      case DO_NOT_INITIALIZE:
+      case "":
+        Log.warn("Android Runtime (ART) is not being initialized for this fuzzer.");
+        break;
+
+      default:
+        Log.error(String.format(
+            "%s is not a valid options for android_init_options. Valid Options: [use_none, use_platform_libs]",
+            androidInitOptions));
+        System.exit(1);
     }
   };
 
@@ -50,18 +74,18 @@ public class AndroidRuntime {
 
   /**
    * Builds and returns the value to set for LD_LIBRARY_PATH.
-   * This value is consumed when launching jazzer on the device
-   * and specifies which directories to search for dependencies.
    *
    * @return The string for LD_LIBRARY_PATH.
    */
   public static String getLdLibraryPath() {
+    String ldLibraryPath = FUZZ_DIR;
+
     String initOptString = Opt.androidInitOptions.get();
-    if (initOptString.equals(DO_NOT_INITIALIZE) || initOptString.equals("")) {
-      return FUZZ_DIR;
+    if (initOptString != null && initOptString.equals(INIT_JAVA_ART)) {
+      ldLibraryPath += PLATFORM_LIB_DIRS;
     }
 
-    return FUZZ_DIR + PLATFORM_LIB_DIRS;
+    return ldLibraryPath;
   }
 
   private static native int registerNatives();

--- a/src/main/java/com/code_intelligence/jazzer/android/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/android/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:compat.bzl", "SKIP_ON_WINDOWS")
+load("//bazel:compat.bzl", "ANDROID_ONLY", "SKIP_ON_WINDOWS")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@fmeum_rules_jni//jni:defs.bzl", "java_jni_library")
 
@@ -8,13 +8,13 @@ java_import(
         "//src/main/java/com/code_intelligence/jazzer/runtime:jazzer_bootstrap",
     ],
     tags = ["manual"],
-    target_compatible_with = SKIP_ON_WINDOWS,
+    target_compatible_with = ANDROID_ONLY,
 )
 
 android_library(
     name = "jazzer_bootstrap_android_lib",
     tags = ["manual"],
-    target_compatible_with = SKIP_ON_WINDOWS,
+    target_compatible_with = ANDROID_ONLY,
     visibility = [
         "//src/main/java/com/code_intelligence/jazzer/agent:__pkg__",
     ],
@@ -28,7 +28,7 @@ android_binary(
     manifest = "//launcher/android:android_manifest",
     min_sdk_version = 26,
     tags = ["manual"],
-    target_compatible_with = SKIP_ON_WINDOWS,
+    target_compatible_with = ANDROID_ONLY,
     deps = [
         ":jazzer_bootstrap_android_lib",
     ],
@@ -39,7 +39,7 @@ copy_file(
     src = "jazzer_bootstrap_android_bin.apk",
     out = "jazzer_bootstrap_android.jar",
     tags = ["manual"],
-    target_compatible_with = SKIP_ON_WINDOWS,
+    target_compatible_with = ANDROID_ONLY,
     visibility = [
         "//src/main/java/com/code_intelligence/jazzer/agent:__pkg__",
     ],
@@ -51,12 +51,14 @@ java_jni_library(
     native_libs = [
         "//src/main/native/com/code_intelligence/jazzer/android:android_native_agent",
     ],
+    tags = ["manual"],
+    target_compatible_with = ANDROID_ONLY,
 )
 
 android_library(
     name = "jazzer_standalone_library",
     tags = ["manual"],
-    target_compatible_with = SKIP_ON_WINDOWS,
+    target_compatible_with = ANDROID_ONLY,
     exports = [
         "//deploy:jazzer-api-lib",
         "//src/main/java/com/code_intelligence/jazzer:jazzer_import",
@@ -68,7 +70,7 @@ android_binary(
     manifest = "//launcher/android:android_manifest",
     min_sdk_version = 26,
     tags = ["manual"],
-    target_compatible_with = SKIP_ON_WINDOWS,
+    target_compatible_with = ANDROID_ONLY,
     visibility = [
         "//:__pkg__",
         "//launcher/android:__pkg__",
@@ -83,9 +85,12 @@ java_jni_library(
     name = "android_runtime",
     srcs = ["AndroidRuntime.java"],
     native_libs = select({
-        "@platforms//os:windows": [],
-        "//conditions:default": ["//src/main/native/com/code_intelligence/jazzer/driver:jazzer_android_tooling"],
+        "@platforms//os:android": [
+            "//src/main/native/com/code_intelligence/jazzer/driver:jazzer_android_tooling",
+        ],
+        "//conditions:default": [],
     }),
+    tags = ["manual"],
     visibility = [
         "//src/main/java/com/code_intelligence/jazzer:__pkg__",
         "//src/main/java/com/code_intelligence/jazzer/driver:__subpackages__",
@@ -93,6 +98,7 @@ java_jni_library(
     ],
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/driver:opt",
+        "//src/main/java/com/code_intelligence/jazzer/runtime:constants",
         "//src/main/java/com/code_intelligence/jazzer/utils:log",
     ],
 )

--- a/src/main/java/com/code_intelligence/jazzer/driver/OfflineInstrumentor.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/OfflineInstrumentor.java
@@ -78,7 +78,7 @@ public class OfflineInstrumentor {
       }
 
       try {
-        createInstrumentedJar(jarPath, Opt.dumpClassesDir + File.separator + outputBaseName,
+        createInstrumentedJar(jarPath, Opt.dumpClassesDir.get() + File.separator + outputBaseName,
             outputBaseName + ".instrumented.jar");
       } catch (Exception e) {
         errorMessages.add("Failed to instrument jar: " + jarPath + ". Error: " + e);

--- a/src/main/java/com/code_intelligence/jazzer/utils/ZipUtils.java
+++ b/src/main/java/com/code_intelligence/jazzer/utils/ZipUtils.java
@@ -81,7 +81,7 @@ public final class ZipUtils {
     HashSet<String> filesAdded = new HashSet<>();
     File sourceDir = new File(src);
     if (!sourceDir.isDirectory()) {
-      throw new IllegalArgumentException("Argument src must be a directory.");
+      throw new IllegalArgumentException("Argument src must be a directory. Path provided: " + src);
     }
 
     Files.walkFileTree(sourceDir.toPath(), new SimpleFileVisitor<Path>() {

--- a/src/main/native/com/code_intelligence/jazzer/android/BUILD.bazel
+++ b/src/main/native/com/code_intelligence/jazzer/android/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bazel:compat.bzl", "SKIP_ON_WINDOWS")
+load("//bazel:compat.bzl", "ANDROID_ONLY")
 load("@fmeum_rules_jni//jni:defs.bzl", "cc_jni_library")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 
@@ -8,7 +8,7 @@ copy_file(
     out = "jvmti.encoded",
     is_executable = False,
     tags = ["manual"],
-    target_compatible_with = SKIP_ON_WINDOWS,
+    target_compatible_with = ANDROID_ONLY,
 )
 
 genrule(
@@ -19,7 +19,7 @@ genrule(
     outs = ["jvmti.h"],
     cmd = "cat $< | base64 --decode > $(OUTS)",
     tags = ["manual"],
-    target_compatible_with = SKIP_ON_WINDOWS,
+    target_compatible_with = ANDROID_ONLY,
 )
 
 cc_jni_library(
@@ -38,7 +38,7 @@ cc_jni_library(
         "-lz",
     ],
     tags = ["manual"],
-    target_compatible_with = SKIP_ON_WINDOWS,
+    target_compatible_with = ANDROID_ONLY,
     visibility = ["//visibility:public"],
     deps = [
         "@com_google_absl//absl/strings",

--- a/src/main/native/com/code_intelligence/jazzer/android/BUILD.bazel
+++ b/src/main/native/com/code_intelligence/jazzer/android/BUILD.bazel
@@ -17,7 +17,7 @@ genrule(
         "jvmti.encoded",
     ],
     outs = ["jvmti.h"],
-    cmd = "base64 --decode $< > $(OUTS)",
+    cmd = "cat $< | base64 --decode > $(OUTS)",
     tags = ["manual"],
     target_compatible_with = SKIP_ON_WINDOWS,
 )

--- a/src/main/native/com/code_intelligence/jazzer/driver/BUILD.bazel
+++ b/src/main/native/com/code_intelligence/jazzer/driver/BUILD.bazel
@@ -37,7 +37,7 @@ cc_jni_library(
     name = "jazzer_android_tooling",
     srcs = ["android_tooling.cpp"],
     platforms = MULTI_PLATFORM,
-    target_compatible_with = SKIP_ON_WINDOWS,
+    tags = ["manual"],
     visibility = ["//src/main/java/com/code_intelligence/jazzer/android:__pkg__"],
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/android:android_runtime.hdrs",

--- a/src/main/native/com/code_intelligence/jazzer/driver/android_tooling.cpp
+++ b/src/main/native/com/code_intelligence/jazzer/driver/android_tooling.cpp
@@ -47,8 +47,7 @@ Java_com_code_1intelligence_jazzer_android_AndroidRuntime_registerNatives(
       dlsym(handle, "registerFrameworkNatives"));
   const char *dlsym_error = dlerror();
   if (dlsym_error) {
-    std::cerr << "ERROR: Unable to invoke registerFrameworkNatives."
-              << std::endl;
+    std::cerr << "ERROR: Unable to find registerFrameworkNatives." << std::endl;
     exit(1);
   }
 


### PR DESCRIPTION
This is to correct the Android build targets compatibility configuration. This makes the Android build targets only compatible when building for Android target.

This will also add a check that will fail with a message when building for Android on a non-linux host machine. This is because:
1. Android modules aren't supported on Windows
2. the genrule command needed for jvmti.h doesn't work on Mac 
