### PR TITLE
Allow `@FuzzTest` to be applied to annotations

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/junit/FuzzTest.java
+++ b/src/main/java/com/code_intelligence/jazzer/junit/FuzzTest.java
@@ -50,6 +50,11 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  *       also render previous findings unreproducible.
  * </dl>
  *
+ * <p>The {@link FuzzTest} annotation can also be applied to another annotations as a
+ * meta-annotation and then applies to all methods annotated with that annotation. This can be used
+ * to create reusable custom annotations for fuzz tests combined with other JUnit annotations such
+ * as {@link org.junit.jupiter.api.Timeout} or {@link org.junit.jupiter.api.Tag}.
+ *
  * <h2>Test modes</h2>
  *
  * A fuzz test can be run in two modes: fuzzing and regression testing.
@@ -84,7 +89,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * fuzz tests contained in the class {@code com.example.MyFuzzTests} would run on all files under
  * {@code src/test/resources/com/example/MyFuzzTestsInputs}.
  */
-@Target({ElementType.METHOD})
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 @AgentConfiguringArgumentsProviderArgumentsSource
 @ArgumentsSource(SeedArgumentsProvider.class)

--- a/tests/src/test/java/com/example/JUnitTimeoutTest.java
+++ b/tests/src/test/java/com/example/JUnitTimeoutTest.java
@@ -17,14 +17,21 @@
 package com.example;
 
 import com.code_intelligence.jazzer.junit.FuzzTest;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.time.Instant;
 import org.junit.jupiter.api.Timeout;
 
 class JUnitTimeoutTest {
-  private static int runs = 0;
 
+  @Retention(RetentionPolicy.RUNTIME)
   @FuzzTest
   @Timeout(3)
+  public @interface TimedFuzzTest {}
+
+  private static int runs = 0;
+
+  @TimedFuzzTest
   void timesOutTest(byte[] data) throws InterruptedException {
     if (runs++ > 0) {
       return;


### PR DESCRIPTION
This can be used to create custom reusable variants of `@FuzzTest`. `cifuzz` added support for this in https://github.com/CodeIntelligenceTesting/cifuzz/pull/986.