### PR TITLE
feat: add big decimal sanitizer

### DIFF
--- a/sanitizers/sanitizers.bzl
+++ b/sanitizers/sanitizers.bzl
@@ -18,6 +18,7 @@ _sanitizer_package_prefix = "com.code_intelligence.jazzer.sanitizers."
 
 _sanitizer_class_names = [
     # keep sorted
+    "BigDecimal",
     "ClojureLangHooks",
     "Deserialization",
     "ExpressionLanguageInjection",

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BUILD.bazel
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BUILD.bazel
@@ -53,6 +53,14 @@ java_library(
 )
 
 java_library(
+    name = "big_decimal",
+    srcs = ["BigDecimal.java"],
+    deps = [
+        "//src/main/java/com/code_intelligence/jazzer/api:hooks",
+    ],
+)
+
+java_library(
     name = "unsafe_sanitizer",
     srcs = ["UnsafeSanitizer.java"],
     deps = [
@@ -79,6 +87,7 @@ kt_jvm_library(
         "//sanitizers/src/test/java/com/code_intelligence/jazzer/sanitizers:__pkg__",
     ],
     runtime_deps = [
+        ":big_decimal",
         ":clojure_lang_hooks",
         ":file_path_traversal",
         ":regex_roadblocks",

--- a/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BigDecimal.java
+++ b/sanitizers/src/main/java/com/code_intelligence/jazzer/sanitizers/BigDecimal.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2025 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.sanitizers;
+
+import com.code_intelligence.jazzer.api.HookType;
+import com.code_intelligence.jazzer.api.Jazzer;
+import com.code_intelligence.jazzer.api.MethodHook;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * Guides inputs passed to {@link java.math.BigDecimal} constructors towards forms with huge
+ * exponents (e.g., 1e1000000) to trigger performance issues like timeouts or OOMs.
+ */
+public final class BigDecimal {
+
+  private static final String HUGE_EXPONENT = "1e1000000";
+
+  @MethodHook(
+      type = HookType.BEFORE,
+      targetClassName = "java.math.BigDecimal",
+      targetMethod = "<init>")
+  public static void bigDecimalConstructorHook(
+      MethodHandle method, Object thisObject, Object[] args, int hookId) {
+    if (args.length == 0 || args[0] == null) {
+      return;
+    }
+
+    String s = null;
+    Object first = args[0];
+    if (first instanceof String) {
+      s = (String) first;
+    } else if (first instanceof char[]) {
+      s = new String((char[]) first);
+    }
+
+    if (s == null || s.isEmpty()) {
+      return;
+    }
+
+    // Nudge the fuzzer towards a BigDecimal string with a huge exponent.
+    Jazzer.guideTowardsEquality(s, HUGE_EXPONENT, hookId);
+  }
+}

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1077,6 +1077,19 @@ java_fuzz_target_test(
 )
 
 java_fuzz_target_test(
+    name = "BigDecimalFuzzer",
+    srcs = [
+        "src/test/java/com/example/BigDecimalFuzzer.java",
+    ],
+    allowed_findings = ["timeout"],
+    fuzzer_args = [
+        "-timeout=1",
+    ],
+    target_class = "com.example.BigDecimalFuzzer",
+    verify_crash_reproducer = False,
+)
+
+java_fuzz_target_test(
     name = "JUnitInvalidJavaSeedTest",
     timeout = "short",
     srcs = ["src/test/java/com/example/JUnitInvalidJavaSeedTest.java"],

--- a/tests/src/test/java/com/example/BigDecimalFuzzer.java
+++ b/tests/src/test/java/com/example/BigDecimalFuzzer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example;
+
+import com.code_intelligence.jazzer.mutation.annotation.NotNull;
+import java.math.BigDecimal;
+
+public class BigDecimalFuzzer {
+  public static void fuzzerTestOneInput(@NotNull String value) {
+    try {
+      BigDecimal bd = new BigDecimal(value);
+      bd.toBigInteger();
+
+    } catch (NumberFormatException | ArithmeticException ignored) {
+    }
+  }
+}


### PR DESCRIPTION
This sanitizer guides the parsing of big decimals from `String` or `char[]` inputs towards inputs with huge exponents. Those can lead to timeouts or out of memory exceptions.