### PR TITLE
Change cifuzz timeout value to 5 minutes

### DIFF
--- a/selffuzz/cifuzz.yaml
+++ b/selffuzz/cifuzz.yaml
@@ -40,7 +40,7 @@ engine-args:
  - --experimental_mutator
 
 ## Maximum time to run fuzz tests. The default is to run indefinitely.
-#timeout: 30m
+timeout: 5m
 
 ## By default, fuzz tests are executed in a sandbox to prevent accidental
 ## damage to the system. Set to false to run fuzz tests unsandboxed.


### PR DESCRIPTION
This changes the timeout for fuzzing in CI Sense to 5 minutes. Since the same corpora are used for subsequent fuzzing runs, it is not necessary to run for 30 minutes for every branch pushed.