### PR TITLE
fix: don't apply Bean factories for proto enums

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection/BUILD.bazel
@@ -2,7 +2,7 @@ java_library(
     name = "collection",
     srcs = glob(["*.java"]),
     visibility = [
-        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator:__pkg__",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator:__subpackages__",
         "//src/test/java/com/code_intelligence/jazzer/mutation/mutator:__subpackages__",
     ],
     deps = [

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang/BUILD.bazel
@@ -2,7 +2,7 @@ java_library(
     name = "lang",
     srcs = glob(["*.java"]),
     visibility = [
-        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator:__pkg__",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator:__subpackages__",
         "//src/test/java/com/code_intelligence/jazzer/mutation/mutator:__subpackages__",
     ],
     deps = [

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/proto/BUILD.bazel
@@ -13,6 +13,8 @@ java_library(
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
         "//src/main/java/com/code_intelligence/jazzer/mutation/combinator",
         "//src/main/java/com/code_intelligence/jazzer/mutation/engine",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/collection",
+        "//src/main/java/com/code_intelligence/jazzer/mutation/mutator/lang",
         "//src/main/java/com/code_intelligence/jazzer/mutation/support",
         "//src/main/java/com/code_intelligence/jazzer/mutation/utils",
     ],

--- a/src/test/java/com/code_intelligence/jazzer/mutation/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/BUILD.bazel
@@ -10,6 +10,8 @@ java_test_suite(
         "//src/main/java/com/code_intelligence/jazzer/mutation/annotation",
         "//src/main/java/com/code_intelligence/jazzer/mutation/api",
         "//src/main/java/com/code_intelligence/jazzer/mutation/mutator",
+        "//src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto:proto2_java_proto",
         "//src/test/java/com/code_intelligence/jazzer/mutation/support:test_support",
+        "@protobuf//java/core",
     ],
 )

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BUILD.bazel
@@ -28,7 +28,7 @@ java_proto_library(
     testonly = True,
     visibility = [
         "//selffuzz:__subpackages__",
-        "//src/test/java/com/code_intelligence/jazzer/mutation/mutator:__pkg__",
+        "//src/test/java/com/code_intelligence/jazzer/mutation:__subpackages__",
         "//tests:__pkg__",
     ],
     deps = [":proto2_proto"],


### PR DESCRIPTION
The following fuzz test signature would fail during printing of the constructed mutator

```
 @FuzzTest
 public static void complexProtoFuzzTest(
      @NotNull TestProtobuf proto, @NotNull DescriptorProtos.DescriptorProto descriptor) {}
```

```
...
INFO: Loaded 6 hooks from com.code_intelligence.jazzer.sanitizers.XPathInjection
INFO: Instrumented com.example.MutatorComplexProtoFuzzer (took 34 ms, size +8%)
Exception in thread "main" java.lang.ExceptionInInitializerError
	at com.code_intelligence.jazzer.driver.Driver.start(Driver.java:181)
	at com.code_intelligence.jazzer.Jazzer.start(Jazzer.java:118)
	at com.code_intelligence.jazzer.Jazzer.main(Jazzer.java:71)
Caused by: java.lang.NullPointerException: Cannot invoke "com.code_intelligence.jazzer.mutation.api.SerializingMutator.toDebugString(java.util.function.Predicate)" because "productMutator" is null
	at com.code_intelligence.jazzer.mutation.mutator.aggregate.AggregatesHelper.lambda$createMutator$5(AggregatesHelper.java:138)
	at com.code_intelligence.jazzer.mutation.combinator.MutatorCombinators$7.toDebugString(MutatorCombinators.java:263)
	at com.code_intelligence.jazzer.mutation.combinator.MutatorCombinators$14.toDebugString(MutatorCombinators.java:585)
	at com.code_intelligence.jazzer.mutation.mutator.lang.NullableMutatorFactory$NullableMutator.toDebugString(NullableMutatorFactory.java:130)
	at com.code_intelligence.jazzer.mutation.combinator.MutatorCombinators$1.toDebugString(MutatorCombinators.java:102)
...
```

Using the full original factory to construct a mutator for protobuf enum types would trigger a deeply nested mutator construction attempt on the EnumValueDescriptor class using e.g. the `CachedConstructorMutatorFactory`. While this still ended up at the dedicated enum mutator for most cases, for complex protobuf parameters it could lead to the construction of invalid mutators.

At the point where an enum type is reached we now use a simplified factory instead that only deals with repeated or nullable enums.
