### PR TITLE
fix: correct descriptors for String.split methods

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -326,6 +326,7 @@ java_fuzz_target_test(
         "src/main/java/com/example/JsonSanitizerValidJsonFuzzer.java",
     ],
     allowed_findings = ["com.code_intelligence.jazzer.api.FuzzerSecurityIssueLow"],
+    expected_warning_or_error = "WARN: Some hooks could not be applied to class files built for Java 7 or lower.",
     target_class = "com.example.JsonSanitizerValidJsonFuzzer",
     deps = [
         "@maven//:com_google_code_gson_gson",

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/RegexInjection.kt
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/RegexInjection.kt
@@ -107,13 +107,13 @@ object RegexInjection {
             type = HookType.REPLACE,
             targetClassName = "java.lang.String",
             targetMethod = "split",
-            targetMethodDescriptor = "(Ljava/lang/String;)Ljava/lang/String;",
+            targetMethodDescriptor = "(Ljava/lang/String;)[Ljava/lang/String;",
         ),
         MethodHook(
             type = HookType.REPLACE,
             targetClassName = "java.lang.String",
             targetMethod = "split",
-            targetMethodDescriptor = "(Ljava/lang/String;I)Ljava/lang/String;",
+            targetMethodDescriptor = "(Ljava/lang/String;I)[Ljava/lang/String;",
         ),
     )
     @JvmStatic

--- a/sanitizers/src/test/java/com/example/BUILD.bazel
+++ b/sanitizers/src/test/java/com/example/BUILD.bazel
@@ -216,6 +216,14 @@ java_fuzz_target_test(
 )
 
 java_fuzz_target_test(
+    name = "RegexSplitInjection",
+    srcs = ["RegexSplitInjection.java"],
+    allowed_findings = ["com.code_intelligence.jazzer.api.FuzzerSecurityIssueLow"],
+    target_class = "com.example.RegexSplitInjection",
+    verify_crash_reproducer = False,
+)
+
+java_fuzz_target_test(
     name = "RegexCanonEqInjection",
     srcs = [
         "RegexCanonEqInjection.java",

--- a/sanitizers/src/test/java/com/example/RegexSplitInjection.java
+++ b/sanitizers/src/test/java/com/example/RegexSplitInjection.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.code_intelligence.jazzer.api.FuzzedDataProvider;
+import java.util.regex.PatternSyntaxException;
+
+public class RegexSplitInjection {
+  public static void fuzzerTestOneInput(FuzzedDataProvider fdp) {
+    String regex = fdp.consumeRemainingAsString();
+    try {
+      "foobar".split(regex);
+    } catch (PatternSyntaxException ignored) {
+    }
+  }
+}


### PR DESCRIPTION
The java.lang.String.split method was not hooked for regex injection due to incorrect method descriptors.
