### PR TITLE
driver: Enhance method-not-found errors when not using JUnit 5

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/driver/FuzzTargetFinder.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/FuzzTargetFinder.java
@@ -95,7 +95,8 @@ class FuzzTargetFinder {
             "%s must define exactly one of the following two functions:%n"
                 + "public static void fuzzerTestOneInput(byte[] ...)%n"
                 + "public static void fuzzerTestOneInput(FuzzedDataProvider ...)%n"
-                + "Note: Fuzz targets returning boolean are no longer supported; exceptions should be thrown instead of returning true.",
+                + "Note: Fuzz targets returning boolean are no longer supported; exceptions should be thrown instead of returning true.%n"
+                + "Note: When using the @FuzzTest annotation, you will need to set up JUnit 5, which can be as simple as adding a dependency on org.junit.jupiter:junit-jupiter-engine.",
             clazz.getName()));
       }
       fuzzTargetMethod = dataFuzzTarget.orElseGet(bytesFuzzTarget::get);


### PR DESCRIPTION
This adds a new note to the error message that appears when the `@FuzzTest` is used, but JUnit 5 is not set up / the dependency `junit-jupiter-engine` in missing in version 5.