### PR TITLE
junit: Fix CLI runs on individual files 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Do not perform LF/CRLF conversion during checkin or checkout.
+* -text

--- a/bazel/tools/java/com/code_intelligence/jazzer/tools/FuzzTargetTestWrapper.java
+++ b/bazel/tools/java/com/code_intelligence/jazzer/tools/FuzzTargetTestWrapper.java
@@ -157,10 +157,6 @@ public class FuzzTargetTestWrapper {
         System.exit(1);
       }
       List<Path> outputFiles = Files.list(outputDir).collect(toList());
-      if (outputFiles.isEmpty()) {
-        System.err.printf("Jazzer did not write a crashing input into %s%n", outputDir);
-        System.exit(1);
-      }
       // Verify that libFuzzer dumped a crashing input.
       if (shouldVerifyCrashInput
           && outputFiles.stream().noneMatch(

--- a/selffuzz/cifuzz.yaml
+++ b/selffuzz/cifuzz.yaml
@@ -36,8 +36,8 @@
 
 ## Command-line arguments to pass to libFuzzer.
 ## See https://llvm.org/docs/LibFuzzer.html#options
-#engine-args:
-# - -rss_limit_mb=4096
+engine-args:
+ - --experimental_mutator
 
 ## Maximum time to run fuzz tests. The default is to run indefinitely.
 #timeout: 30m

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -281,6 +281,29 @@ sh_test(
 )
 
 java_fuzz_target_test(
+    name = "JUnitReproducerTest",
+    srcs = ["src/test/java/com/example/JUnitReproducerTest.java"],
+    allowed_findings = ["com.code_intelligence.jazzer.api.FuzzerSecurityIssueCritical"],
+    data = [
+        "src/test/java/com/example/JUnitReproducerTest.seed",
+    ],
+    fuzzer_args = [
+        "$(rlocationpath src/test/java/com/example/JUnitReproducerTest.seed)",
+    ],
+    target_class = "com.example.JUnitReproducerTest",
+    verify_crash_input = False,
+    verify_crash_reproducer = False,
+    runtime_deps = [
+        "@maven//:org_junit_jupiter_junit_jupiter_engine",
+    ],
+    deps = [
+        "//deploy:jazzer-junit",
+        "@maven//:org_junit_jupiter_junit_jupiter_api",
+        "@maven//:org_junit_jupiter_junit_jupiter_params",
+    ],
+)
+
+java_fuzz_target_test(
     name = "TestMethodInManifestFuzzer",
     timeout = "short",
     srcs = ["src/test/java/com/example/TestMethodInManifestFuzzer.java"],

--- a/tests/src/test/java/com/example/JUnitReproducerTest.java
+++ b/tests/src/test/java/com/example/JUnitReproducerTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.code_intelligence.jazzer.api.FuzzerSecurityIssueCritical;
+import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Verifies that reproducing a single input works for @FuzzTests.
+ */
+class JUnitReproducerTest {
+  // echo "Hello, Jazzer!" | openssl dgst -binary -sha256 | openssl base64 -A
+  private static final byte[] TARGET_DIGEST =
+      Base64.getDecoder().decode("DmvypT3h1z31A1sD0XebOUmjn0QHsCvjGPOjYdRwG8Q=");
+
+  public static Stream<Arguments> fuzzTest() {
+    return Stream.of(arguments("Bye, Jazzer!".getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @MethodSource
+  @FuzzTest
+  void fuzzTest(byte[] data) throws NoSuchAlgorithmException {
+    MessageDigest digest = MessageDigest.getInstance("SHA-256");
+    // This check is impossible for the fuzzer to crack - the exception will only be thrown when the
+    // fuzz test is executed on the given seed.
+    if (MessageDigest.isEqual(digest.digest(data), TARGET_DIGEST)) {
+      throw new FuzzerSecurityIssueCritical("Digest found!");
+    }
+  }
+}

--- a/tests/src/test/java/com/example/JUnitReproducerTest.seed
+++ b/tests/src/test/java/com/example/JUnitReproducerTest.seed
@@ -1,0 +1,1 @@
+Hello, Jazzer!


### PR DESCRIPTION
When all user-provided libFuzzer path arguments are files, the JUnit
executor now correctly starts libFuzzer in reproduction mode by not
adding any directories to the command line. In particular, this fixes
a crash when Jazzer is invoked on a single file to reproduce a
particular finding.