### PR TITLE
Update rules_jvm_external to fix POM

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(name = "jazzer")
 # Kept up-to-date by Renovate
 ################################################################################
 
-bazel_dep(name = "abseil-cpp", version = "20230802.0.bcr.1")
+bazel_dep(name = "abseil-cpp", version = "20230802.1")
 bazel_dep(name = "apple_support", version = "1.11.1")
 bazel_dep(name = "bazel_jar_jar", version = "0.1.0")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
@@ -18,11 +18,20 @@ bazel_dep(name = "protobuf")
 bazel_dep(name = "rules_android", version = "0.1.1")
 bazel_dep(name = "rules_android_ndk", version = "0.1.2")
 bazel_dep(name = "rules_foreign_cc", version = "0.11.1")
-bazel_dep(name = "rules_java", version = "7.7.0")
+bazel_dep(name = "rules_java", version = "7.12.2")
 bazel_dep(name = "rules_jni", version = "0.9.1")
-bazel_dep(name = "rules_jvm_external", version = "6.2")
-bazel_dep(name = "rules_kotlin", version = "1.9.5")
-bazel_dep(name = "rules_license", version = "0.0.8")
+bazel_dep(name = "rules_jvm_external")
+
+# TODO: Remove after the next release.
+archive_override(
+    module_name = "rules_jvm_external",
+    integrity = "sha256-7AerLOLhQ+oIDH2id7OE8WJmbH01MqBWV4CbqJ6Nh68=",
+    strip_prefix = "rules_jvm_external-a1d4e4f4267c1797b686719aa385e707b732c541",
+    urls = ["https://github.com/bazelbuild/rules_jvm_external/archive/a1d4e4f4267c1797b686719aa385e707b732c541.tar.gz"],
+)
+
+bazel_dep(name = "rules_kotlin", version = "1.9.6")
+bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_pkg", version = "0.9.1")
 bazel_dep(name = "toolchains_llvm", version = "0.10.3")
 

