### PR TITLE
fix: guard against malformed corpus entries in protobuf mutator

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Build & Fuzz
         run: |
-          bazelisk run ${{env.BUILD_BUDDY_CONFIG}} --java_runtime_version=remotejdk_${{ matrix.jdk }} ${{ matrix.bazel_args }} ${{ matrix.extra_bazel_args }} //selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation:ArgumentsMutatorFuzzTest --jvmopt=-Xmx10000m -- -runs=1000000
+          bazelisk run ${{env.BUILD_BUDDY_CONFIG}} --java_runtime_version=remotejdk_${{ matrix.jdk }} ${{ matrix.bazel_args }} ${{ matrix.extra_bazel_args }} //selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation:ArgumentsMutatorFuzzTest -- -runs=1000000
 
   # Notification job that runs after all matrix jobs complete
   notification:

--- a/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/BUILD.bazel
+++ b/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/BUILD.bazel
@@ -9,6 +9,9 @@ java_fuzz_target_test(
         "ImmutableBean.java",
     ],
     data = ["//selffuzz/src/test/resources:ArgumentsMutatorFuzzTest-corpus"],
+    env = {
+        "_JAVA_OPTIONS": "-Xmx1024m",
+    },
     fuzzer_args = [
         # Make sure that the fuzzer can run. Longer fuzzing runs will be done in a separate GH action.
         "-runs=10000",


### PR DESCRIPTION
When decoding protobuf messages no size limit was enforced which could lead to OOM failures for corpus entries that were produced by a different mutator / arbitrary binary data.
