### PR TITLE
bazel: Start building before all external deps are fetched 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,8 @@ build --enable_platform_specific_config
 build -c opt
 # Ensure that paths of files printed by our examples are valid.
 build --nozip_undeclared_test_outputs
+# Allow build to start before all external deps have been fetched.
+common --experimental_merged_skyframe_analysis_execution
 
 # C/C++
 # GCC is supported on a best-effort basis.


### PR DESCRIPTION
This is a new feature that will be enabled by default soon, but should already be stable enough to speed up our builds with.

This requires updating Bazel to fix https://github.com/bazelbuild/bazel/issues/18969.