### PR TITLE
bazel: Remove usages of host JDK

### DIFF
--- a/deploy/BUILD.bazel
+++ b/deploy/BUILD.bazel
@@ -96,10 +96,11 @@ java_export(
         srcs = [artifact + "_artifact_test.sh"],
         args = [
             "$(rootpath :%s)" % artifact,
+            "$(JAVABASE)",
         ],
         data = [
             ":" + artifact,
-            "@local_jdk//:bin/jar",
+            "@bazel_tools//tools/jdk:current_java_runtime",
         ],
         tags = [
             # Coverage instrumentation necessarily adds files to the jar that we
@@ -107,6 +108,9 @@ java_export(
             "no-coverage",
         ],
         target_compatible_with = SKIP_ON_WINDOWS,
+        toolchains = [
+            "@bazel_tools//tools/jdk:current_java_runtime",
+        ],
     )
     for artifact in [
         "jazzer-api",

--- a/deploy/jazzer-api_artifact_test.sh
+++ b/deploy/jazzer-api_artifact_test.sh
@@ -14,10 +14,12 @@
 # limitations under the License.
 
 [ -f "$1" ] || exit 1
+JAR="$2/bin/jar"
+[ -e "$JAR" ] || exit 1
 # List all files in the jar and exclude an allowed list of files.
 # Since grep fails if there is no match, ! ... | grep ... fails if there is a
 # match.
-! external/local_jdk/bin/jar tf "$1" | \
+! "$JAR" tf "$1" | \
   grep -v \
     -e '^com/$' \
     -e '^com/code_intelligence/$' \

--- a/deploy/jazzer-junit_artifact_test.sh
+++ b/deploy/jazzer-junit_artifact_test.sh
@@ -14,10 +14,12 @@
 # limitations under the License.
 
 [ -f "$1" ] || exit 1
+JAR="$2/bin/jar"
+[ -e "$JAR" ] || exit 1
 # List all files in the jar and exclude an allowed list of files.
 # Since grep fails if there is no match, ! ... | grep ... fails if there is a
 # match.
-! external/local_jdk/bin/jar tf "$1" | \
+! "$JAR" tf "$1" | \
   grep -v \
     -e '^com/$' \
     -e '^com/code_intelligence/$' \

--- a/deploy/jazzer_artifact_test.sh
+++ b/deploy/jazzer_artifact_test.sh
@@ -14,10 +14,12 @@
 # limitations under the License.
 
 [ -f "$1" ] || exit 1
+JAR="$2/bin/jar"
+[ -e "$JAR" ] || exit 1
 # List all files in the jar and exclude an allowed list of files.
 # Since grep fails if there is no match, ! ... | grep ... fails if there is a
 # match.
-! external/local_jdk/bin/jar tf "$1" | \
+! "$JAR" tf "$1" | \
   grep -v \
     -e '^com/$' \
     -e '^com/code_intelligence/$' \

--- a/src/main/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/BUILD.bazel
@@ -65,10 +65,11 @@ sh_test(
     srcs = ["verify_shading.sh"],
     args = [
         "$(rootpath jazzer_bootstrap.jar)",
+        "$(JAVABASE)",
     ],
     data = [
         "jazzer_bootstrap.jar",
-        "@local_jdk//:bin/jar",
+        "@bazel_tools//tools/jdk:current_java_runtime",
     ],
     tags = [
         # Coverage instrumentation necessarily adds files to the jar that we
@@ -76,6 +77,9 @@ sh_test(
         "no-coverage",
     ],
     target_compatible_with = SKIP_ON_WINDOWS,
+    toolchains = [
+        "@bazel_tools//tools/jdk:current_java_runtime",
+    ],
 )
 
 # At runtime, the AgentInstaller appends jazzer_bootstrap.jar to the bootstrap

--- a/src/main/java/com/code_intelligence/jazzer/runtime/verify_shading.sh
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/verify_shading.sh
@@ -14,10 +14,12 @@
 # limitations under the License.
 
 [ -f "$1" ] || exit 1
+JAR="$2/bin/jar"
+[ -e "$JAR" ] || exit 1
 # List all files in the jar and exclude an allowed list of files.
 # Since grep fails if there is no match, ! ... | grep ... fails if there is a
 # match.
-! external/local_jdk/bin/jar tf "$1" | \
+! "$JAR" tf "$1" | \
   grep -v \
     -e '^com/$' \
     -e '^com/code_intelligence/$' \


### PR DESCRIPTION
With this change, all tests should pass even without a local JDK.