### PR TITLE
Add an override of reversed to Zer for compatibility with JDK 21

### DIFF
--- a/src/main/java/jaz/Zer.java
+++ b/src/main/java/jaz/Zer.java
@@ -349,6 +349,11 @@ public class Zer
     return this;
   }
 
+  public Zer reversed() {
+    reportFindingIfEnabled();
+    return this;
+  }
+
   // readObject calls can directly result in RCE, see https://github.com/frohoff/ysoserial for
   // examples. Since deserialization doesn't call constructors (see
   // https://docs.oracle.com/javase/7/docs/platform/serialization/spec/input.html#2971), we emit a


### PR DESCRIPTION
This change allows Zer to compile with JDK 21, which adds new methods to the collections API for https://openjdk.org/jeps/431

Fixes https://github.com/CodeIntelligenceTesting/jazzer/issues/781