### PR TITLE
Fix maven deployment

### DIFF
--- a/deploy/BUILD.bazel
+++ b/deploy/BUILD.bazel
@@ -38,7 +38,6 @@ java_export(
     ],
     maven_coordinates = "com.code-intelligence:jazzer-api:$(JAZZER_VERSION)",
     pom_template = "//deploy:jazzer-api.pom",
-    tags = ["no-sources"],
     toolchains = [":jazzer_version"],
     visibility = ["//visibility:public"],
     runtime_deps = ["//src/main/java/com/code_intelligence/jazzer/api"],
@@ -73,9 +72,14 @@ alias(
 
 java_export(
     name = "jazzer-junit",
-    # Exclude the unshaded classes comprising com.code-intelligence:jazzer since the java_library
-    # target comprising jazzer-junit depend on the individual libraries, not the shaded jar.
-    deploy_env = ["//src/main/java/com/code_intelligence/jazzer:jazzer_lib"],
+    deploy_env = [
+        # Exclude the unshaded classes comprising com.code-intelligence:jazzer since the java_library
+        # target comprising jazzer-junit depend on the individual libraries, not the shaded jar.
+        "//src/main/java/com/code_intelligence/jazzer:jazzer_lib",
+        # Spring dependencies are required for javadoc but should be excluded from the jar.
+        "@maven//:org_springframework_spring_test",
+        "@maven//:org_springframework_spring_web",
+    ],
     doc_deps = [
         ":jazzer-api-docs",
         ":jazzer-docs",
@@ -89,12 +93,6 @@ java_export(
     ],
     maven_coordinates = "com.code-intelligence:jazzer-junit:$(JAZZER_VERSION)",
     pom_template = "jazzer-junit.pom",
-    tags = [
-        "no-sources",
-        # Generating javadocs breaks the build due to weird dependency issues.
-        # Deactivate it for now.
-        "no-javadocs",
-    ],
     toolchains = [":jazzer_version"],
     visibility = ["//visibility:public"],
     runtime_deps = [

--- a/deploy/jazzer-api.pom
+++ b/deploy/jazzer-api.pom
@@ -38,4 +38,25 @@
     <scm>
         <url>https://github.com/CodeIntelligenceTesting/jazzer</url>
     </scm>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Fabian Meumertzheim</name>
+        </developer>
+        <developer>
+            <name>Norbert Schneider</name>
+        </developer>
+        <developer>
+            <name>Khaled Yakdan</name>
+        </developer>
+        <developer>
+            <name>Peter Samarin</name>
+        </developer>
+    </developers>
 </project>

--- a/deploy/jazzer-junit.pom
+++ b/deploy/jazzer-junit.pom
@@ -37,4 +37,25 @@
     <scm>
         <url>https://github.com/CodeIntelligenceTesting/jazzer</url>
     </scm>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Fabian Meumertzheim</name>
+        </developer>
+        <developer>
+            <name>Norbert Schneider</name>
+        </developer>
+        <developer>
+            <name>Khaled Yakdan</name>
+        </developer>
+        <developer>
+            <name>Peter Samarin</name>
+        </developer>
+    </developers>
 </project>

--- a/deploy/jazzer.pom
+++ b/deploy/jazzer.pom
@@ -37,4 +37,25 @@
     <scm>
         <url>https://github.com/CodeIntelligenceTesting/jazzer</url>
     </scm>
+
+    <licenses>
+        <license>
+            <name>Apache-2.0</name>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <name>Fabian Meumertzheim</name>
+        </developer>
+        <developer>
+            <name>Norbert Schneider</name>
+        </developer>
+        <developer>
+            <name>Khaled Yakdan</name>
+        </developer>
+        <developer>
+            <name>Peter Samarin</name>
+        </developer>
+    </developers>
 </project>


### PR DESCRIPTION
Adds license and developer information to maven pom files.

Adds necessary source and javadoc jars for `jazzer-api` and `jazzer-junit` required for maven publishing