--- a/examples/src/main/java/com/example/ExampleKotlinFuzzer.kt
+++ b/examples/src/main/java/com/example/ExampleKotlinFuzzer.kt
@@ -20,13 +20,16 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider
 import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium
 
 object ExampleKotlinFuzzer {
-
     @JvmStatic
     fun fuzzerTestOneInput(data: FuzzedDataProvider) {
         exploreMe(data.consumeString(8), data.consumeInt(), data.consumeRemainingAsString())
     }
 
-    private fun exploreMe(prefix: String, n: Int, suffix: String) {
+    private fun exploreMe(
+        prefix: String,
+        n: Int,
+        suffix: String,
+    ) {
         if (prefix.findAnyOf(arrayListOf("Fuzz", "Test")) != null) {
             if (n >= 2000000) {
                 if (suffix.startsWith("@")) {

--- a/examples/src/main/java/com/example/ExampleKotlinValueProfileFuzzer.kt
+++ b/examples/src/main/java/com/example/ExampleKotlinValueProfileFuzzer.kt
@@ -20,7 +20,6 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider
 import com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium
 
 object ExampleKotlinValueProfileFuzzer {
-
     @JvmStatic
     fun fuzzerTestOneInput(data: FuzzedDataProvider) {
         if (data.consumeInt().compareTo(0x11223344) != 0) {
@@ -33,7 +32,5 @@ object ExampleKotlinValueProfileFuzzer {
         }
     }
 
-    private fun encrypt(n: Long): Long {
-        return n.xor(0x1122334455667788)
-    }
+    private fun encrypt(n: Long): Long = n.xor(0x1122334455667788)
 }

--- a/examples/src/main/java/com/example/KlaxonFuzzer.kt
+++ b/examples/src/main/java/com/example/KlaxonFuzzer.kt
@@ -22,7 +22,6 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider
 
 // Reproduces https://github.com/cbeust/klaxon/pull/330
 object KlaxonFuzzer {
-
     @JvmStatic
     fun fuzzerTestOneInput(data: FuzzedDataProvider) {
         try {

--- a/format.sh
+++ b/format.sh
@@ -35,9 +35,9 @@ if [[ "${CI:-0}" == 0 ]]; then
     # Check which ktlint_tests failed and run the corresponding fix targets. This is much faster than
     # running all ktlint_fix targets when e.g. only a few or no .kt files changed.
     # shellcheck disable=SC2046
-    TARGETS_TO_RUN=$(bazel test --config=quiet $(bazel query --config=quiet 'kind(ktlint_test, //...)') | { grep FAILED || true; } | cut -f1 -d' ' | sed -e 's/:ktlint_test/:ktlint_fix/g')
+    TARGETS_TO_RUN=$(bazel test --config=quiet $(bazel query --config=quiet 'kind(ktlint_test, //...)') | { grep FAILED || true; } | cut -f1 -d' ' | sed -e 's/:ktlint_test/:ktlint_fix/g' || true)
     if [[ -n "${TARGETS_TO_RUN}" ]]; then
-        echo "$TARGETS_TO_RUN" | xargs -n 1 bazel run --config=quiet
+        echo "$TARGETS_TO_RUN" | xargs -I '{}' -n 1 bazel run --config=quiet {} -- --format
     fi
 
     # BUILD files

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/Deserialization.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/Deserialization.kt
@@ -33,7 +33,6 @@ import java.util.WeakHashMap
  */
 @Suppress("unused_parameter", "unused")
 object Deserialization {
-
     private val OBJECT_INPUT_STREAM_HEADER =
         ObjectStreamConstants.STREAM_MAGIC.toBytes() + ObjectStreamConstants.STREAM_VERSION.toBytes()
 
@@ -88,13 +87,19 @@ object Deserialization {
         targetMethodDescriptor = "(Ljava/io/InputStream;)V",
     )
     @JvmStatic
-    fun objectInputStreamInitBeforeHook(method: MethodHandle?, alwaysNull: Any?, args: Array<Any?>, hookId: Int) {
+    fun objectInputStreamInitBeforeHook(
+        method: MethodHandle?,
+        alwaysNull: Any?,
+        args: Array<Any?>,
+        hookId: Int,
+    ) {
         val originalInputStream = args[0] as? InputStream ?: return
-        val fixedInputStream = if (originalInputStream.markSupported()) {
-            originalInputStream
-        } else {
-            BufferedInputStream(originalInputStream)
-        }
+        val fixedInputStream =
+            if (originalInputStream.markSupported()) {
+                originalInputStream
+            } else {
+                BufferedInputStream(originalInputStream)
+            }
         args[0] = fixedInputStream
         guideMarkableInputStreamTowardsEquality(fixedInputStream, OBJECT_INPUT_STREAM_HEADER, hookId)
     }

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/ExpressionLanguageInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/ExpressionLanguageInjection.kt
@@ -28,7 +28,6 @@ import java.lang.invoke.MethodHandle
  */
 @Suppress("unused_parameter", "unused")
 object ExpressionLanguageInjection {
-
     /**
      * Try to call the default constructor of the honeypot class.
      */
@@ -71,7 +70,9 @@ object ExpressionLanguageInjection {
         hookId: Int,
     ) {
         // The overloads taking a second string argument have either three or four arguments
-        if (arguments.size < 3) { return }
+        if (arguments.size < 3) {
+            return
+        }
         val expression = arguments[1] as? String ?: return
         Jazzer.guideTowardsContainment(expression, EXPRESSION_LANGUAGE_ATTACK, hookId)
     }
@@ -95,7 +96,9 @@ object ExpressionLanguageInjection {
         arguments: Array<Any>,
         hookId: Int,
     ) {
-        if (arguments.size != 1) { return }
+        if (arguments.size != 1) {
+            return
+        }
         val message = arguments[0] as String
         Jazzer.guideTowardsContainment(message, EXPRESSION_LANGUAGE_ATTACK, hookId)
     }

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/LdapInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/LdapInjection.kt
@@ -44,7 +44,6 @@ import javax.naming.directory.InvalidSearchFilterException
  */
 @Suppress("unused_parameter", "unused")
 object LdapInjection {
-
     // Characters to escape in DNs
     private const val NAME_CHARACTERS = "\\+<>,;\"="
 
@@ -67,7 +66,6 @@ object LdapInjection {
             targetMethodDescriptor = "(Ljava/lang/String;Ljavax/naming.directory/Attributes;[Ljava/lang/Sting;)Ljavax/naming/NamingEnumeration;",
             additionalClassesToHook = ["javax.naming.directory.InitialDirContext"],
         ),
-
         // Object search, possible DN and search filter injection
         MethodHook(
             type = HookType.REPLACE,
@@ -92,7 +90,12 @@ object LdapInjection {
         ),
     )
     @JvmStatic
-    fun searchLdapContext(method: MethodHandle, thisObject: Any?, args: Array<Any>, hookId: Int): Any? {
+    fun searchLdapContext(
+        method: MethodHandle,
+        thisObject: Any?,
+        args: Array<Any>,
+        hookId: Int,
+    ): Any? {
         try {
             return method.invokeWithArguments(thisObject, *args).also {
                 (args[0] as? String)?.let { name ->

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/LdapInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/LdapInjection.kt
@@ -50,6 +50,7 @@ object LdapInjection {
     // Characters to escape in search filter queries
     private const val FILTER_CHARACTERS = "*()\\\u0000"
 
+    @Suppress("ktlint:standard:max-line-length")
     @MethodHooks(
         // Single object lookup, possible DN injection
         MethodHook(

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/NamingContextLookup.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/NamingContextLookup.kt
@@ -26,7 +26,6 @@ import javax.naming.CommunicationException
 
 @Suppress("unused")
 object NamingContextLookup {
-
     // The particular URL g.co is used here since it is:
     // - short, which makes it easier for the fuzzer to incorporate into the input;
     // - valid, which means that a `lookup` call on it could actually result in RCE;
@@ -50,7 +49,12 @@ object NamingContextLookup {
         ),
     )
     @JvmStatic
-    fun lookupHook(method: MethodHandle?, thisObject: Any?, args: Array<Any?>, hookId: Int): Any {
+    fun lookupHook(
+        method: MethodHandle?,
+        thisObject: Any?,
+        args: Array<Any?>,
+        hookId: Int,
+    ): Any {
         val name = args[0] as? String ?: throw CommunicationException()
         if (name.startsWith(RMI_MARKER) || name.startsWith(LDAP_MARKER)) {
             Jazzer.reportFindingFromHook(

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/OsCommandInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/OsCommandInjection.kt
@@ -33,7 +33,6 @@ import java.lang.invoke.MethodHandle
  */
 @Suppress("unused_parameter", "unused")
 object OsCommandInjection {
-
     // Short and probably non-existing command name
     private const val COMMAND = "jazze"
 
@@ -44,8 +43,15 @@ object OsCommandInjection {
         additionalClassesToHook = ["java.lang.ProcessBuilder"],
     )
     @JvmStatic
-    fun processImplStartHook(method: MethodHandle?, alwaysNull: Any?, args: Array<Any?>, hookId: Int) {
-        if (args.isEmpty()) { return }
+    fun processImplStartHook(
+        method: MethodHandle?,
+        alwaysNull: Any?,
+        args: Array<Any?>,
+        hookId: Int,
+    ) {
+        if (args.isEmpty()) {
+            return
+        }
         // Calling ProcessBuilder already checks if command array is empty
         @Suppress("UNCHECKED_CAST")
         (args[0] as? Array<String>)?.first().let { cmd ->

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/ReflectiveCall.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/ReflectiveCall.kt
@@ -30,25 +30,64 @@ import java.lang.invoke.MethodHandle
  */
 @Suppress("unused_parameter", "unused")
 object ReflectiveCall {
-
     @MethodHooks(
-        MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.Class", targetMethod = "forName", targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Class;"),
-        MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.Class", targetMethod = "forName", targetMethodDescriptor = "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;"),
-        MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.ClassLoader", targetMethod = "loadClass", targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Class;"),
-        MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.ClassLoader", targetMethod = "loadClass", targetMethodDescriptor = "(Ljava/lang/String;Z)Ljava/lang/Class;"),
+        MethodHook(
+            type = HookType.BEFORE,
+            targetClassName = "java.lang.Class",
+            targetMethod = "forName",
+            targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Class;",
+        ),
+        MethodHook(
+            type = HookType.BEFORE,
+            targetClassName = "java.lang.Class",
+            targetMethod = "forName",
+            targetMethodDescriptor = "(Ljava/lang/String;ZLjava/lang/ClassLoader;)Ljava/lang/Class;",
+        ),
+        MethodHook(
+            type = HookType.BEFORE,
+            targetClassName = "java.lang.ClassLoader",
+            targetMethod = "loadClass",
+            targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/Class;",
+        ),
+        MethodHook(
+            type = HookType.BEFORE,
+            targetClassName = "java.lang.ClassLoader",
+            targetMethod = "loadClass",
+            targetMethodDescriptor = "(Ljava/lang/String;Z)Ljava/lang/Class;",
+        ),
     )
     @JvmStatic
-    fun loadClassHook(method: MethodHandle?, alwaysNull: Any?, args: Array<Any?>, hookId: Int) {
+    fun loadClassHook(
+        method: MethodHandle?,
+        alwaysNull: Any?,
+        args: Array<Any?>,
+        hookId: Int,
+    ) {
         val className = args[0] as? String ?: return
         Jazzer.guideTowardsEquality(className, HONEYPOT_CLASS_NAME, hookId)
     }
 
     @MethodHooks(
-        MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.Class", targetMethod = "forName", targetMethodDescriptor = "(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/Class;"),
-        MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.ClassLoader", targetMethod = "loadClass", targetMethodDescriptor = "(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/Class;"),
+        MethodHook(
+            type = HookType.BEFORE,
+            targetClassName = "java.lang.Class",
+            targetMethod = "forName",
+            targetMethodDescriptor = "(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/Class;",
+        ),
+        MethodHook(
+            type = HookType.BEFORE,
+            targetClassName = "java.lang.ClassLoader",
+            targetMethod = "loadClass",
+            targetMethodDescriptor = "(Ljava/lang/Module;Ljava/lang/String;)Ljava/lang/Class;",
+        ),
     )
     @JvmStatic
-    fun loadClassWithModuleHook(method: MethodHandle?, alwaysNull: Any?, args: Array<Any?>, hookId: Int) {
+    fun loadClassWithModuleHook(
+        method: MethodHandle?,
+        alwaysNull: Any?,
+        args: Array<Any?>,
+        hookId: Int,
+    ) {
         val className = args[1] as? String ?: return
         Jazzer.guideTowardsEquality(className, HONEYPOT_CLASS_NAME, hookId)
     }
@@ -62,8 +101,15 @@ object ReflectiveCall {
         MethodHook(type = HookType.BEFORE, targetClassName = "java.lang.ClassLoader", targetMethod = "findLibrary"),
     )
     @JvmStatic
-    fun loadLibraryHook(method: MethodHandle?, alwaysNull: Any?, args: Array<Any?>, hookId: Int) {
-        if (args.isEmpty()) { return }
+    fun loadLibraryHook(
+        method: MethodHandle?,
+        alwaysNull: Any?,
+        args: Array<Any?>,
+        hookId: Int,
+    ) {
+        if (args.isEmpty()) {
+            return
+        }
         val libraryName = args[0] as? String ?: return
         if (libraryName == HONEYPOT_LIBRARY_NAME) {
             Jazzer.reportFindingFromHook(

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/RegexInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/RegexInjection.kt
@@ -51,7 +51,12 @@ object RegexInjection {
         targetMethodDescriptor = "(Ljava/lang/String;I)Ljava/util/regex/Pattern;",
     )
     @JvmStatic
-    fun compileWithFlagsHook(method: MethodHandle, alwaysNull: Any?, args: Array<Any?>, hookId: Int): Any? {
+    fun compileWithFlagsHook(
+        method: MethodHandle,
+        alwaysNull: Any?,
+        args: Array<Any?>,
+        hookId: Int,
+    ): Any? {
         val pattern = args[0] as String?
         val hasCanonEqFlag = ((args[1] as Int) and Pattern.CANON_EQ) != 0
         return hookInternal(method, pattern, hasCanonEqFlag, hookId, *args)
@@ -72,9 +77,12 @@ object RegexInjection {
         ),
     )
     @JvmStatic
-    fun patternHook(method: MethodHandle, alwaysNull: Any?, args: Array<Any?>, hookId: Int): Any? {
-        return hookInternal(method, args[0] as String?, false, hookId, *args)
-    }
+    fun patternHook(
+        method: MethodHandle,
+        alwaysNull: Any?,
+        args: Array<Any?>,
+        hookId: Int,
+    ): Any? = hookInternal(method, args[0] as String?, false, hookId, *args)
 
     @MethodHooks(
         MethodHook(
@@ -109,9 +117,12 @@ object RegexInjection {
         ),
     )
     @JvmStatic
-    fun stringHook(method: MethodHandle, thisObject: Any?, args: Array<Any?>, hookId: Int): Any? {
-        return hookInternal(method, args[0] as String?, false, hookId, thisObject, *args)
-    }
+    fun stringHook(
+        method: MethodHandle,
+        thisObject: Any?,
+        args: Array<Any?>,
+        hookId: Int,
+    ): Any? = hookInternal(method, args[0] as String?, false, hookId, thisObject, *args)
 
     private fun hookInternal(
         method: MethodHandle,

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/Utils.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/Utils.kt
@@ -25,12 +25,11 @@ import java.io.InputStream
 const val HONEYPOT_CLASS_NAME = "jaz.Zer"
 const val HONEYPOT_LIBRARY_NAME = "jazzer_honeypot"
 
-internal fun Short.toBytes(): ByteArray {
-    return byteArrayOf(
+internal fun Short.toBytes(): ByteArray =
+    byteArrayOf(
         ((toInt() shr 8) and 0xFF).toByte(),
         (toInt() and 0xFF).toByte(),
     )
-}
 
 // Runtime is only O(size * needle.size), only use for small arrays.
 internal fun ByteArray.indexOf(needle: ByteArray): Int {
@@ -45,8 +44,15 @@ internal fun ByteArray.indexOf(needle: ByteArray): Int {
     return -1
 }
 
-internal fun guideMarkableInputStreamTowardsEquality(stream: InputStream, target: ByteArray, id: Int) {
-    fun readBytes(stream: InputStream, size: Int): ByteArray {
+internal fun guideMarkableInputStreamTowardsEquality(
+    stream: InputStream,
+    target: ByteArray,
+    id: Int,
+) {
+    fun readBytes(
+        stream: InputStream,
+        size: Int,
+    ): ByteArray {
         val current = ByteArray(size)
         var n = 0
         while (n < size) {

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/XPathInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/XPathInjection.kt
@@ -36,7 +36,6 @@ import javax.xml.xpath.XPathExpressionException
  */
 @Suppress("unused_parameter", "unused")
 object XPathInjection {
-
     // Characters that should be escaped in user input.
     // https://owasp.org/www-community/attacks/XPATH_Injection
     private const val CHARACTERS_TO_ESCAPE = "'\""
@@ -49,7 +48,12 @@ object XPathInjection {
         MethodHook(type = HookType.REPLACE, targetClassName = "javax.xml.xpath.XPath", targetMethod = "evaluateExpression"),
     )
     @JvmStatic
-    fun checkXpathExecute(method: MethodHandle, thisObject: Any?, arguments: Array<Any>, hookId: Int): Any {
+    fun checkXpathExecute(
+        method: MethodHandle,
+        thisObject: Any?,
+        arguments: Array<Any>,
+        hookId: Int,
+    ): Any {
         if (arguments.isNotEmpty() && arguments[0] is String) {
             val query = arguments[0] as String
             Jazzer.guideTowardsContainment(query, CHARACTERS_TO_ESCAPE, hookId)
@@ -67,8 +71,8 @@ object XPathInjection {
                 Jazzer.reportFindingFromHook(
                     FuzzerSecurityIssueHigh(
                         """
-                    XPath Injection
-                    Injected query: ${arguments[0]}
+                        XPath Injection
+                        Injected query: ${arguments[0]}
                         """.trimIndent(),
                         exception,
                     ),

--- a/src/jmh/java/com/code_intelligence/jazzer/instrumentor/DirectByteBufferStrategy.kt
+++ b/src/jmh/java/com/code_intelligence/jazzer/instrumentor/DirectByteBufferStrategy.kt
@@ -20,7 +20,6 @@ import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 
 object DirectByteBufferStrategy : EdgeCoverageStrategy {
-
     override fun instrumentControlFlowEdge(
         mv: MethodVisitor,
         edgeId: Int,
@@ -66,7 +65,11 @@ object DirectByteBufferStrategy : EdgeCoverageStrategy {
 
     override val localVariableType get() = "java/nio/ByteBuffer"
 
-    override fun loadLocalVariable(mv: MethodVisitor, variable: Int, coverageMapInternalClassName: String) {
+    override fun loadLocalVariable(
+        mv: MethodVisitor,
+        variable: Int,
+        coverageMapInternalClassName: String,
+    ) {
         mv.apply {
             visitFieldInsn(
                 Opcodes.GETSTATIC,

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/ClassInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/ClassInstrumentor.kt
@@ -18,21 +18,23 @@ package com.code_intelligence.jazzer.instrumentor
 
 import com.code_intelligence.jazzer.runtime.CoverageMap
 
-fun extractClassFileMajorVersion(classfileBuffer: ByteArray): Int {
-    return ((classfileBuffer[6].toInt() and 0xff) shl 8) or (classfileBuffer[7].toInt() and 0xff)
-}
+fun extractClassFileMajorVersion(classfileBuffer: ByteArray): Int =
+    ((classfileBuffer[6].toInt() and 0xff) shl 8) or (classfileBuffer[7].toInt() and 0xff)
 
-class ClassInstrumentor(private val internalClassName: String, bytecode: ByteArray) {
-
+class ClassInstrumentor(
+    private val internalClassName: String,
+    bytecode: ByteArray,
+) {
     var instrumentedBytecode = bytecode
         private set
 
     fun coverage(initialEdgeId: Int): Int {
-        val edgeCoverageInstrumentor = EdgeCoverageInstrumentor(
-            defaultEdgeCoverageStrategy,
-            defaultCoverageMap,
-            initialEdgeId,
-        )
+        val edgeCoverageInstrumentor =
+            EdgeCoverageInstrumentor(
+                defaultEdgeCoverageStrategy,
+                defaultCoverageMap,
+                initialEdgeId,
+            )
         instrumentedBytecode = edgeCoverageInstrumentor.instrument(internalClassName, instrumentedBytecode)
         return edgeCoverageInstrumentor.numEdges
     }
@@ -42,12 +44,16 @@ class ClassInstrumentor(private val internalClassName: String, bytecode: ByteArr
             TraceDataFlowInstrumentor(instrumentations).instrument(internalClassName, instrumentedBytecode)
     }
 
-    fun hooks(hooks: Iterable<Hook>, classWithHooksEnabledField: String?) {
-        instrumentedBytecode = HookInstrumentor(
-            hooks,
-            java6Mode = extractClassFileMajorVersion(instrumentedBytecode) < 51,
-            classWithHooksEnabledField = classWithHooksEnabledField,
-        ).instrument(internalClassName, instrumentedBytecode)
+    fun hooks(
+        hooks: Iterable<Hook>,
+        classWithHooksEnabledField: String?,
+    ) {
+        instrumentedBytecode =
+            HookInstrumentor(
+                hooks,
+                java6Mode = extractClassFileMajorVersion(instrumentedBytecode) < 51,
+                classWithHooksEnabledField = classWithHooksEnabledField,
+            ).instrument(internalClassName, instrumentedBytecode)
     }
 
     companion object {

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/DescriptorUtils.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/DescriptorUtils.kt
@@ -25,40 +25,39 @@ val Class<*>.descriptor: String
     get() = Type.getDescriptor(this)
 
 val Executable.descriptor: String
-    get() = if (this is Method) {
-        Type.getMethodDescriptor(this)
-    } else {
-        Type.getConstructorDescriptor(this as Constructor<*>?)
-    }
+    get() =
+        if (this is Method) {
+            Type.getMethodDescriptor(this)
+        } else {
+            Type.getConstructorDescriptor(this as Constructor<*>?)
+        }
 
-internal fun isPrimitiveType(typeDescriptor: String): Boolean {
-    return typeDescriptor in arrayOf("B", "C", "D", "F", "I", "J", "S", "V", "Z")
-}
+internal fun isPrimitiveType(typeDescriptor: String): Boolean = typeDescriptor in arrayOf("B", "C", "D", "F", "I", "J", "S", "V", "Z")
 
 private fun isPrimitiveType(typeDescriptor: Char) = isPrimitiveType(typeDescriptor.toString())
 
-internal fun getWrapperTypeDescriptor(typeDescriptor: String): String = when (typeDescriptor) {
-    "B" -> "Ljava/lang/Byte;"
-    "C" -> "Ljava/lang/Character;"
-    "D" -> "Ljava/lang/Double;"
-    "F" -> "Ljava/lang/Float;"
-    "I" -> "Ljava/lang/Integer;"
-    "J" -> "Ljava/lang/Long;"
-    "S" -> "Ljava/lang/Short;"
-    "V" -> "Ljava/lang/Void;"
-    "Z" -> "Ljava/lang/Boolean;"
-    else -> typeDescriptor
-}
+internal fun getWrapperTypeDescriptor(typeDescriptor: String): String =
+    when (typeDescriptor) {
+        "B" -> "Ljava/lang/Byte;"
+        "C" -> "Ljava/lang/Character;"
+        "D" -> "Ljava/lang/Double;"
+        "F" -> "Ljava/lang/Float;"
+        "I" -> "Ljava/lang/Integer;"
+        "J" -> "Ljava/lang/Long;"
+        "S" -> "Ljava/lang/Short;"
+        "V" -> "Ljava/lang/Void;"
+        "Z" -> "Ljava/lang/Boolean;"
+        else -> typeDescriptor
+    }
 
 // Removes the 'L' and ';' prefix/suffix from signatures to get the full class name.
 // Note that array signatures '[Ljava/lang/String;' already have the correct form.
-internal fun extractInternalClassName(typeDescriptor: String): String {
-    return if (typeDescriptor.startsWith("L") && typeDescriptor.endsWith(";")) {
+internal fun extractInternalClassName(typeDescriptor: String): String =
+    if (typeDescriptor.startsWith("L") && typeDescriptor.endsWith(";")) {
         typeDescriptor.substring(1, typeDescriptor.length - 1)
     } else {
         typeDescriptor
     }
-}
 
 internal fun extractParameterTypeDescriptors(methodDescriptor: String): List<String> {
     require(methodDescriptor.startsWith('(')) { "Method descriptor must start with '('" }

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/DeterministicRandom.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/DeterministicRandom.kt
@@ -20,16 +20,20 @@ import java.security.MessageDigest
 import java.security.SecureRandom
 
 // This RNG is resistant to collisions (even under XOR) but fully deterministic.
-internal class DeterministicRandom(vararg contexts: String) {
-    private val random = SecureRandom.getInstance("SHA1PRNG").apply {
-        val contextHash = MessageDigest.getInstance("SHA-256").run {
-            for (context in contexts) {
-                update(context.toByteArray())
-            }
-            digest()
+internal class DeterministicRandom(
+    vararg contexts: String,
+) {
+    private val random =
+        SecureRandom.getInstance("SHA1PRNG").apply {
+            val contextHash =
+                MessageDigest.getInstance("SHA-256").run {
+                    for (context in contexts) {
+                        update(context.toByteArray())
+                    }
+                    digest()
+                }
+            setSeed(contextHash)
         }
-        setSeed(contextHash)
-    }
 
     fun nextInt(bound: Int) = random.nextInt(bound)
 

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/HookInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/HookInstrumentor.kt
@@ -26,39 +26,42 @@ internal class HookInstrumentor(
     private val java6Mode: Boolean,
     private val classWithHooksEnabledField: String?,
 ) : Instrumentor {
-
     private lateinit var random: DeterministicRandom
 
-    override fun instrument(internalClassName: String, bytecode: ByteArray): ByteArray {
+    override fun instrument(
+        internalClassName: String,
+        bytecode: ByteArray,
+    ): ByteArray {
         val reader = ClassReader(bytecode)
         val writer = ClassWriter(reader, ClassWriter.COMPUTE_MAXS)
         random = DeterministicRandom("hook", reader.className)
-        val interceptor = object : ClassVisitor(Instrumentor.ASM_API_VERSION, writer) {
-            override fun visitMethod(
-                access: Int,
-                name: String?,
-                descriptor: String?,
-                signature: String?,
-                exceptions: Array<String>?,
-            ): MethodVisitor? {
-                val mv = cv.visitMethod(access, name, descriptor, signature, exceptions) ?: return null
-                return if (shouldInstrument(access)) {
-                    makeHookMethodVisitor(
-                        internalClassName,
-                        access,
-                        name,
-                        descriptor,
-                        mv,
-                        hooks,
-                        java6Mode,
-                        random,
-                        classWithHooksEnabledField,
-                    )
-                } else {
-                    mv
+        val interceptor =
+            object : ClassVisitor(Instrumentor.ASM_API_VERSION, writer) {
+                override fun visitMethod(
+                    access: Int,
+                    name: String?,
+                    descriptor: String?,
+                    signature: String?,
+                    exceptions: Array<String>?,
+                ): MethodVisitor? {
+                    val mv = cv.visitMethod(access, name, descriptor, signature, exceptions) ?: return null
+                    return if (shouldInstrument(access)) {
+                        makeHookMethodVisitor(
+                            internalClassName,
+                            access,
+                            name,
+                            descriptor,
+                            mv,
+                            hooks,
+                            java6Mode,
+                            random,
+                            classWithHooksEnabledField,
+                        )
+                    } else {
+                        mv
+                    }
                 }
             }
-        }
         reader.accept(interceptor, ClassReader.EXPAND_FRAMES)
         return writer.toByteArray()
     }

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/Hooks.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/Hooks.kt
@@ -31,27 +31,31 @@ data class Hooks(
     val hookClasses: Set<Class<*>>,
     val additionalHookClassNameGlobber: ClassNameGlobber,
 ) {
-
     companion object {
-
-        fun appendHooksToBootstrapClassLoaderSearch(instrumentation: Instrumentation, hookClassNames: Set<String>) {
-            hookClassNames.mapNotNull { hook ->
-                val hookClassFilePath = "/${hook.replace('.', '/')}.class"
-                val hookClassFile = Companion::class.java.getResource(hookClassFilePath) ?: return@mapNotNull null
-                if ("jar" != hookClassFile.protocol) {
-                    return@mapNotNull null
-                }
-                // hookClassFile.file looks as follows:
-                // file:/tmp/ExampleFuzzerHooks_deploy.jar!/com/example/ExampleFuzzerHooks.class
-                hookClassFile.file.removePrefix("file:").takeWhile { it != '!' }
-            }
-                .toSet()
+        fun appendHooksToBootstrapClassLoaderSearch(
+            instrumentation: Instrumentation,
+            hookClassNames: Set<String>,
+        ) {
+            hookClassNames
+                .mapNotNull { hook ->
+                    val hookClassFilePath = "/${hook.replace('.', '/')}.class"
+                    val hookClassFile = Companion::class.java.getResource(hookClassFilePath) ?: return@mapNotNull null
+                    if ("jar" != hookClassFile.protocol) {
+                        return@mapNotNull null
+                    }
+                    // hookClassFile.file looks as follows:
+                    // file:/tmp/ExampleFuzzerHooks_deploy.jar!/com/example/ExampleFuzzerHooks.class
+                    hookClassFile.file.removePrefix("file:").takeWhile { it != '!' }
+                }.toSet()
                 .map { JarFile(it) }
                 .forEach { instrumentation.appendToBootstrapClassLoaderSearch(it) }
         }
 
-        fun loadHooks(excludeHookClassNames: List<String>, vararg hookClassNames: Set<String>): List<Hooks> {
-            return ClassGraph()
+        fun loadHooks(
+            excludeHookClassNames: List<String>,
+            vararg hookClassNames: Set<String>,
+        ): List<Hooks> =
+            ClassGraph()
                 .enableClassInfo()
                 .enableSystemJarsAndModules()
                 .acceptLibOrExtJars()
@@ -63,38 +67,40 @@ data class Hooks(
                     val loader = HooksLoader(scanResult, excludeHookClassNames)
                     hookClassNames.map(loader::load)
                 }
-        }
 
-        private class HooksLoader(private val scanResult: ScanResult, val excludeHookClassNames: List<String>) {
-
+        private class HooksLoader(
+            private val scanResult: ScanResult,
+            val excludeHookClassNames: List<String>,
+        ) {
             fun load(hookClassNames: Set<String>): Hooks {
                 val hooksWithHookClasses = hookClassNames.flatMap(::loadHooks)
                 val hooks = hooksWithHookClasses.map { it.first }
                 val hookClasses = hooksWithHookClasses.map { it.second }.toSet()
-                val additionalHookClassNameGlobber = ClassNameGlobber(
-                    hooks.flatMap(Hook::additionalClassesToHook),
-                    excludeHookClassNames,
-                )
+                val additionalHookClassNameGlobber =
+                    ClassNameGlobber(
+                        hooks.flatMap(Hook::additionalClassesToHook),
+                        excludeHookClassNames,
+                    )
                 return Hooks(hooks, hookClasses, additionalHookClassNameGlobber)
             }
 
-            private fun loadHooks(hookClassName: String): List<Pair<Hook, Class<*>>> {
-                return try {
+            private fun loadHooks(hookClassName: String): List<Pair<Hook, Class<*>>> =
+                try {
                     // We let the static initializers of hook classes execute so that hooks can run
                     // code before the fuzz target class has been loaded (e.g., register themselves
                     // for the onFuzzTargetReady callback).
                     val hookClass =
                         Class.forName(hookClassName, true, Companion::class.java.classLoader)
-                    loadHooks(hookClass).also {
-                        Log.info("Loaded ${it.size} hooks from $hookClassName")
-                    }.map {
-                        it to hookClass
-                    }
+                    loadHooks(hookClass)
+                        .also {
+                            Log.info("Loaded ${it.size} hooks from $hookClassName")
+                        }.map {
+                            it to hookClass
+                        }
                 } catch (e: ClassNotFoundException) {
                     Log.warn("Failed to load hooks from $hookClassName", e)
                     emptyList()
                 }
-            }
 
             private fun loadHooks(hookClass: Class<*>): List<Hook> {
                 val hooks = mutableListOf<Hook>()
@@ -111,23 +117,26 @@ data class Hooks(
                 return hooks
             }
 
-            private fun verifyAndGetHooks(hookMethod: Method, hookData: MethodHook): List<Hook> {
-                return lookupClassesToHook(hookData.targetClassName)
+            private fun verifyAndGetHooks(
+                hookMethod: Method,
+                hookData: MethodHook,
+            ): List<Hook> =
+                lookupClassesToHook(hookData.targetClassName)
                     .map { className ->
                         Hook.createAndVerifyHook(hookMethod, hookData, className)
                     }
-            }
 
             private fun lookupClassesToHook(annotationTargetClassName: String): List<String> {
                 // Allowing arbitrary exterior whitespace in the target class name allows for an easy workaround
                 // for mangled hooks due to shading applied to hooks.
                 val targetClassName = annotationTargetClassName.trim()
                 val targetClassInfo = scanResult.getClassInfo(targetClassName) ?: return listOf(targetClassName)
-                val additionalTargetClasses = when {
-                    targetClassInfo.isInterface -> scanResult.getClassesImplementing(targetClassName)
-                    targetClassInfo.isAbstract -> scanResult.getSubclasses(targetClassName)
-                    else -> emptyList()
-                }
+                val additionalTargetClasses =
+                    when {
+                        targetClassInfo.isInterface -> scanResult.getClassesImplementing(targetClassName)
+                        targetClassInfo.isAbstract -> scanResult.getSubclasses(targetClassName)
+                        else -> emptyList()
+                    }
                 return (listOf(targetClassName) + additionalTargetClasses.map { it.name }).sorted()
             }
         }

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/Instrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/Instrumentor.kt
@@ -29,17 +29,18 @@ enum class InstrumentationType {
 }
 
 internal interface Instrumentor {
-    fun instrument(internalClassName: String, bytecode: ByteArray): ByteArray
+    fun instrument(
+        internalClassName: String,
+        bytecode: ByteArray,
+    ): ByteArray
 
-    fun shouldInstrument(access: Int): Boolean {
-        return (access and Opcodes.ACC_ABSTRACT == 0) &&
+    fun shouldInstrument(access: Int): Boolean =
+        (access and Opcodes.ACC_ABSTRACT == 0) &&
             (access and Opcodes.ACC_NATIVE == 0)
-    }
 
-    fun shouldInstrument(method: MethodNode): Boolean {
-        return shouldInstrument(method.access) &&
+    fun shouldInstrument(method: MethodNode): Boolean =
+        shouldInstrument(method.access) &&
             method.instructions.size() > 0
-    }
 
     companion object {
         const val ASM_API_VERSION = Opcodes.ASM9

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentor.kt
@@ -36,10 +36,12 @@ internal class TraceDataFlowInstrumentor(
     private val types: Set<InstrumentationType>,
     private val callbackInternalClassName: String = "com/code_intelligence/jazzer/runtime/TraceDataFlowNativeCallbacks",
 ) : Instrumentor {
-
     private lateinit var random: DeterministicRandom
 
-    override fun instrument(internalClassName: String, bytecode: ByteArray): ByteArray {
+    override fun instrument(
+        internalClassName: String,
+        bytecode: ByteArray,
+    ): ByteArray {
         val node = ClassNode()
         val reader = ClassReader(bytecode)
         reader.accept(node, 0)
@@ -93,31 +95,33 @@ internal class TraceDataFlowInstrumentor(
                     // https://github.com/llvm-mirror/compiler-rt/blob/69445f095c22aac2388f939bedebf224a6efcdaf/lib/fuzzer/FuzzerTracePC.cpp#L520
                     // Case values are reported to libFuzzer via an array of unsigned long values and thus need to be
                     // sorted by unsigned value.
-                    val caseValues = when (inst) {
-                        is LookupSwitchInsnNode -> {
-                            // If the switch is over String values, find out the actual values and not the hashes, and
-                            // report them to libFuzzer in the switch's default case.
-                            if (instrumentSwitchOverStrings(method, inst)) {
-                                continue@loop
+                    val caseValues =
+                        when (inst) {
+                            is LookupSwitchInsnNode -> {
+                                // If the switch is over String values, find out the actual values and not the hashes, and
+                                // report them to libFuzzer in the switch's default case.
+                                if (instrumentSwitchOverStrings(method, inst)) {
+                                    continue@loop
+                                }
+                                if (inst.keys.isEmpty() || (0 <= inst.keys.first() && inst.keys.last() < 256)) {
+                                    continue@loop
+                                }
+                                inst.keys
                             }
-                            if (inst.keys.isEmpty() || (0 <= inst.keys.first() && inst.keys.last() < 256)) {
-                                continue@loop
+                            is TableSwitchInsnNode -> {
+                                if (0 <= inst.min && inst.max < 256) {
+                                    continue@loop
+                                }
+                                (inst.min..inst.max)
+                                    .filter { caseValue ->
+                                        val index = caseValue - inst.min
+                                        // Filter out "gap cases".
+                                        inst.labels[index].label != inst.dflt.label
+                                    }.toList()
                             }
-                            inst.keys
-                        }
-                        is TableSwitchInsnNode -> {
-                            if (0 <= inst.min && inst.max < 256) {
-                                continue@loop
-                            }
-                            (inst.min..inst.max).filter { caseValue ->
-                                val index = caseValue - inst.min
-                                // Filter out "gap cases".
-                                inst.labels[index].label != inst.dflt.label
-                            }.toList()
-                        }
-                        // Not reached.
-                        else -> continue@loop
-                    }.sortedBy { it.toUInt() }.map { it.toLong() }.toLongArray()
+                            // Not reached.
+                            else -> continue@loop
+                        }.sortedBy { it.toUInt() }.map { it.toLong() }.toLongArray()
                     method.instructions.insertBefore(inst, switchInstrumentation(caseValues))
                 }
                 Opcodes.IDIV -> {
@@ -244,69 +248,75 @@ internal class TraceDataFlowInstrumentor(
         add(LdcInsnNode(random.nextInt(512)))
     }
 
-    private fun longCmpInstrumentation() = InsnList().apply {
-        pushFakePc()
-        // traceCmpLong returns the result of the comparison as duplicating two longs on the stack
-        // is not possible without local variables.
-        add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceCmpLongWrapper", "(JJI)I", false))
-    }
-
-    private fun intCmpInstrumentation() = InsnList().apply {
-        add(InsnNode(Opcodes.DUP2))
-        pushFakePc()
-        add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceCmpInt", "(III)V", false))
-    }
-
-    private fun ifInstrumentation() = InsnList().apply {
-        add(InsnNode(Opcodes.DUP))
-        // All if* instructions are compares to the constant 0.
-        add(InsnNode(Opcodes.ICONST_0))
-        add(InsnNode(Opcodes.SWAP))
-        pushFakePc()
-        add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceConstCmpInt", "(III)V", false))
-    }
-
-    private fun intDivInstrumentation() = InsnList().apply {
-        add(InsnNode(Opcodes.DUP))
-        pushFakePc()
-        add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceDivInt", "(II)V", false))
-    }
-
-    private fun longDivInstrumentation() = InsnList().apply {
-        add(InsnNode(Opcodes.DUP2))
-        pushFakePc()
-        add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceDivLong", "(JI)V", false))
-    }
-
-    private fun switchInstrumentation(caseValues: LongArray) = InsnList().apply {
-        // duplicate {lookup,table}switch key for use as first function argument
-        add(InsnNode(Opcodes.DUP))
-        add(InsnNode(Opcodes.I2L))
-        // Set up array with switch case values. The format libfuzzer expects is created here directly, i.e., the first
-        // two entries are the number of cases and the bit size of values (always 32).
-        add(IntInsnNode(Opcodes.SIPUSH, caseValues.size + 2))
-        add(IntInsnNode(Opcodes.NEWARRAY, Opcodes.T_LONG))
-        // Store number of cases
-        add(InsnNode(Opcodes.DUP))
-        add(IntInsnNode(Opcodes.SIPUSH, 0))
-        add(LdcInsnNode(caseValues.size.toLong()))
-        add(InsnNode(Opcodes.LASTORE))
-        // Store bit size of keys
-        add(InsnNode(Opcodes.DUP))
-        add(IntInsnNode(Opcodes.SIPUSH, 1))
-        add(LdcInsnNode(32.toLong()))
-        add(InsnNode(Opcodes.LASTORE))
-        // Store {lookup,table}switch case values
-        for ((i, caseValue) in caseValues.withIndex()) {
-            add(InsnNode(Opcodes.DUP))
-            add(IntInsnNode(Opcodes.SIPUSH, 2 + i))
-            add(LdcInsnNode(caseValue))
-            add(InsnNode(Opcodes.LASTORE))
+    private fun longCmpInstrumentation() =
+        InsnList().apply {
+            pushFakePc()
+            // traceCmpLong returns the result of the comparison as duplicating two longs on the stack
+            // is not possible without local variables.
+            add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceCmpLongWrapper", "(JJI)I", false))
         }
-        pushFakePc()
-        // call the native callback function
-        add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceSwitch", "(J[JI)V", false))
-    }
+
+    private fun intCmpInstrumentation() =
+        InsnList().apply {
+            add(InsnNode(Opcodes.DUP2))
+            pushFakePc()
+            add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceCmpInt", "(III)V", false))
+        }
+
+    private fun ifInstrumentation() =
+        InsnList().apply {
+            add(InsnNode(Opcodes.DUP))
+            // All if* instructions are compares to the constant 0.
+            add(InsnNode(Opcodes.ICONST_0))
+            add(InsnNode(Opcodes.SWAP))
+            pushFakePc()
+            add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceConstCmpInt", "(III)V", false))
+        }
+
+    private fun intDivInstrumentation() =
+        InsnList().apply {
+            add(InsnNode(Opcodes.DUP))
+            pushFakePc()
+            add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceDivInt", "(II)V", false))
+        }
+
+    private fun longDivInstrumentation() =
+        InsnList().apply {
+            add(InsnNode(Opcodes.DUP2))
+            pushFakePc()
+            add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceDivLong", "(JI)V", false))
+        }
+
+    private fun switchInstrumentation(caseValues: LongArray) =
+        InsnList().apply {
+            // duplicate {lookup,table}switch key for use as first function argument
+            add(InsnNode(Opcodes.DUP))
+            add(InsnNode(Opcodes.I2L))
+            // Set up array with switch case values. The format libfuzzer expects is created here directly, i.e., the first
+            // two entries are the number of cases and the bit size of values (always 32).
+            add(IntInsnNode(Opcodes.SIPUSH, caseValues.size + 2))
+            add(IntInsnNode(Opcodes.NEWARRAY, Opcodes.T_LONG))
+            // Store number of cases
+            add(InsnNode(Opcodes.DUP))
+            add(IntInsnNode(Opcodes.SIPUSH, 0))
+            add(LdcInsnNode(caseValues.size.toLong()))
+            add(InsnNode(Opcodes.LASTORE))
+            // Store bit size of keys
+            add(InsnNode(Opcodes.DUP))
+            add(IntInsnNode(Opcodes.SIPUSH, 1))
+            add(LdcInsnNode(32.toLong()))
+            add(InsnNode(Opcodes.LASTORE))
+            // Store {lookup,table}switch case values
+            for ((i, caseValue) in caseValues.withIndex()) {
+                add(InsnNode(Opcodes.DUP))
+                add(IntInsnNode(Opcodes.SIPUSH, 2 + i))
+                add(LdcInsnNode(caseValue))
+                add(InsnNode(Opcodes.LASTORE))
+            }
+            pushFakePc()
+            // call the native callback function
+            add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceSwitch", "(J[JI)V", false))
+        }
 
     /**
      * Returns true if [node] represents an instruction that possibly pushes a valid, non-zero, constant array index
@@ -324,47 +334,54 @@ internal class TraceDataFlowInstrumentor(
         return MethodInfo(node.owner, node.name, returnType) in GEP_LOAD_METHODS
     }
 
-    private fun gepLoadInstrumentation() = InsnList().apply {
-        // Duplicate the index and convert to long.
-        add(InsnNode(Opcodes.DUP))
-        add(InsnNode(Opcodes.I2L))
-        pushFakePc()
-        add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceGep", "(JI)V", false))
-    }
+    private fun gepLoadInstrumentation() =
+        InsnList().apply {
+            // Duplicate the index and convert to long.
+            add(InsnNode(Opcodes.DUP))
+            add(InsnNode(Opcodes.I2L))
+            pushFakePc()
+            add(MethodInsnNode(Opcodes.INVOKESTATIC, callbackInternalClassName, "traceGep", "(JI)V", false))
+        }
 
     companion object {
         // Low constants (0, 1) are omitted as they create a lot of noise.
-        val CONSTANT_INTEGER_PUSH_OPCODES = listOf(
-            Opcodes.BIPUSH,
-            Opcodes.SIPUSH,
-            Opcodes.LDC,
-            Opcodes.ICONST_2,
-            Opcodes.ICONST_3,
-            Opcodes.ICONST_4,
-            Opcodes.ICONST_5,
+        val CONSTANT_INTEGER_PUSH_OPCODES =
+            listOf(
+                Opcodes.BIPUSH,
+                Opcodes.SIPUSH,
+                Opcodes.LDC,
+                Opcodes.ICONST_2,
+                Opcodes.ICONST_3,
+                Opcodes.ICONST_4,
+                Opcodes.ICONST_5,
+            )
+
+        data class MethodInfo(
+            val internalClassName: String,
+            val name: String,
+            val returnType: String,
         )
 
-        data class MethodInfo(val internalClassName: String, val name: String, val returnType: String)
-
-        val GEP_LOAD_METHODS = setOf(
-            MethodInfo("java/util/AbstractList", "get", "Ljava/lang/Object;"),
-            MethodInfo("java/util/ArrayList", "get", "Ljava/lang/Object;"),
-            MethodInfo("java/util/List", "get", "Ljava/lang/Object;"),
-            MethodInfo("java/util/Stack", "get", "Ljava/lang/Object;"),
-            MethodInfo("java/util/Vector", "get", "Ljava/lang/Object;"),
-            MethodInfo("java/lang/CharSequence", "charAt", "C"),
-            MethodInfo("java/lang/String", "charAt", "C"),
-            MethodInfo("java/lang/StringBuffer", "charAt", "C"),
-            MethodInfo("java/lang/StringBuilder", "charAt", "C"),
-            MethodInfo("java/lang/String", "codePointAt", "I"),
-            MethodInfo("java/lang/String", "codePointBefore", "I"),
-            MethodInfo("java/nio/ByteBuffer", "get", "B"),
-            MethodInfo("java/nio/ByteBuffer", "getChar", "C"),
-            MethodInfo("java/nio/ByteBuffer", "getDouble", "D"),
-            MethodInfo("java/nio/ByteBuffer", "getFloat", "F"),
-            MethodInfo("java/nio/ByteBuffer", "getInt", "I"),
-            MethodInfo("java/nio/ByteBuffer", "getLong", "J"),
-            MethodInfo("java/nio/ByteBuffer", "getShort", "S"),
-        )
+        val GEP_LOAD_METHODS =
+            setOf(
+                MethodInfo("java/util/AbstractList", "get", "Ljava/lang/Object;"),
+                MethodInfo("java/util/ArrayList", "get", "Ljava/lang/Object;"),
+                MethodInfo("java/util/List", "get", "Ljava/lang/Object;"),
+                MethodInfo("java/util/Stack", "get", "Ljava/lang/Object;"),
+                MethodInfo("java/util/Vector", "get", "Ljava/lang/Object;"),
+                MethodInfo("java/lang/CharSequence", "charAt", "C"),
+                MethodInfo("java/lang/String", "charAt", "C"),
+                MethodInfo("java/lang/StringBuffer", "charAt", "C"),
+                MethodInfo("java/lang/StringBuilder", "charAt", "C"),
+                MethodInfo("java/lang/String", "codePointAt", "I"),
+                MethodInfo("java/lang/String", "codePointBefore", "I"),
+                MethodInfo("java/nio/ByteBuffer", "get", "B"),
+                MethodInfo("java/nio/ByteBuffer", "getChar", "C"),
+                MethodInfo("java/nio/ByteBuffer", "getDouble", "D"),
+                MethodInfo("java/nio/ByteBuffer", "getFloat", "F"),
+                MethodInfo("java/nio/ByteBuffer", "getInt", "I"),
+                MethodInfo("java/nio/ByteBuffer", "getLong", "J"),
+                MethodInfo("java/nio/ByteBuffer", "getShort", "S"),
+            )
     }
 }

--- a/src/main/java/com/code_intelligence/jazzer/utils/ClassNameGlobber.kt
+++ b/src/main/java/com/code_intelligence/jazzer/utils/ClassNameGlobber.kt
@@ -16,53 +16,62 @@
 
 package com.code_intelligence.jazzer.utils
 
-private val BASE_INCLUDED_CLASS_NAME_GLOBS = listOf(
-    "**", // everything
-)
+private val BASE_INCLUDED_CLASS_NAME_GLOBS =
+    listOf(
+        "**", // everything
+    )
 
 // We use both a strong indicator for running as a Bazel test together with an indicator for a
 // Bazel coverage run to rule out false positives.
-private val IS_BAZEL_COVERAGE_RUN = System.getenv("TEST_UNDECLARED_OUTPUTS_DIR") != null &&
-    System.getenv("COVERAGE_DIR") != null
+private val IS_BAZEL_COVERAGE_RUN =
+    System.getenv("TEST_UNDECLARED_OUTPUTS_DIR") != null &&
+        System.getenv("COVERAGE_DIR") != null
 
-private val ADDITIONAL_EXCLUDED_NAME_GLOBS_FOR_BAZEL_COVERAGE = listOf(
-    "com.google.testing.coverage.**",
-    "org.jacoco.**",
-)
+private val ADDITIONAL_EXCLUDED_NAME_GLOBS_FOR_BAZEL_COVERAGE =
+    listOf(
+        "com.google.testing.coverage.**",
+        "org.jacoco.**",
+    )
 
-private val BASE_EXCLUDED_CLASS_NAME_GLOBS = listOf(
-    // JDK internals
-    "\\[**", // array types
-    "java.**",
-    "javax.**",
-    "jdk.**",
-    "sun.**",
-    "com.sun.**", // package for Proxy objects
-    // Azul JDK internals
-    "com.azul.tooling.**",
-    // Kotlin internals
-    "kotlin.**",
-    // Jazzer internals
-    "com.code_intelligence.jazzer.**",
-    "jaz.Ter", // safe companion of the honeypot class used by sanitizers
-    "jaz.Zer", // honeypot class used by sanitizers
-    // Test and instrumentation tools
-    "org.junit.**", // dependency of @FuzzTest
-    "org.mockito.**", // can cause instrumentation cycles
-    "net.bytebuddy.**", // ignore Byte Buddy, though it's probably shaded
-    "org.jetbrains.**", // ignore JetBrains products (coverage agent)
-) + if (IS_BAZEL_COVERAGE_RUN) ADDITIONAL_EXCLUDED_NAME_GLOBS_FOR_BAZEL_COVERAGE else listOf()
+private val BASE_EXCLUDED_CLASS_NAME_GLOBS =
+    listOf(
+        // JDK internals
+        "\\[**", // array types
+        "java.**",
+        "javax.**",
+        "jdk.**",
+        "sun.**",
+        "com.sun.**", // package for Proxy objects
+        // Azul JDK internals
+        "com.azul.tooling.**",
+        // Kotlin internals
+        "kotlin.**",
+        // Jazzer internals
+        "com.code_intelligence.jazzer.**",
+        "jaz.Ter", // safe companion of the honeypot class used by sanitizers
+        "jaz.Zer", // honeypot class used by sanitizers
+        // Test and instrumentation tools
+        "org.junit.**", // dependency of @FuzzTest
+        "org.mockito.**", // can cause instrumentation cycles
+        "net.bytebuddy.**", // ignore Byte Buddy, though it's probably shaded
+        "org.jetbrains.**", // ignore JetBrains products (coverage agent)
+    ) + if (IS_BAZEL_COVERAGE_RUN) ADDITIONAL_EXCLUDED_NAME_GLOBS_FOR_BAZEL_COVERAGE else listOf()
 
-class ClassNameGlobber(includes: List<String>, excludes: List<String>) {
+class ClassNameGlobber(
+    includes: List<String>,
+    excludes: List<String>,
+) {
     // If no include globs are provided, start with all classes.
-    private val includeMatchers = includes.ifEmpty { BASE_INCLUDED_CLASS_NAME_GLOBS }
-        .map(::SimpleGlobMatcher)
+    private val includeMatchers =
+        includes
+            .ifEmpty { BASE_INCLUDED_CLASS_NAME_GLOBS }
+            .map(::SimpleGlobMatcher)
 
     // If no include globs are provided, additionally exclude stdlib classes as well as our own classes.
-    private val excludeMatchers = (if (includes.isEmpty()) BASE_EXCLUDED_CLASS_NAME_GLOBS + excludes else excludes)
-        .map(::SimpleGlobMatcher)
+    private val excludeMatchers =
+        (if (includes.isEmpty()) BASE_EXCLUDED_CLASS_NAME_GLOBS + excludes else excludes)
+            .map(::SimpleGlobMatcher)
 
-    fun includes(className: String): Boolean {
-        return includeMatchers.any { it.matches(className) } && excludeMatchers.none { it.matches(className) }
-    }
+    fun includes(className: String): Boolean =
+        includeMatchers.any { it.matches(className) } && excludeMatchers.none { it.matches(className) }
 }

--- a/src/main/java/com/code_intelligence/jazzer/utils/ManifestUtils.kt
+++ b/src/main/java/com/code_intelligence/jazzer/utils/ManifestUtils.kt
@@ -19,18 +19,19 @@ package com.code_intelligence.jazzer.utils
 import java.util.jar.Manifest
 
 object ManifestUtils {
-
     private const val FUZZ_TARGET_CLASS = "Jazzer-Fuzz-Target-Class"
     const val HOOK_CLASSES = "Jazzer-Hook-Classes"
 
     fun combineManifestValues(attribute: String): List<String> {
         val manifests = ManifestUtils::class.java.classLoader.getResources("META-INF/MANIFEST.MF")
-        return manifests.asSequence().mapNotNull { url ->
-            url.openStream().use { inputStream ->
-                val manifest = Manifest(inputStream)
-                manifest.mainAttributes.getValue(attribute)
-            }
-        }.toList()
+        return manifests
+            .asSequence()
+            .mapNotNull { url ->
+                url.openStream().use { inputStream ->
+                    val manifest = Manifest(inputStream)
+                    manifest.mainAttributes.getValue(attribute)
+                }
+            }.toList()
     }
 
     /**

--- a/src/main/java/com/code_intelligence/jazzer/utils/SimpleGlobMatcher.kt
+++ b/src/main/java/com/code_intelligence/jazzer/utils/SimpleGlobMatcher.kt
@@ -16,7 +16,9 @@
 
 package com.code_intelligence.jazzer.utils
 
-class SimpleGlobMatcher(val glob: String) {
+class SimpleGlobMatcher(
+    val glob: String,
+) {
     private enum class Type {
         // foo.bar (matches foo.bar only)
         FULL_MATCH,

--- a/src/main/java/com/code_intelligence/jazzer/utils/Utils.kt
+++ b/src/main/java/com/code_intelligence/jazzer/utils/Utils.kt
@@ -20,28 +20,30 @@ package com.code_intelligence.jazzer.utils
 import java.lang.reflect.Executable
 
 val Class<*>.readableDescriptor: String
-    get() = when {
-        isPrimitive -> {
-            when (this) {
-                Boolean::class.javaPrimitiveType -> "boolean"
-                Byte::class.javaPrimitiveType -> "byte"
-                Char::class.javaPrimitiveType -> "char"
-                Short::class.javaPrimitiveType -> "short"
-                Int::class.javaPrimitiveType -> "int"
-                Long::class.javaPrimitiveType -> "long"
-                Float::class.javaPrimitiveType -> "float"
-                Double::class.javaPrimitiveType -> "double"
-                java.lang.Void::class.javaPrimitiveType -> "void"
-                else -> throw IllegalStateException("Unknown primitive type: $name")
+    get() =
+        when {
+            isPrimitive -> {
+                when (this) {
+                    Boolean::class.javaPrimitiveType -> "boolean"
+                    Byte::class.javaPrimitiveType -> "byte"
+                    Char::class.javaPrimitiveType -> "char"
+                    Short::class.javaPrimitiveType -> "short"
+                    Int::class.javaPrimitiveType -> "int"
+                    Long::class.javaPrimitiveType -> "long"
+                    Float::class.javaPrimitiveType -> "float"
+                    Double::class.javaPrimitiveType -> "double"
+                    java.lang.Void::class.javaPrimitiveType -> "void"
+                    else -> throw IllegalStateException("Unknown primitive type: $name")
+                }
             }
+            isArray -> "${componentType.readableDescriptor}[]"
+            java.lang.Object::class.java.isAssignableFrom(this) -> name
+            else -> throw IllegalArgumentException("Unknown class type: $name")
         }
-        isArray -> "${componentType.readableDescriptor}[]"
-        java.lang.Object::class.java.isAssignableFrom(this) -> name
-        else -> throw IllegalArgumentException("Unknown class type: $name")
-    }
 
 // This does not include the return type as the parameter descriptors already uniquely identify the executable.
 val Executable.readableDescriptor: String
-    get() = parameterTypes.joinToString(separator = ",", prefix = "(", postfix = ")") { parameterType ->
-        parameterType.readableDescriptor
-    }
+    get() =
+        parameterTypes.joinToString(separator = ",", prefix = "(", postfix = ")") { parameterType ->
+            parameterType.readableDescriptor
+        }

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooksPatchTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooksPatchTest.kt
@@ -52,6 +52,7 @@ private fun getPatchedAfterHooksTargetInstance(classWithHooksEnabledField: Class
     return patchedClass.getDeclaredConstructor().newInstance() as AfterHooksTargetContract
 }
 
+@Suppress("ktlint:standard:property-naming")
 class AfterHooksPatchTest {
     @Test
     fun testOriginal() {

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooksPatchTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/AfterHooksPatchTest.kt
@@ -21,17 +21,16 @@ import com.code_intelligence.jazzer.instrumentor.PatchTestUtils.classToBytecode
 import org.junit.Test
 import java.io.File
 
-private fun getOriginalAfterHooksTargetInstance(): AfterHooksTargetContract {
-    return AfterHooksTarget()
-}
+private fun getOriginalAfterHooksTargetInstance(): AfterHooksTargetContract = AfterHooksTarget()
 
 private fun getNoHooksAfterHooksTargetInstance(): AfterHooksTargetContract {
     val originalBytecode = classToBytecode(AfterHooksTarget::class.java)
     // Let the bytecode pass through the hooking logic, but don't apply any hooks.
-    val patchedBytecode = HookInstrumentor(emptyList(), false, null).instrument(
-        AfterHooksTarget::class.java.name.replace('.', '/'),
-        originalBytecode,
-    )
+    val patchedBytecode =
+        HookInstrumentor(emptyList(), false, null).instrument(
+            AfterHooksTarget::class.java.name.replace('.', '/'),
+            originalBytecode,
+        )
     val patchedClass = bytecodeToClass(AfterHooksTarget::class.java.name, patchedBytecode)
     return patchedClass.getDeclaredConstructor().newInstance() as AfterHooksTargetContract
 }
@@ -39,11 +38,12 @@ private fun getNoHooksAfterHooksTargetInstance(): AfterHooksTargetContract {
 private fun getPatchedAfterHooksTargetInstance(classWithHooksEnabledField: Class<*>?): AfterHooksTargetContract {
     val originalBytecode = classToBytecode(AfterHooksTarget::class.java)
     val hooks = Hooks.loadHooks(emptyList(), setOf(AfterHooks::class.java.name)).first().hooks
-    val patchedBytecode = HookInstrumentor(
-        hooks,
-        false,
-        classWithHooksEnabledField = classWithHooksEnabledField?.name?.replace('.', '/'),
-    ).instrument(AfterHooksTarget::class.java.name.replace('.', '/'), originalBytecode)
+    val patchedBytecode =
+        HookInstrumentor(
+            hooks,
+            false,
+            classWithHooksEnabledField = classWithHooksEnabledField?.name?.replace('.', '/'),
+        ).instrument(AfterHooksTarget::class.java.name.replace('.', '/'), originalBytecode)
     // Make the patched class available in bazel-testlogs/.../test.outputs for manual inspection.
     val outDir = System.getenv("TEST_UNDECLARED_OUTPUTS_DIR")
     File("$outDir/${AfterHooksTarget::class.java.simpleName}.class").writeBytes(originalBytecode)
@@ -53,7 +53,6 @@ private fun getPatchedAfterHooksTargetInstance(classWithHooksEnabledField: Class
 }
 
 class AfterHooksPatchTest {
-
     @Test
     fun testOriginal() {
         assertSelfCheck(getOriginalAfterHooksTargetInstance(), false)

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/BeforeHooksPatchTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/BeforeHooksPatchTest.kt
@@ -21,17 +21,16 @@ import com.code_intelligence.jazzer.instrumentor.PatchTestUtils.classToBytecode
 import org.junit.Test
 import java.io.File
 
-private fun getOriginalBeforeHooksTargetInstance(): BeforeHooksTargetContract {
-    return BeforeHooksTarget()
-}
+private fun getOriginalBeforeHooksTargetInstance(): BeforeHooksTargetContract = BeforeHooksTarget()
 
 private fun getNoHooksBeforeHooksTargetInstance(): BeforeHooksTargetContract {
     val originalBytecode = classToBytecode(BeforeHooksTarget::class.java)
     // Let the bytecode pass through the hooking logic, but don't apply any hooks.
-    val patchedBytecode = HookInstrumentor(emptyList(), false, null).instrument(
-        BeforeHooksTarget::class.java.name.replace('.', '/'),
-        originalBytecode,
-    )
+    val patchedBytecode =
+        HookInstrumentor(emptyList(), false, null).instrument(
+            BeforeHooksTarget::class.java.name.replace('.', '/'),
+            originalBytecode,
+        )
     val patchedClass = bytecodeToClass(BeforeHooksTarget::class.java.name, patchedBytecode)
     return patchedClass.getDeclaredConstructor().newInstance() as BeforeHooksTargetContract
 }
@@ -39,11 +38,12 @@ private fun getNoHooksBeforeHooksTargetInstance(): BeforeHooksTargetContract {
 private fun getPatchedBeforeHooksTargetInstance(classWithHooksEnabledField: Class<*>?): BeforeHooksTargetContract {
     val originalBytecode = classToBytecode(BeforeHooksTarget::class.java)
     val hooks = Hooks.loadHooks(emptyList(), setOf(BeforeHooks::class.java.name)).first().hooks
-    val patchedBytecode = HookInstrumentor(
-        hooks,
-        false,
-        classWithHooksEnabledField = classWithHooksEnabledField?.name?.replace('.', '/'),
-    ).instrument(BeforeHooksTarget::class.java.name.replace('.', '/'), originalBytecode)
+    val patchedBytecode =
+        HookInstrumentor(
+            hooks,
+            false,
+            classWithHooksEnabledField = classWithHooksEnabledField?.name?.replace('.', '/'),
+        ).instrument(BeforeHooksTarget::class.java.name.replace('.', '/'), originalBytecode)
     // Make the patched class available in bazel-testlogs/.../test.outputs for manual inspection.
     val outDir = System.getenv("TEST_UNDECLARED_OUTPUTS_DIR")
     File("$outDir/${BeforeHooksTarget::class.java.simpleName}.class").writeBytes(originalBytecode)
@@ -53,7 +53,6 @@ private fun getPatchedBeforeHooksTargetInstance(classWithHooksEnabledField: Clas
 }
 
 class BeforeHooksPatchTest {
-
     @Test
     fun testOriginal() {
         assertSelfCheck(getOriginalBeforeHooksTargetInstance(), false)

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/BeforeHooksPatchTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/BeforeHooksPatchTest.kt
@@ -52,6 +52,7 @@ private fun getPatchedBeforeHooksTargetInstance(classWithHooksEnabledField: Clas
     return patchedClass.getDeclaredConstructor().newInstance() as BeforeHooksTargetContract
 }
 
+@Suppress("ktlint:standard:property-naming")
 class BeforeHooksPatchTest {
     @Test
     fun testOriginal() {

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/CoverageInstrumentationTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/CoverageInstrumentationTest.kt
@@ -41,17 +41,16 @@ private fun makeTestable(strategy: EdgeCoverageStrategy): EdgeCoverageStrategy =
         }
     }
 
-private fun getOriginalInstrumentationTargetInstance(): DynamicTestContract {
-    return CoverageInstrumentationTarget()
-}
+private fun getOriginalInstrumentationTargetInstance(): DynamicTestContract = CoverageInstrumentationTarget()
 
 private fun getInstrumentedInstrumentationTargetInstance(): DynamicTestContract {
     val originalBytecode = classToBytecode(CoverageInstrumentationTarget::class.java)
-    val patchedBytecode = EdgeCoverageInstrumentor(
-        makeTestable(ClassInstrumentor.defaultEdgeCoverageStrategy),
-        MockCoverageMap::class.java,
-        0,
-    ).instrument(CoverageInstrumentationTarget::class.java.name.replace('.', '/'), originalBytecode)
+    val patchedBytecode =
+        EdgeCoverageInstrumentor(
+            makeTestable(ClassInstrumentor.defaultEdgeCoverageStrategy),
+            MockCoverageMap::class.java,
+            0,
+        ).instrument(CoverageInstrumentationTarget::class.java.name.replace('.', '/'), originalBytecode)
     // Make the patched class available in bazel-testlogs/.../test.outputs for manual inspection.
     val outDir = System.getenv("TEST_UNDECLARED_OUTPUTS_DIR")
     File("$outDir/${CoverageInstrumentationTarget::class.java.simpleName}.class").writeBytes(originalBytecode)
@@ -66,7 +65,6 @@ private fun assertControlFlow(expectedLocations: List<Int>) {
 
 @Suppress("unused")
 class CoverageInstrumentationTest {
-
     private val constructorReturn = 0
 
     private val mapConstructor = 1
@@ -105,26 +103,31 @@ class CoverageInstrumentationTest {
 
         val mapControlFlow = listOf(mapConstructor, addFor0, addFor1, addFor2, addFor3, addFor4, addFoobar)
         val ifControlFlow = listOf(ifTrueBranch, addBlock1, ifEnd)
-        val forFirstRunControlFlow = mutableListOf<Int>().apply {
-            add(outerForCondition)
-            repeat(5) {
-                addAll(listOf(innerForCondition, innerForBodyIfFalseBranch, innerForBodyPutInvocation))
-            }
-            add(outerForIncrementCounter)
-        }.toList()
-        val forSecondRunControlFlow = mutableListOf<Int>().apply {
-            add(outerForCondition)
-            repeat(5) {
-                addAll(listOf(innerForCondition, innerForBodyIfTrueBranch, innerForBodyPutInvocation))
-            }
-            add(outerForIncrementCounter)
-        }.toList()
+        val forFirstRunControlFlow =
+            mutableListOf<Int>()
+                .apply {
+                    add(outerForCondition)
+                    repeat(5) {
+                        addAll(listOf(innerForCondition, innerForBodyIfFalseBranch, innerForBodyPutInvocation))
+                    }
+                    add(outerForIncrementCounter)
+                }.toList()
+        val forSecondRunControlFlow =
+            mutableListOf<Int>()
+                .apply {
+                    add(outerForCondition)
+                    repeat(5) {
+                        addAll(listOf(innerForCondition, innerForBodyIfTrueBranch, innerForBodyPutInvocation))
+                    }
+                    add(outerForIncrementCounter)
+                }.toList()
         val forControlFlow = forFirstRunControlFlow + forSecondRunControlFlow
-        val fooCallControlFlow = listOf(
-            barAfterPutInvocation,
-            fooAfterBarInvocation,
-            afterFooInvocation,
-        )
+        val fooCallControlFlow =
+            listOf(
+                barAfterPutInvocation,
+                fooAfterBarInvocation,
+                afterFooInvocation,
+            )
         assertControlFlow(
             listOf(constructorReturn) +
                 mapControlFlow +
@@ -149,8 +152,9 @@ class CoverageInstrumentationTest {
             assertSelfCheck(target)
             assertEquals(1, MockCoverageMap.counters[takenOnceEdge])
             // Verify that the counter increments, but is never zero.
-            val expectedCounter = (lastCounter + 1U).toUByte().takeUnless { it == 0.toUByte() }
-                ?: (lastCounter + 2U).toUByte()
+            val expectedCounter =
+                (lastCounter + 1U).toUByte().takeUnless { it == 0.toUByte() }
+                    ?: (lastCounter + 2U).toUByte()
             lastCounter = expectedCounter
             val actualCounter = MockCoverageMap.counters[takenOnEveryRunEdge].toUByte()
             assertEquals(expectedCounter, actualCounter, "After $i runs:")
@@ -160,11 +164,12 @@ class CoverageInstrumentationTest {
     @Test
     fun testSpecialCases() {
         val originalBytecode = classToBytecode(CoverageInstrumentationSpecialCasesTarget::class.java)
-        val patchedBytecode = EdgeCoverageInstrumentor(
-            makeTestable(ClassInstrumentor.defaultEdgeCoverageStrategy),
-            MockCoverageMap::class.java,
-            0,
-        ).instrument(CoverageInstrumentationSpecialCasesTarget::class.java.name.replace('.', '/'), originalBytecode)
+        val patchedBytecode =
+            EdgeCoverageInstrumentor(
+                makeTestable(ClassInstrumentor.defaultEdgeCoverageStrategy),
+                MockCoverageMap::class.java,
+                0,
+            ).instrument(CoverageInstrumentationSpecialCasesTarget::class.java.name.replace('.', '/'), originalBytecode)
         // Make the patched class available in bazel-testlogs/.../test.outputs for manual inspection.
         val outDir = System.getenv("TEST_UNDECLARED_OUTPUTS_DIR")
         File("$outDir/${CoverageInstrumentationSpecialCasesTarget::class.simpleName}.class").writeBytes(originalBytecode)

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/DescriptorUtilsTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/DescriptorUtilsTest.kt
@@ -20,7 +20,6 @@ import org.junit.Test
 import kotlin.test.assertEquals
 
 class DescriptorUtilsTest {
-
     @Test
     fun testClassDescriptor() {
         assertEquals("V", java.lang.Void::class.javaPrimitiveType?.descriptor)
@@ -38,33 +37,47 @@ class DescriptorUtilsTest {
 
     @Test
     fun testExtractTypeDescriptors() {
-        val testCases = listOf(
-            Triple(
-                String::class.java.getMethod("equals", Object::class.java),
-                listOf("Ljava/lang/Object;"),
-                "Z",
-            ),
-            Triple(
-                String::class.java.getMethod("regionMatches", Boolean::class.javaPrimitiveType, Int::class.javaPrimitiveType, String::class.java, Int::class.javaPrimitiveType, Integer::class.javaPrimitiveType),
-                listOf("Z", "I", "Ljava/lang/String;", "I", "I"),
-                "Z",
-            ),
-            Triple(
-                String::class.java.getMethod("getChars", Integer::class.javaPrimitiveType, Int::class.javaPrimitiveType, CharArray::class.java, Int::class.javaPrimitiveType),
-                listOf("I", "I", "[C", "I"),
-                "V",
-            ),
-            Triple(
-                String::class.java.getMethod("subSequence", Integer::class.javaPrimitiveType, Integer::class.javaPrimitiveType),
-                listOf("I", "I"),
-                "Ljava/lang/CharSequence;",
-            ),
-            Triple(
-                String::class.java.getConstructor(),
-                emptyList(),
-                "V",
-            ),
-        )
+        val testCases =
+            listOf(
+                Triple(
+                    String::class.java.getMethod("equals", Object::class.java),
+                    listOf("Ljava/lang/Object;"),
+                    "Z",
+                ),
+                Triple(
+                    String::class.java.getMethod(
+                        "regionMatches",
+                        Boolean::class.javaPrimitiveType,
+                        Int::class.javaPrimitiveType,
+                        String::class.java,
+                        Int::class.javaPrimitiveType,
+                        Integer::class.javaPrimitiveType,
+                    ),
+                    listOf("Z", "I", "Ljava/lang/String;", "I", "I"),
+                    "Z",
+                ),
+                Triple(
+                    String::class.java.getMethod(
+                        "getChars",
+                        Integer::class.javaPrimitiveType,
+                        Int::class.javaPrimitiveType,
+                        CharArray::class.java,
+                        Int::class.javaPrimitiveType,
+                    ),
+                    listOf("I", "I", "[C", "I"),
+                    "V",
+                ),
+                Triple(
+                    String::class.java.getMethod("subSequence", Integer::class.javaPrimitiveType, Integer::class.javaPrimitiveType),
+                    listOf("I", "I"),
+                    "Ljava/lang/CharSequence;",
+                ),
+                Triple(
+                    String::class.java.getConstructor(),
+                    emptyList(),
+                    "V",
+                ),
+            )
         for ((executable, parameterDescriptors, returnTypeDescriptor) in testCases) {
             val descriptor = executable.descriptor
             assertEquals(extractParameterTypeDescriptors(descriptor), parameterDescriptors)

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/PatchTestUtils.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/PatchTestUtils.kt
@@ -20,22 +20,26 @@ import java.io.FileOutputStream
 
 object PatchTestUtils {
     @JvmStatic
-    fun classToBytecode(targetClass: Class<*>): ByteArray {
-        return ClassLoader
+    fun classToBytecode(targetClass: Class<*>): ByteArray =
+        ClassLoader
             .getSystemClassLoader()
             .getResourceAsStream("${targetClass.name.replace('.', '/')}.class")!!
             .use {
                 it.readBytes()
             }
-    }
 
     @JvmStatic
-    fun bytecodeToClass(name: String, bytecode: ByteArray): Class<*> {
-        return BytecodeClassLoader(name, bytecode).loadClass(name)
-    }
+    fun bytecodeToClass(
+        name: String,
+        bytecode: ByteArray,
+    ): Class<*> = BytecodeClassLoader(name, bytecode).loadClass(name)
 
     @JvmStatic
-    fun dumpBytecode(outDir: String, name: String, originalBytecode: ByteArray) {
+    fun dumpBytecode(
+        outDir: String,
+        name: String,
+        originalBytecode: ByteArray,
+    ) {
         FileOutputStream("$outDir/$name.class").use { fos -> fos.write(originalBytecode) }
     }
 
@@ -43,8 +47,10 @@ object PatchTestUtils {
      * A ClassLoader that dynamically loads a single specified class from byte code and delegates all other class loads to
      * its own ClassLoader.
      */
-    class BytecodeClassLoader(val className: String, private val classBytecode: ByteArray) :
-        ClassLoader(BytecodeClassLoader::class.java.classLoader) {
+    class BytecodeClassLoader(
+        val className: String,
+        private val classBytecode: ByteArray,
+    ) : ClassLoader(BytecodeClassLoader::class.java.classLoader) {
         override fun loadClass(name: String): Class<*> {
             if (name != className) {
                 return super.loadClass(name)
@@ -54,7 +60,10 @@ object PatchTestUtils {
     }
 }
 
-fun assertSelfCheck(target: DynamicTestContract, shouldPass: Boolean = true) {
+fun assertSelfCheck(
+    target: DynamicTestContract,
+    shouldPass: Boolean = true,
+) {
     val results = target.selfCheck()
     for ((test, passed) in results) {
         if (shouldPass) {

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/ReplaceHooksPatchTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/ReplaceHooksPatchTest.kt
@@ -21,17 +21,16 @@ import com.code_intelligence.jazzer.instrumentor.PatchTestUtils.classToBytecode
 import org.junit.Test
 import java.io.File
 
-private fun getOriginalReplaceHooksTargetInstance(): ReplaceHooksTargetContract {
-    return ReplaceHooksTarget()
-}
+private fun getOriginalReplaceHooksTargetInstance(): ReplaceHooksTargetContract = ReplaceHooksTarget()
 
 private fun getNoHooksReplaceHooksTargetInstance(): ReplaceHooksTargetContract {
     val originalBytecode = classToBytecode(ReplaceHooksTarget::class.java)
     // Let the bytecode pass through the hooking logic, but don't apply any hooks.
-    val patchedBytecode = HookInstrumentor(emptyList(), false, null).instrument(
-        ReplaceHooksTarget::class.java.name.replace('.', '/'),
-        originalBytecode,
-    )
+    val patchedBytecode =
+        HookInstrumentor(emptyList(), false, null).instrument(
+            ReplaceHooksTarget::class.java.name.replace('.', '/'),
+            originalBytecode,
+        )
     val patchedClass = bytecodeToClass(ReplaceHooksTarget::class.java.name, patchedBytecode)
     return patchedClass.getDeclaredConstructor().newInstance() as ReplaceHooksTargetContract
 }
@@ -39,11 +38,12 @@ private fun getNoHooksReplaceHooksTargetInstance(): ReplaceHooksTargetContract {
 private fun getPatchedReplaceHooksTargetInstance(classWithHooksEnabledField: Class<*>?): ReplaceHooksTargetContract {
     val originalBytecode = classToBytecode(ReplaceHooksTarget::class.java)
     val hooks = Hooks.loadHooks(emptyList(), setOf(ReplaceHooks::class.java.name)).first().hooks
-    val patchedBytecode = HookInstrumentor(
-        hooks,
-        false,
-        classWithHooksEnabledField = classWithHooksEnabledField?.name?.replace('.', '/'),
-    ).instrument(ReplaceHooksTarget::class.java.name.replace('.', '/'), originalBytecode)
+    val patchedBytecode =
+        HookInstrumentor(
+            hooks,
+            false,
+            classWithHooksEnabledField = classWithHooksEnabledField?.name?.replace('.', '/'),
+        ).instrument(ReplaceHooksTarget::class.java.name.replace('.', '/'), originalBytecode)
     // Make the patched class available in bazel-testlogs/.../test.outputs for manual inspection.
     val outDir = System.getenv("TEST_UNDECLARED_OUTPUTS_DIR")
     File("$outDir/${ReplaceHooksTarget::class.java.simpleName}.class").writeBytes(originalBytecode)
@@ -53,7 +53,6 @@ private fun getPatchedReplaceHooksTargetInstance(classWithHooksEnabledField: Cla
 }
 
 class ReplaceHooksPatchTest {
-
     @Test
     fun testOriginal() {
         assertSelfCheck(getOriginalReplaceHooksTargetInstance(), false)

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/ReplaceHooksPatchTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/ReplaceHooksPatchTest.kt
@@ -52,6 +52,7 @@ private fun getPatchedReplaceHooksTargetInstance(classWithHooksEnabledField: Cla
     return patchedClass.getDeclaredConstructor().newInstance() as ReplaceHooksTargetContract
 }
 
+@Suppress("ktlint:standard:property-naming")
 class ReplaceHooksPatchTest {
     @Test
     fun testOriginal() {

--- a/src/test/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentationTest.kt
+++ b/src/test/java/com/code_intelligence/jazzer/instrumentor/TraceDataFlowInstrumentationTest.kt
@@ -21,20 +21,19 @@ import com.code_intelligence.jazzer.instrumentor.PatchTestUtils.classToBytecode
 import org.junit.Test
 import java.io.File
 
-private fun getOriginalInstrumentationTargetInstance(): DynamicTestContract {
-    return TraceDataFlowInstrumentationTarget()
-}
+private fun getOriginalInstrumentationTargetInstance(): DynamicTestContract = TraceDataFlowInstrumentationTarget()
 
 private fun getInstrumentedInstrumentationTargetInstance(): DynamicTestContract {
     val originalBytecode = classToBytecode(TraceDataFlowInstrumentationTarget::class.java)
-    val patchedBytecode = TraceDataFlowInstrumentor(
-        setOf(
-            InstrumentationType.CMP,
-            InstrumentationType.DIV,
-            InstrumentationType.GEP,
-        ),
-        MockTraceDataFlowCallbacks::class.java.name.replace('.', '/'),
-    ).instrument(TraceDataFlowInstrumentationTarget::class.java.name.replace('.', '/'), originalBytecode)
+    val patchedBytecode =
+        TraceDataFlowInstrumentor(
+            setOf(
+                InstrumentationType.CMP,
+                InstrumentationType.DIV,
+                InstrumentationType.GEP,
+            ),
+            MockTraceDataFlowCallbacks::class.java.name.replace('.', '/'),
+        ).instrument(TraceDataFlowInstrumentationTarget::class.java.name.replace('.', '/'), originalBytecode)
     // Make the patched class available in bazel-testlogs/.../test.outputs for manual inspection.
     val outDir = System.getenv("TEST_UNDECLARED_OUTPUTS_DIR")
     File("$outDir/${TraceDataFlowInstrumentationTarget::class.simpleName}.class").writeBytes(originalBytecode)
@@ -44,7 +43,6 @@ private fun getInstrumentedInstrumentationTargetInstance(): DynamicTestContract 
 }
 
 class TraceDataFlowInstrumentationTest {
-
     @Test
     fun testOriginal() {
         MockTraceDataFlowCallbacks.init()
@@ -101,7 +99,6 @@ class TraceDataFlowInstrumentationTest {
             // shortArray[8] == 8
             "GEP: 8",
             "ICMP: 8, 8",
-
             "GEP: 2",
             "GEP: 3",
             "GEP: 4",

--- a/tests/src/test/java/com/example/KotlinStringCompareFuzzer.kt
+++ b/tests/src/test/java/com/example/KotlinStringCompareFuzzer.kt
@@ -25,7 +25,8 @@ object KotlinStringCompareFuzzer {
     @OptIn(ExperimentalEncodingApi::class)
     fun fuzzerTestOneInput(data: ByteArray) {
         val text = Base64.encode(data)
-        if (text.startsWith("aGVsbG8K") && // hello
+        if (text.startsWith("aGVsbG8K") &&
+            // hello
             text.endsWith("d29ybGQK") // world
         ) {
             throw IOException("Found the secret message!")

--- a/tests/src/test/java/com/example/KotlinVararg.kt
+++ b/tests/src/test/java/com/example/KotlinVararg.kt
@@ -16,7 +16,9 @@
 
 package com.example
 
-class KotlinVararg(vararg opts: String) {
+class KotlinVararg(
+    vararg opts: String,
+) {
     private val allOpts = opts.toList().joinToString(", ")
 
     fun doStuff() = allOpts


### PR DESCRIPTION
Requires updating a few deps, which in turn adds more checks to ktlint. Most of them can be fixed automatically (see commits 2 and 3, reviewing with "Hide whitespace" makes this more manageable), very few need manual suppression (commit 4).

Work towards #919