### PR TITLE
Fix Maven releases

### DIFF
--- a/deploy/BUILD.bazel
+++ b/deploy/BUILD.bazel
@@ -40,7 +40,11 @@ java_export(
     pom_template = "//deploy:jazzer-api.pom",
     toolchains = [":jazzer_version"],
     visibility = ["//visibility:public"],
-    runtime_deps = ["//src/main/java/com/code_intelligence/jazzer/api"],
+    exports = [
+        "//src/main/java/com/code_intelligence/jazzer/api",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto",
+    ],
 )
 
 java_export(
@@ -95,12 +99,15 @@ java_export(
     pom_template = "jazzer-junit.pom",
     toolchains = [":jazzer_version"],
     visibility = ["//visibility:public"],
-    runtime_deps = [
-        # These deps' only effect is to include a dependency on the 'jazzer' and 'jazzer-api' Maven artifacts in the
-        # POM.
-        "//deploy:jazzer",
+    exports = [
+        # Maven users should not need to depend on jazzer-api directly if they already directly depend on jazzer-junit,
+        # both for convenience and backwards compatibility.
         "//deploy:jazzer-api",
         "//src/main/java/com/code_intelligence/jazzer/junit",
+    ],
+    runtime_deps = [
+        # This dep's only effect is to include a dependency on the 'jazzer' Maven artifacts in the POM.
+        "//deploy:jazzer",
     ],
 )
 

--- a/deploy/jazzer-api_artifact_test.sh
+++ b/deploy/jazzer-api_artifact_test.sh
@@ -27,6 +27,9 @@ JAR="$2/bin/jar"
     -e '^com/code_intelligence/$' \
     -e '^com/code_intelligence/jazzer/$' \
     -e '^com/code_intelligence/jazzer/api/' \
+    -e '^com/code_intelligence/jazzer/mutation/$' \
+    -e '^com/code_intelligence/jazzer/mutation/annotation/' \
+    -e '^com/code_intelligence/jazzer/mutation/utils/' \
     -e '^jaz/' \
     -e '^META-INF/$' \
     -e '^META-INF/MANIFEST.MF$'

--- a/src/main/java/com/code_intelligence/jazzer/api/Autofuzz.java
+++ b/src/main/java/com/code_intelligence/jazzer/api/Autofuzz.java
@@ -146,15 +146,15 @@ public final class Autofuzz {
    * <p><b>Note:</b> This function is inherently heuristic and may fail to execute {@code func} in
    * meaningful ways for a number of reasons.
    *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
+   *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param func a method reference for the function to autofuzz. If there are multiple overloads,
    *     resolve ambiguities by explicitly casting to {@link Function1} with (partially) specified
    *     type variables, e.g. {@code (Function1<String, ?>) String::new}.
    * @return the return value of {@code func}, or {@code null} if {@code autofuzz} failed to invoke
    *     the function.
-   * @throws Throwable any {@link Throwable} thrown by {@code func}, or an {@link
-   *     AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
-   *     The {@link Throwable} is thrown unchecked.
    */
   @SuppressWarnings("unchecked")
   public static <T1, R> R autofuzz(FuzzedDataProvider data, Function1<T1, R> func) {
@@ -176,15 +176,15 @@ public final class Autofuzz {
    * <p><b>Note:</b> This function is inherently heuristic and may fail to execute {@code func} in
    * meaningful ways for a number of reasons.
    *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
+   *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param func a method reference for the function to autofuzz. If there are multiple overloads,
    *     resolve ambiguities by explicitly casting to {@link Function2} with (partially) specified
    *     type variables.
    * @return the return value of {@code func}, or {@code null} if {@code autofuzz} failed to invoke
    *     the function.
-   * @throws Throwable any {@link Throwable} thrown by {@code func}, or an {@link
-   *     AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
-   *     The {@link Throwable} is thrown unchecked.
    */
   @SuppressWarnings("unchecked")
   public static <T1, T2, R> R autofuzz(FuzzedDataProvider data, Function2<T1, T2, R> func) {
@@ -206,15 +206,15 @@ public final class Autofuzz {
    * <p><b>Note:</b> This function is inherently heuristic and may fail to execute {@code func} in
    * meaningful ways for a number of reasons.
    *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
+   *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param func a method reference for the function to autofuzz. If there are multiple overloads,
    *     resolve ambiguities by explicitly casting to {@link Function3} with (partially) specified
    *     type variables.
    * @return the return value of {@code func}, or {@code null} if {@code autofuzz} failed to invoke
    *     the function.
-   * @throws Throwable any {@link Throwable} thrown by {@code func}, or an {@link
-   *     AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
-   *     The {@link Throwable} is thrown unchecked.
    */
   @SuppressWarnings("unchecked")
   public static <T1, T2, T3, R> R autofuzz(FuzzedDataProvider data, Function3<T1, T2, T3, R> func) {
@@ -236,15 +236,15 @@ public final class Autofuzz {
    * <p><b>Note:</b> This function is inherently heuristic and may fail to execute {@code func} in
    * meaningful ways for a number of reasons.
    *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
+   *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param func a method reference for the function to autofuzz. If there are multiple overloads,
    *     resolve ambiguities by explicitly casting to {@link Function4} with (partially) specified
    *     type variables.
    * @return the return value of {@code func}, or {@code null} if {@code autofuzz} failed to invoke
    *     the function.
-   * @throws Throwable any {@link Throwable} thrown by {@code func}, or an {@link
-   *     AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
-   *     The {@link Throwable} is thrown unchecked.
    */
   @SuppressWarnings("unchecked")
   public static <T1, T2, T3, T4, R> R autofuzz(
@@ -267,15 +267,15 @@ public final class Autofuzz {
    * <p><b>Note:</b> This function is inherently heuristic and may fail to execute {@code func} in
    * meaningful ways for a number of reasons.
    *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
+   *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param func a method reference for the function to autofuzz. If there are multiple overloads,
    *     resolve ambiguities by explicitly casting to {@link Function5} with (partially) specified
    *     type variables.
    * @return the return value of {@code func}, or {@code null} if {@code autofuzz} failed to invoke
    *     the function.
-   * @throws Throwable any {@link Throwable} thrown by {@code func}, or an {@link
-   *     AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
-   *     The {@link Throwable} is thrown unchecked.
    */
   @SuppressWarnings("unchecked")
   public static <T1, T2, T3, T4, T5, R> R autofuzz(
@@ -298,13 +298,13 @@ public final class Autofuzz {
    * <p><b>Note:</b> This function is inherently heuristic and may fail to execute {@code func} in
    * meaningful ways for a number of reasons.
    *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
+   *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param func a method reference for the function to autofuzz. If there are multiple overloads,
    *     resolve ambiguities by explicitly casting to {@link Consumer1} with explicitly specified
    *     type variable.
-   * @throws Throwable any {@link Throwable} thrown by {@code func}, or an {@link
-   *     AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
-   *     The {@link Throwable} is thrown unchecked.
    */
   public static <T1> void autofuzz(FuzzedDataProvider data, Consumer1<T1> func) {
     try {
@@ -323,13 +323,13 @@ public final class Autofuzz {
    * <p><b>Note:</b> This function is inherently heuristic and may fail to execute {@code func} in
    * meaningful ways for a number of reasons.
    *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
+   *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param func a method reference for the function to autofuzz. If there are multiple overloads,
    *     resolve ambiguities by explicitly casting to {@link Consumer2} with (partially) specified
    *     type variables.
-   * @throws Throwable any {@link Throwable} thrown by {@code func}, or an {@link
-   *     AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
-   *     The {@link Throwable} is thrown unchecked.
    */
   public static <T1, T2> void autofuzz(FuzzedDataProvider data, Consumer2<T1, T2> func) {
     try {
@@ -348,13 +348,13 @@ public final class Autofuzz {
    * <p><b>Note:</b> This function is inherently heuristic and may fail to execute {@code func} in
    * meaningful ways for a number of reasons.
    *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
+   *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param func a method reference for the function to autofuzz. If there are multiple overloads,
    *     resolve ambiguities by explicitly casting to {@link Consumer3} with (partially) specified
    *     type variables.
-   * @throws Throwable any {@link Throwable} thrown by {@code func}, or an {@link
-   *     AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
-   *     The {@link Throwable} is thrown unchecked.
    */
   public static <T1, T2, T3> void autofuzz(FuzzedDataProvider data, Consumer3<T1, T2, T3> func) {
     try {
@@ -373,13 +373,13 @@ public final class Autofuzz {
    * <p><b>Note:</b> This function is inherently heuristic and may fail to execute {@code func} in
    * meaningful ways for a number of reasons.
    *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
+   *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param func a method reference for the function to autofuzz. If there are multiple overloads,
    *     resolve ambiguities by explicitly casting to {@link Consumer4} with (partially) specified
    *     type variables.
-   * @throws Throwable any {@link Throwable} thrown by {@code func}, or an {@link
-   *     AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
-   *     The {@link Throwable} is thrown unchecked.
    */
   public static <T1, T2, T3, T4> void autofuzz(
       FuzzedDataProvider data, Consumer4<T1, T2, T3, T4> func) {
@@ -399,13 +399,13 @@ public final class Autofuzz {
    * <p><b>Note:</b> This function is inherently heuristic and may fail to execute {@code func} in
    * meaningful ways for a number of reasons.
    *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
+   *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param func a method reference for the function to autofuzz. If there are multiple overloads,
    *     resolve ambiguities by explicitly casting to {@link Consumer5} with (partially) specified
    *     type variables.
-   * @throws Throwable any {@link Throwable} thrown by {@code func}, or an {@link
-   *     AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
-   *     The {@link Throwable} is thrown unchecked.
    */
   public static <T1, T2, T3, T4, T5> void autofuzz(
       FuzzedDataProvider data, Consumer5<T1, T2, T3, T4, T5> func) {
@@ -424,6 +424,9 @@ public final class Autofuzz {
    *
    * <p><b>Note:</b> This function is inherently heuristic and may fail to return meaningful values
    * for a variety of reasons.
+   *
+   * <p>May throw (unchecked) any {@link Throwable} thrown by {@code func} or an {@link
+   * AutofuzzConstructionException} if autofuzz failed to construct the arguments for the call.
    *
    * @param data the {@link FuzzedDataProvider} instance provided to {@code fuzzerTestOneInput}.
    * @param type the {@link Class} to construct an instance of.

--- a/src/main/java/com/code_intelligence/jazzer/api/MethodHook.java
+++ b/src/main/java/com/code_intelligence/jazzer/api/MethodHook.java
@@ -119,6 +119,8 @@ import java.lang.invoke.MethodType;
  *             reference a target method, no other types allowed. Attention must be paid to not
  *             guide the Fuzzer in different directions via {@link Jazzer}'s {@code guideTowardsXY}
  *             methods in the different hooks.
+ *       </ul>
+ * </dl>
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/UrlSegment.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/UrlSegment.java
@@ -27,8 +27,8 @@ import java.lang.annotation.Target;
 /**
  * An annotation that applies to {@link String} and <strong>limits the character set</strong> of the
  * annotated type to valid URL segment characters, as described in <a
- * href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>. </br> Can be combined with
- * {@link WithUtf8Length} to limit the length of the generated string.
+ * href="https://www.ietf.org/rfc/rfc3986.txt">RFC 3986, appendix A</a>. <br>
+ * Can be combined with {@link WithUtf8Length} to limit the length of the generated string.
  */
 @Target(TYPE_USE)
 @Retention(RUNTIME)

--- a/src/main/java/com/code_intelligence/jazzer/mutation/utils/ValidateContainerDimensions.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/utils/ValidateContainerDimensions.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 /**
  * Meta-annotation intended to be used internally by Jazzer for container annotations with min and
  * max fields. Annotations annotated with @ValidateContainerDimensions will be validated to ensure
- * that min and max are both >= 0, and that min <= max.
+ * that min and max are both {@code >= 0}, and that {@code min <= max}.
  */
 @Target(ANNOTATION_TYPE)
 @Retention(RUNTIME)

--- a/src/main/java/com/code_intelligence/jazzer/mutation/utils/ValidateMinMax.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/utils/ValidateMinMax.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 
 /**
  * Meta-annotation intended to be used internally by Jazzer for annotations that have min and max
- * fields. For all such annotations, Jazzer will assert that min <= max.
+ * fields. For all such annotations, Jazzer will assert that {@code min <= max}.
  */
 @Target(ANNOTATION_TYPE)
 @Retention(RUNTIME)


### PR DESCRIPTION
See individual commit messages. This still requires https://github.com/bazel-contrib/rules_jvm_external/pull/1308, which can be brought in via an `archive_override` after it has been merged or as a patch before that.

Work towards #919