### PR TITLE
junit: Only create `.cifuzz-corpus` if it is the generated corpus

### DIFF
--- a/src/test/java/com/code_intelligence/jazzer/junit/CorpusDirectoryTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/junit/CorpusDirectoryTest.java
@@ -158,11 +158,11 @@ public class CorpusDirectoryTest {
     assertCrashFileExistsIn(artifactsDirectory);
     assertNoCrashFileExistsIn(baseDir);
     assertNoCrashFileExistsIn(explicitGeneratedCorpus);
-    assertNoCrashFileExistsIn(defaultGeneratedCorpus);
+    // Default generated corpus directory isn't used and thus should not have been created.
+    assertThat(Files.notExists(defaultGeneratedCorpus)).isTrue();
 
     // Verify that corpus files are written to given corpus directory and not generated one.
     assertThat(Files.list(explicitGeneratedCorpus)).isNotEmpty();
-    assertThat(Files.list(defaultGeneratedCorpus)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
If users add custom corpus directories, the first of those will be used as the generated corpus instead of the default `.cifuzz-corpus` directory. We now no longer create this directory if it is going to stay empty because it isn't used as the generated corpus directory.