### PR TITLE
docs: document mutation annotation `AppliesTo` in Javadoc

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/mutation/utils/AppliesTo.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/utils/AppliesTo.java
@@ -19,12 +19,14 @@ package com.code_intelligence.jazzer.mutation.utils;
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 /** A meta-annotation that limits the concrete types an annotation for type usages applies to. */
 @Target(ANNOTATION_TYPE)
 @Retention(RUNTIME)
+@Documented
 public @interface AppliesTo {
   /** The meta-annotated annotation can be applied to these classes. */
   Class<?>[] value() default {};


### PR DESCRIPTION
This hopefully makes it more obvious to users to which types annotations such as `@InRange` apply (which use `@AppliesTo` to limit the valid target types).

What do you think?