### PR TITLE
ci: Update softprops/action-gh-release to v2.2.0 in prerelease workflow

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -143,7 +143,7 @@ jobs:
           path: _releases/
 
       - name: create release
-        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
+        uses: softprops/action-gh-release@v2.2.0
         with:
           generate_release_notes: true
           draft: true


### PR DESCRIPTION
This workflow failed before because 

> Error
> softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981 is not allowed to be used in CodeIntelligenceTesting/jazzer. Actions in this workflow must be: within a repository that belongs to your Enterprise account, created by GitHub, or matching the following: softprops/action-gh-release@c9b46fe7aad9f02afd89b12450b780f52dacfb2d.
