### PR TITLE
runtime: Fix ClassCastException for primitive `compare` calls

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
@@ -37,7 +37,8 @@ final public class TraceCmpHooks {
       targetMethod = "compare", targetMethodDescriptor = "(II)I")
   public static void
   integerCompare(MethodHandle method, Object alwaysNull, Object[] arguments, int hookId) {
-    TraceDataFlowNativeCallbacks.traceCmpInt((int) arguments[0], (int) arguments[1], hookId);
+    TraceDataFlowNativeCallbacks.traceCmpInt(
+        ((Number) arguments[0]).intValue(), ((Number) arguments[1]).intValue(), hookId);
   }
 
   @MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.Byte",
@@ -48,7 +49,8 @@ final public class TraceCmpHooks {
       targetMethod = "compareTo", targetMethodDescriptor = "(Ljava/lang/Integer;)I")
   public static void
   integerCompareTo(MethodHandle method, Object thisObject, Object[] arguments, int hookId) {
-    TraceDataFlowNativeCallbacks.traceCmpInt((int) thisObject, (int) arguments[0], hookId);
+    TraceDataFlowNativeCallbacks.traceCmpInt(
+        ((Number) thisObject).intValue(), ((Number) arguments[0]).intValue(), hookId);
   }
 
   @MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.Long", targetMethod = "compare",

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -563,4 +563,12 @@ sh_test(
     ],
 )
 
+java_fuzz_target_test(
+    name = "PrimitiveTypeCompareHookFuzzer",
+    srcs = ["src/test/java/com/example/PrimitiveTypeCompareHookFuzzer.java"],
+    allowed_findings = ["com.code_intelligence.jazzer.api.FuzzerSecurityIssueCritical"],
+    fuzzer_args = ["-runs=0"],
+    target_class = "com.example.PrimitiveTypeCompareHookFuzzer",
+)
+
 ktlint()

--- a/tests/src/test/java/com/example/PrimitiveTypeCompareHookFuzzer.java
+++ b/tests/src/test/java/com/example/PrimitiveTypeCompareHookFuzzer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueCritical;
+
+/*
+ * Regression test for https://github.com/CodeIntelligenceTesting/jazzer/issues/790.
+ */
+public class PrimitiveTypeCompareHookFuzzer {
+  public static void fuzzerTestOneInput(FuzzedDataProvider data) {
+    Byte.compare(data.consumeByte(), (byte) 127);
+    Short.compare(data.consumeShort(), (short) 4096);
+    throw new FuzzerSecurityIssueCritical();
+  }
+}


### PR DESCRIPTION
Previously, calls to `{Byte,Short}.compare{Unsigned,}` resulted in exceptions such as the following:

```
java.lang.ClassCastException: class java.lang.Short cannot be cast to class java.lang.Integer (java.lang.Short and java.lang.Integer are in module java.base of loader 'bootstrap')
	at com.code_intelligence.jazzer.runtime.TraceCmpHooks.integerCompare(TraceCmpHooks.java:40)
        ...
```

Fixes #790 