### PR TITLE
junit: Do not depend on `junit-jupiter-engine`

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -64,6 +64,9 @@ def jazzer_dependencies(android = False):
             # Fixes an incompatibility with latest Bazel introduced in
             # https://github.com/bazelbuild/bazel/commit/d0e29582a2e788e8acdaf53fe30ab7f7dc592df3
             "//third_party:rules_jvm_external-add-toolchain-to-maven-project-jar.patch",
+            # https://github.com/bazelbuild/rules_jvm_external/pull/952
+            # Fixes javadoc generation when using neverlink dependencies.
+            "//third_party:rules_jvm_external-add-neverlink-deps-to-javadoc-classpath.patch",
         ],
         sha256 = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac",
         strip_prefix = "rules_jvm_external-5.3",

--- a/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -87,6 +87,12 @@ java_jni_library(
 java_library(
     name = "junit_internals_compile_only",
     neverlink = True,
+    # Do not add a dependency on junit-jupiter-engine to the POM file. The user
+    # has to add and control this dependency themselves if they want to use
+    # JUnit 5. Even if we added it, Maven resolution mechanics mean that we do
+    # not control the version anyway.
+    # https://github.com/junit-team/junit5/discussions/3441#discussioncomment-6884855
+    tags = ["maven:compile-only"],
     exports = [
         "@maven//:org_junit_jupiter_junit_jupiter_engine",
     ],

--- a/third_party/rules_jvm_external-add-neverlink-deps-to-javadoc-classpath.patch
+++ b/third_party/rules_jvm_external-add-neverlink-deps-to-javadoc-classpath.patch
@@ -1,0 +1,33 @@
+From 920048a2b213e2c7cb6ce679ffa5a414054339f6 Mon Sep 17 00:00:00 2001
+From: Fabian Meumertzheim <fabian@meumertzhe.im>
+Date: Fri, 1 Sep 2023 22:12:42 +0200
+Subject: [PATCH] Add compile-only deps to javadocs classpath
+
+javadoc may have to inspect compile-only dependencies.
+
+Also removes a line that only added elements to a depset that are
+already contained in this depset.
+---
+ private/rules/javadoc.bzl | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/private/rules/javadoc.bzl b/private/rules/javadoc.bzl
+index 325aced1..3261248a 100644
+--- a/private/rules/javadoc.bzl
++++ b/private/rules/javadoc.bzl
+@@ -21,9 +21,12 @@ def _javadoc_impl(ctx):
+ 
+     jar_file = ctx.actions.declare_file("%s.jar" % ctx.attr.name)
+ 
+-    # Gather additional files to add to the classpath
+-    additional_deps = depset(transitive = [dep[JavaInfo].transitive_runtime_jars for dep in ctx.attr.deps])
+-    classpath = depset(transitive = [dep[JavaInfo].transitive_runtime_jars for dep in ctx.attr.deps] + [additional_deps])
++    # javadoc may need to inspect compile-time dependencies (neverlink)
++    # of the runtime classpath.
++    classpath = depset(
++        transitive = [dep[JavaInfo].transitive_runtime_jars for dep in ctx.attr.deps] +
++                     [dep[JavaInfo].transitive_compile_time_jars for dep in ctx.attr.deps],
++    )
+ 
+     # javadoc options and javac options overlap, but we cannot
+     # necessarily rely on those to derive the javadoc options we need


### PR DESCRIPTION
The user has to add and control this dependency themselves if they want
to use JUnit 5. Even if we added it, Maven resolution mechanics mean
that we do not control the version anyway.

This fixes an issue introduced by 1ca007d04325014d4fa0e48d239745f3ecc8fbcf.

See https://github.com/junit-team/junit5/discussions/3441#discussioncomment-6884855

Also require fixing an issue in rules_jvm_external that results in
neverlink deps not appearing on the javadoc classpath.