### PR TITLE
fix: fuzz test invocation with referring protobufs

### DIFF
--- a/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ArgumentsMutatorFuzzTest.java
+++ b/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ArgumentsMutatorFuzzTest.java
@@ -22,6 +22,7 @@ import com.code_intelligence.jazzer.api.FuzzedDataProvider;
 import com.code_intelligence.jazzer.junit.FuzzTest;
 import com.code_intelligence.jazzer.mutation.annotation.WithSize;
 import com.code_intelligence.jazzer.mutation.annotation.WithUtf8Length;
+import com.code_intelligence.jazzer.protobuf.Proto2;
 import com.code_intelligence.jazzer.protobuf.Proto3;
 import com.code_intelligence.selffuzz.jazzer.mutation.ArgumentsMutator;
 import com.code_intelligence.selffuzz.jazzer.mutation.annotation.NotNull;
@@ -246,11 +247,9 @@ public class ArgumentsMutatorFuzzTest {
   @SelfFuzzTest
   void fuzz_MapField3(Proto3.MapField3 o1) {}
 
-  // BUG: causes java.lang.IllegalArgumentException: argument type mismatch
-  //      no problem when testing the two types separately
-  //  @SelfFuzzTest
-  //  public static void fuzz_MutuallyReferringProtobufs(
-  //      Proto2.TestProtobuf o1, Proto2.TestSubProtobuf o2) {}
+  @SelfFuzzTest
+  public static void fuzz_MutuallyReferringProtobufs(
+      Proto2.TestProtobuf o1, Proto2.TestSubProtobuf o2) {}
 
   /**
    * @return all methods in this class annotated by @SelfFuzzTest. If any of those methods are

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -928,7 +928,8 @@ public class StressTest {
                 OptionalPrimitiveField3.newBuilder().setSomeField(true).build())),
         arguments(
             new TypeHolder<@NotNull RepeatedRecursiveMessageField3>() {}.annotatedType(),
-            "{Builder.Boolean, WithoutInit(Builder via List<(cycle) -> Message>)} -> Message",
+            "{Builder.Boolean, WithoutInit(Builder via List<{Builder.Boolean, WithoutInit(Builder"
+                + " via List<(cycle) -> Message>)} -> Message>)} -> Message",
             false,
             // The message field is recursive and thus not initialized.
             exactly(
@@ -1041,14 +1042,25 @@ public class StressTest {
                 + " Builder.Nullable<Double>, Builder.Nullable<String>,"
                 + " Builder.Nullable<Enum<Enum>>,"
                 + " WithoutInit(Builder.Nullable<{Builder.Nullable<Integer>, Builder via"
-                + " List<Integer>, WithoutInit(Builder.Nullable<(cycle) -> Message>)} -> Message>),"
-                + " Builder via List<Boolean>, Builder via List<Integer>, Builder via"
-                + " List<Integer>, Builder via List<Long>, Builder via List<Long>, Builder via"
-                + " List<Float>, Builder via List<Double>, Builder via List<String>, Builder via"
-                + " List<Enum<Enum>>, WithoutInit(Builder via List<(cycle) -> Message>),"
-                + " Builder.Map<Integer, Integer>, Builder.Nullable<FixedValue(OnlyLabel)>,"
-                + " Builder.Nullable<{<empty>} -> Message>, Builder.Nullable<Integer> |"
-                + " Builder.Nullable<Long> | Builder.Nullable<Integer>} -> Message",
+                + " List<Integer>, WithoutInit(Builder.Nullable<{Builder.Nullable<Boolean>,"
+                + " Builder.Nullable<Integer>, Builder.Nullable<Integer>, Builder.Nullable<Long>,"
+                + " Builder.Nullable<Long>, Builder.Nullable<Float>, Builder.Nullable<Double>,"
+                + " Builder.Nullable<String>, Builder.Nullable<Enum<Enum>>,"
+                + " WithoutInit(Builder.Nullable<(cycle) -> Message>), Builder via List<Boolean>,"
+                + " Builder via List<Integer>, Builder via List<Integer>, Builder via List<Long>,"
+                + " Builder via List<Long>, Builder via List<Float>, Builder via List<Double>,"
+                + " Builder via List<String>, Builder via List<Enum<Enum>>, WithoutInit(Builder via"
+                + " List<(cycle) -> Message>), Builder.Map<Integer, Integer>,"
+                + " Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<{<empty>} ->"
+                + " Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> |"
+                + " Builder.Nullable<Integer>} -> Message>)} -> Message>), Builder via"
+                + " List<Boolean>, Builder via List<Integer>, Builder via List<Integer>, Builder"
+                + " via List<Long>, Builder via List<Long>, Builder via List<Float>, Builder via"
+                + " List<Double>, Builder via List<String>, Builder via List<Enum<Enum>>,"
+                + " WithoutInit(Builder via List<(cycle) -> Message>), Builder.Map<Integer,"
+                + " Integer>, Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<(cycle) ->"
+                + " Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> |"
+                + " Builder.Nullable<Integer>} -> Message",
             false,
             manyDistinctElements(),
             manyDistinctElements()),
@@ -1063,14 +1075,25 @@ public class StressTest {
                 + " Builder.Nullable<Double>, Builder.Nullable<String>,"
                 + " Builder.Nullable<Enum<Enum>>,"
                 + " WithoutInit(Builder.Nullable<{Builder.Nullable<Integer>, Builder via"
-                + " List<Integer>, WithoutInit(Builder.Nullable<(cycle) -> Message>)} -> Message>),"
-                + " Builder via List<Boolean>, Builder via List<Integer>, Builder via"
-                + " List<Integer>, Builder via List<Long>, Builder via List<Long>, Builder via"
-                + " List<Float>, Builder via List<Double>, Builder via List<String>, Builder via"
-                + " List<Enum<Enum>>, WithoutInit(Builder via List<(cycle) -> Message>),"
-                + " Builder.Map<Integer, Integer>, Builder.Nullable<FixedValue(OnlyLabel)>,"
-                + " Builder.Nullable<{<empty>} -> Message>, Builder.Nullable<Integer> |"
-                + " Builder.Nullable<Long> | Builder.Nullable<Integer>} -> Message",
+                + " List<Integer>, WithoutInit(Builder.Nullable<{Builder.Nullable<Boolean>,"
+                + " Builder.Nullable<Integer>, Builder.Nullable<Integer>, Builder.Nullable<Long>,"
+                + " Builder.Nullable<Long>, Builder.Nullable<Float>, Builder.Nullable<Double>,"
+                + " Builder.Nullable<String>, Builder.Nullable<Enum<Enum>>,"
+                + " WithoutInit(Builder.Nullable<(cycle) -> Message>), Builder via List<Boolean>,"
+                + " Builder via List<Integer>, Builder via List<Integer>, Builder via List<Long>,"
+                + " Builder via List<Long>, Builder via List<Float>, Builder via List<Double>,"
+                + " Builder via List<String>, Builder via List<Enum<Enum>>, WithoutInit(Builder via"
+                + " List<(cycle) -> Message>), Builder.Map<Integer, Integer>,"
+                + " Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<{<empty>} ->"
+                + " Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> |"
+                + " Builder.Nullable<Integer>} -> Message>)} -> Message>), Builder via"
+                + " List<Boolean>, Builder via List<Integer>, Builder via List<Integer>, Builder"
+                + " via List<Long>, Builder via List<Long>, Builder via List<Float>, Builder via"
+                + " List<Double>, Builder via List<String>, Builder via List<Enum<Enum>>,"
+                + " WithoutInit(Builder via List<(cycle) -> Message>), Builder.Map<Integer,"
+                + " Integer>, Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<(cycle) ->"
+                + " Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> |"
+                + " Builder.Nullable<Integer>} -> Message",
             false,
             manyDistinctElements(),
             manyDistinctElements()),
@@ -1079,8 +1102,8 @@ public class StressTest {
                 @NotNull @AnySource({PrimitiveField3.class, MessageField3.class})
                 AnyField3>() {}.annotatedType(),
             "{Builder.Nullable<Builder.{Builder.Boolean} -> Message |"
-                + " Builder.{Builder.Nullable<(cycle) -> Message>} -> Message -> Message>} ->"
-                + " Message",
+                + " Builder.{Builder.Nullable<{Builder.Boolean} -> Message>} -> Message ->"
+                + " Message>} -> Message",
             true,
             exactly(
                 AnyField3.getDefaultInstance(),

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto2Test.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto2Test.java
@@ -336,7 +336,9 @@ class BuilderMutatorProto2Test {
             factory.createInPlaceOrThrow(
                 new TypeHolder<RecursiveMessageField2.@NotNull Builder>() {}.annotatedType());
     assertThat(mutator.toString())
-        .isEqualTo("{Builder.Boolean, WithoutInit(Builder.Nullable<(cycle) -> Message>)}");
+        .isEqualTo(
+            "{Builder.Boolean, WithoutInit(Builder.Nullable<{Builder.Boolean,"
+                + " WithoutInit(Builder.Nullable<(cycle) -> Message>)} -> Message>)}");
     assertThat(mutator.hasFixedSize()).isFalse();
     RecursiveMessageField2.Builder builder = RecursiveMessageField2.newBuilder();
 

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto3Test.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/BuilderMutatorProto3Test.java
@@ -403,7 +403,9 @@ class BuilderMutatorProto3Test {
             factory.createInPlaceOrThrow(
                 new TypeHolder<RecursiveMessageField3.@NotNull Builder>() {}.annotatedType());
     assertThat(mutator.toString())
-        .isEqualTo("{Builder.Boolean, WithoutInit(Builder.Nullable<(cycle) -> Message>)}");
+        .isEqualTo(
+            "{Builder.Boolean, WithoutInit(Builder.Nullable<{Builder.Boolean,"
+                + " WithoutInit(Builder.Nullable<(cycle) -> Message>)} -> Message>)}");
     assertThat(mutator.hasFixedSize()).isFalse();
     RecursiveMessageField3.Builder builder = RecursiveMessageField3.newBuilder();
 
@@ -609,7 +611,8 @@ class BuilderMutatorProto3Test {
     assertThat(mutator.toString())
         .isEqualTo(
             "{Builder.Nullable<Builder.{Builder.Boolean} -> Message |"
-                + " Builder.{Builder.Nullable<(cycle) -> Message>} -> Message -> Message>}");
+                + " Builder.{Builder.Nullable<{Builder.Boolean} -> Message>} -> Message ->"
+                + " Message>}");
     assertThat(mutator.hasFixedSize()).isTrue();
     AnyField3.Builder builder = AnyField3.newBuilder();
 


### PR DESCRIPTION
When constructing a mutator for a protobuf message the mutator is cached based on the protobuf descriptor. This led to issues for fuzz tests that take two protobuf messages where one message is referring to the other.

While building the mutator for the top level message nested messages are constructed with the type `DynamicMessage` which lead to 'argument type mismatch' exceptions when invoking the fuzz test method. This is fixed by including the message class in the mutator cache key which ensures that a generated protobuf message class does not re-use the corresponding `DynamicMessage` mutator.

Note, that this causes some recursion breaking to happen one layer deeper (see test assertion changes).