### PR TITLE
Also scan `lib/` and `ext/` `.jar`s with ClassGraph

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/agent/RuntimeInstrumentor.kt
@@ -178,6 +178,7 @@ class RuntimeInstrumentor(
         val className = internalClassName.replace('/', '.')
         val classfileBuffer = maybeClassfileBuffer ?: ClassGraph()
             .enableSystemJarsAndModules()
+            .acceptLibOrExtJars()
             .ignoreClassVisibility()
             .acceptClasses(className)
             .scan()

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/Hooks.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/Hooks.kt
@@ -52,6 +52,7 @@ data class Hooks(
             return ClassGraph()
                 .enableClassInfo()
                 .enableSystemJarsAndModules()
+                .acceptLibOrExtJars()
                 .rejectPackages("jaz.*", "com.code_intelligence.jazzer.*")
                 .scan()
                 .use { scanResult ->


### PR DESCRIPTION
At least for JDK/JRE 8, these directories contain `.jar` files with classes that may need to be instrumented.

Fixes #866 