### PR TITLE
fix index out of bounds when mutating empty constructor arguments

### DIFF
--- a/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ArgumentsMutatorFuzzTest.java
+++ b/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ArgumentsMutatorFuzzTest.java
@@ -137,7 +137,7 @@ public class ArgumentsMutatorFuzzTest {
   void fuzz_EmptyArgs(@NotNull EmptyArgs emptyArgs) {}
 
   @SelfFuzzTest
-  void fuzz_Builder(@NotNull ImmutableBuilder b) {}
+  void fuzz_ImmutableBean(@NotNull ImmutableBean b) {}
 
   @SelfFuzzTest
   void fuzzPrimitives(

--- a/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ArgumentsMutatorFuzzTest.java
+++ b/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ArgumentsMutatorFuzzTest.java
@@ -129,11 +129,15 @@ public class ArgumentsMutatorFuzzTest {
       List<int @WithLength(max = 10) []> listOfIntArrays,
       byte[] @WithLength(max = 11) [] byteArrays) {}
 
+  public static class EmptyArgs {
+    EmptyArgs() {}
+  }
+
   @SelfFuzzTest
-  void fuzz_Builder(
-      // @NotNull  // BUG: @NotNull causes "Index -1 out of bounds for length 0"
-      // in InPlaceProductMutator.writeExclusive
-      ImmutableBuilder b) {}
+  void fuzz_EmptyArgs(@NotNull EmptyArgs emptyArgs) {}
+
+  @SelfFuzzTest
+  void fuzz_Builder(@NotNull ImmutableBuilder b) {}
 
   @SelfFuzzTest
   void fuzzPrimitives(

--- a/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/BUILD.bazel
+++ b/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/BUILD.bazel
@@ -6,7 +6,7 @@ java_fuzz_target_test(
         "ArgumentsMutatorFuzzTest.java",
         "BeanWithParent.java",
         "ConstructorPropertiesAnnotatedBean.java",
-        "ImmutableBuilder.java",
+        "ImmutableBean.java",
     ],
     data = ["//selffuzz/src/test/resources:ArgumentsMutatorFuzzTest-corpus"],
     fuzzer_args = [

--- a/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ImmutableBean.java
+++ b/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ImmutableBean.java
@@ -20,16 +20,16 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public class ImmutableBuilder {
+public class ImmutableBean {
   private final int i;
   private final boolean b;
   private final List<String> list;
 
-  public ImmutableBuilder() {
+  public ImmutableBean() {
     this(0, false, Collections.emptyList());
   }
 
-  private ImmutableBuilder(int i, boolean b, List<String> list) {
+  private ImmutableBean(int i, boolean b, List<String> list) {
     this.i = i;
     this.b = b;
     this.list = list;
@@ -43,25 +43,29 @@ public class ImmutableBuilder {
     return b;
   }
 
-  public ImmutableBuilder withI(int i) {
-    return new ImmutableBuilder(i, b, list);
+  public ImmutableBean withI(int i) {
+    return new ImmutableBean(i, b, list);
   }
 
   // Both withX and setX are supported on immutable builders.
-  public ImmutableBuilder setB(boolean b) {
-    return new ImmutableBuilder(i, b, list);
+  public ImmutableBean setB(boolean b) {
+    return new ImmutableBean(i, b, list);
   }
 
-  public ImmutableBuilder setList(List<String> list) {
-    return new ImmutableBuilder(i, b, list);
+  public ImmutableBean setList(List<String> list) {
+    return new ImmutableBean(i, b, list);
+  }
+
+  public List<String> getList() {
+    return list;
   }
 
   @Override
   @SuppressWarnings("PatternVariableCanBeUsed")
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (!(o instanceof ImmutableBuilder)) return false;
-    ImmutableBuilder that = (ImmutableBuilder) o;
+    if (!(o instanceof ImmutableBean)) return false;
+    ImmutableBean that = (ImmutableBean) o;
     return i == that.i && b == that.b;
   }
 

--- a/src/main/java/com/code_intelligence/jazzer/mutation/combinator/InPlaceProductMutator.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/combinator/InPlaceProductMutator.java
@@ -83,6 +83,11 @@ public final class InPlaceProductMutator extends SerializingInPlaceMutator<Objec
 
   @Override
   public void writeExclusive(Object[] value, OutputStream out) throws IOException {
+    // mutators can be an empty array. This can so far only happen when an empty Java Bean mutator
+    // is used. We simply return in that case and don't write anything to out.
+    if (mutators.length == 0) {
+      return;
+    }
     DataOutputStream dataOut = new DataOutputStream(out);
     int lastIndex = mutators.length - 1;
     for (int i = 0; i < lastIndex; i++) {

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/aggregate/CachedConstructorMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/aggregate/CachedConstructorMutatorTest.java
@@ -26,6 +26,9 @@ import com.code_intelligence.jazzer.mutation.engine.ChainedMutatorFactory;
 import com.code_intelligence.jazzer.mutation.mutator.Mutators;
 import com.code_intelligence.jazzer.mutation.support.TypeHolder;
 import com.code_intelligence.jazzer.mutation.utils.PropertyConstraint;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -168,5 +171,25 @@ class CachedConstructorMutatorTest {
 
   static void emptyInputMethod(SimpleClass simpleClass) {
     // Nothing to do here, only needed for the method reference.
+  }
+
+  public static class EmptyArgs {
+    public EmptyArgs() {}
+  }
+
+  @Test
+  void testEmptyArgsConstructor() throws IOException {
+    SerializingMutator<EmptyArgs> mutator =
+        (SerializingMutator<EmptyArgs>)
+            Mutators.newFactory()
+                .createOrThrow(new TypeHolder<@NotNull EmptyArgs>() {}.annotatedType());
+    assertThat(mutator.toString()).startsWith("[] -> EmptyArgs");
+
+    PseudoRandom prng = anyPseudoRandom();
+    EmptyArgs inited = mutator.init(prng);
+
+    EmptyArgs mutated = mutator.mutate(inited, prng);
+    EmptyArgs read = mutator.readExclusive(new ByteArrayInputStream(new byte[] {}));
+    mutator.writeExclusive(read, new ByteArrayOutputStream());
   }
 }


### PR DESCRIPTION
The `InPlaceProductMutator` did not handle empty mutator lists in its `writeExclusive` implementation. Such a mutator is constructed for Beans with constructors that take no arguments.
If such a mutator was the last in the list of mutators this would lead to a `Index -1 out of bounds for length 0`.