### PR TITLE
Fix prerelease pipeline

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -143,7 +143,7 @@ jobs:
           path: _releases/
 
       - name: create release
-        uses: softprops/action-gh-release@v2.2.0
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
         with:
           generate_release_notes: true
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: Release
 
 on:
   workflow_dispatch:
+  release:
+    types: [released]
+
 
 jobs:
 


### PR DESCRIPTION
Downgrade softprops/action-gh-release again to v2.0.9 because of https://github.com/softprops/action-gh-release/issues/556

Sets the release pipeline to run automatically when the github draft release is released