### PR TITLE
deploy: Fix `jazzer_standalone.jar` not being executable

### DIFF
--- a/deploy/BUILD.bazel
+++ b/deploy/BUILD.bazel
@@ -91,6 +91,21 @@ sh_test(
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
+sh_test(
+    name = "jazzer_standalone_version_test",
+    srcs = ["jazzer_version_test.sh"],
+    data = [
+        "//src/main/java/com/code_intelligence/jazzer:jazzer_standalone_deploy.jar",
+        "@bazel_tools//tools/jdk:current_java_runtime",
+    ],
+    env = {
+        "JAVA_EXECPATH": "$(JAVA)",
+        "JAZZER_RLOCATIONPATH": "$(rlocationpath //src/main/java/com/code_intelligence/jazzer:jazzer_standalone_deploy.jar)",
+    },
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+    deps = ["@bazel_tools//tools/bash/runfiles"],
+)
+
 [
     sh_test(
         name = artifact + "_artifact_test",

--- a/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/BUILD.bazel
@@ -8,9 +8,12 @@ load("//sanitizers:sanitizers.bzl", "SANITIZER_CLASSES")
 java_binary(
     name = "jazzer_standalone",
     create_executable = False,
-    main_class = "com.code_intelligence.jazzer.Jazzer",
+    deploy_manifest_lines = [
+        "Main-Class: com.code_intelligence.jazzer.Jazzer",
+    ],
     visibility = [
         "//:__pkg__",
+        "//deploy:__pkg__",
         "//launcher:__pkg__",
     ],
     runtime_deps = [


### PR DESCRIPTION
This was missed in #838.