### PR TITLE
refactor: reduce build dependencies

### DIFF
--- a/examples/junit/src/test/java/com/example/BUILD.bazel
+++ b/examples/junit/src/test/java/com/example/BUILD.bazel
@@ -9,7 +9,10 @@ java_library(
 java_binary(
     name = "ExampleFuzzTests",
     testonly = True,
-    srcs = glob(["*.java"]),
+    srcs = glob(
+        ["*.java"],
+        exclude = ["TestSuccessfulException.java"],
+    ),
     create_executable = False,
     visibility = [
         "//src/test/java/com/code_intelligence/jazzer/junit:__pkg__",

--- a/sanitizers/src/test/java/com/example/BUILD.bazel
+++ b/sanitizers/src/test/java/com/example/BUILD.bazel
@@ -455,7 +455,6 @@ java_test(
     ],
     test_class = "com.example.DisabledHooksTest",
     deps = [
-        "//src/main/java/com/code_intelligence/jazzer/api",
         "//src/main/java/com/code_intelligence/jazzer/api:hooks",
     ],
 )

--- a/src/jmh/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
+++ b/src/jmh/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
@@ -53,7 +53,6 @@ java_library(
         "UnsafeSimpleIncrementCoverageMap.java",
     ],
     deps = [
-        "//src/main/java/com/code_intelligence/jazzer/instrumentor",
         "@jazzer_jacoco//:jacoco_internal",
         "@maven//:org_ow2_asm_asm",
     ],

--- a/src/main/java/com/code_intelligence/jazzer/driver/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/driver/BUILD.bazel
@@ -47,7 +47,6 @@ kt_jvm_library(
     srcs = ["ExceptionUtils.kt"],
     visibility = ["//src/main/java/com/code_intelligence/jazzer/driver:__subpackages__"],
     deps = [
-        ":opt",
         "//src/main/java/com/code_intelligence/jazzer/api:hooks",
         "//src/main/java/com/code_intelligence/jazzer/runtime:constants",
         "//src/main/java/com/code_intelligence/jazzer/utils:log",
@@ -184,7 +183,6 @@ java_library(
     ],
     deps = [
         ":opt_item",
-        "//src/main/java/com/code_intelligence/jazzer:constants",
         "//src/main/java/com/code_intelligence/jazzer/utils:log",
     ],
 )

--- a/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/instrumentor/BUILD.bazel
@@ -24,9 +24,7 @@ kt_jvm_library(
         "//src/test/java/com/code_intelligence/jazzer/instrumentor:__pkg__",
     ],
     deps = [
-        "//src/main/java/com/code_intelligence/jazzer/api:hooks",
         "//src/main/java/com/code_intelligence/jazzer/runtime:jazzer_bootstrap_compile_only",
-        "//src/main/java/com/code_intelligence/jazzer/utils",
         "//src/main/java/com/code_intelligence/jazzer/utils:class_name_globber",
         "//src/main/java/com/code_intelligence/jazzer/utils:log",
         "@jazzer_jacoco//:jacoco_internal",

--- a/src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/annotation/proto/BUILD.bazel
@@ -4,7 +4,6 @@ java_library(
     visibility = ["//visibility:public"],
     deps = [
         ":protobuf_runtime_compile_only",
-        "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/utils",
     ],
 )

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/BUILD.bazel
@@ -8,7 +8,6 @@ java_library(
     deps = [
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
-        "//src/main/java/com/code_intelligence/jazzer/mutation/combinator",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
     ],
 )

--- a/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/junit/BUILD.bazel
@@ -295,7 +295,6 @@ java_test(
     ],
     deps = [
         "//examples/junit/src/test/java/com/example:test_successful_exception",
-        "//src/main/java/com/code_intelligence/jazzer/api:hooks",
         "//src/main/java/com/code_intelligence/jazzer/junit:common_exceptions",
         "@maven//:junit_junit",
         "@maven//:org_junit_platform_junit_platform_engine",
@@ -359,7 +358,6 @@ java_test(
         "@maven//:org_junit_jupiter_junit_jupiter_engine",
     ],
     deps = [
-        "//src/main/java/com/code_intelligence/jazzer/api:hooks",
         "@maven//:com_google_truth_extensions_truth_java8_extension",
         "@maven//:com_google_truth_truth",
         "@maven//:junit_junit",
@@ -434,7 +432,6 @@ java_test(
         "@maven//:org_junit_jupiter_junit_jupiter_engine",
     ],
     deps = [
-        "//src/main/java/com/code_intelligence/jazzer/api:hooks",
         "@maven//:junit_junit",
         "@maven//:org_assertj_assertj_core",
         "@maven//:org_junit_platform_junit_platform_engine",


### PR DESCRIPTION
We've identified many redundant dependencies in bazel build scripts and refactored them, as part of a research project on dependency reduction.

Feel free to leave feedback, suggest improvements, or directly edit this PR.

Thanks for your support!