### PR TITLE
Change fuzzing to only execute if the secret is available

### DIFF
--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -20,10 +20,8 @@ env:
   CIFUZZ_INSTALL_DIR: ./cifuzz
   FUZZING_ARTIFACT: fuzzing-artifact.tar.gz
 jobs:
-  fuzz_tests:
+  setup:
     runs-on: ubuntu-latest
-    # Configure your build environment here
-    # container: example/docker_image
     steps:
       - id: checkout
         name: Checkout Repository
@@ -59,6 +57,15 @@ jobs:
             --branch $GITHUB_REF_NAME \
             --output $GITHUB_WORKSPACE/$CHECKOUT_DIR/$FUZZING_ARTIFACT
         shell: "bash"
+
+
+  fuzz_tests:
+    runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets
+    env:
+      ci_fuzz_token: ${{ secrets.CI_FUZZ_API_TOKEN }}
+    if: ${{ env.ci_fuzz_token != '' }}
+    steps:
       - id: start-fuzzing
         name: Start Fuzzing
         uses: CodeIntelligenceTesting/github-actions/start-fuzzing@v5

--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -64,11 +64,11 @@ jobs:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets
     env:
       ci_fuzz_token: ${{ secrets.CI_FUZZ_API_TOKEN }}
-    if: ${{ env.ci_fuzz_token != '' }}
     steps:
       - id: start-fuzzing
         name: Start Fuzzing
         uses: CodeIntelligenceTesting/github-actions/start-fuzzing@v5
+        if: ${{ env.ci_fuzz_token != '' }}
         with:
           ci_fuzz_api_token: ${{ secrets.CI_FUZZ_API_TOKEN }}
           fuzzing_server_address: ${{ env.FUZZING_SERVER_ADDRESS }}
@@ -77,6 +77,7 @@ jobs:
       - id: monitor-fuzzing
         name: Fuzzing
         uses: CodeIntelligenceTesting/github-actions/monitor-fuzzing@v5
+        if: ${{ env.ci_fuzz_token != '' }}
         with:
           ci_fuzz_api_token: ${{ secrets.CI_FUZZ_API_TOKEN }}
           test_collection_run: ${{ steps.start-fuzzing.outputs.test_collection_run }}
@@ -85,7 +86,7 @@ jobs:
       - id: save-results
         name: Save Fuzz Test Results
         uses: CodeIntelligenceTesting/github-actions/save-results@v5
-        if: ${{ success() || failure() }}
+        if: ${{ env.ci_fuzz_token != '' && (success() || failure()) }}
         with:
           ci_fuzz_api_token: ${{ secrets.CI_FUZZ_API_TOKEN }}
           test_collection_run: ${{ steps.start-fuzzing.outputs.test_collection_run }}
@@ -93,7 +94,7 @@ jobs:
           dashboard_address: ${{ env.WEB_APP_ADDRESS }}
       - id: upload-artifact
         uses: actions/upload-artifact@v2
-        if: ${{ (success() || failure()) }}
+        if: ${{ env.ci_fuzz_token != '' && (success() || failure()) }}
         with:
           name: ci_fuzz_results
           path: |

--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -22,6 +22,9 @@ env:
 jobs:
   setup:
     runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets
+    env:
+      ci_fuzz_token: ${{ secrets.CI_FUZZ_API_TOKEN }}
     steps:
       - id: checkout
         name: Checkout Repository
@@ -57,15 +60,6 @@ jobs:
             --branch $GITHUB_REF_NAME \
             --output $GITHUB_WORKSPACE/$CHECKOUT_DIR/$FUZZING_ARTIFACT
         shell: "bash"
-
-
-  fuzz_tests:
-    runs-on: ubuntu-latest
-    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets
-    env:
-      ci_fuzz_token: ${{ secrets.CI_FUZZ_API_TOKEN }}
-    needs: ["setup"]
-    steps:
       - id: start-fuzzing
         name: Start Fuzzing
         uses: CodeIntelligenceTesting/github-actions/start-fuzzing@v5

--- a/.github/workflows/fuzzing.yaml
+++ b/.github/workflows/fuzzing.yaml
@@ -64,6 +64,7 @@ jobs:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-secrets
     env:
       ci_fuzz_token: ${{ secrets.CI_FUZZ_API_TOKEN }}
+    needs: ["setup"]
     steps:
       - id: start-fuzzing
         name: Start Fuzzing


### PR DESCRIPTION
PRs from forks will fail because they won't have the required API key for CI Sense so this changes our fuzz test workflow to skip them if the key is not there.

Should unstuck #780 