### PR TITLE
fix: assertion failure when fuzzing proto strings

### DIFF
--- a/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ArgumentsMutatorFuzzTest.java
+++ b/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ArgumentsMutatorFuzzTest.java
@@ -206,15 +206,13 @@ public class ArgumentsMutatorFuzzTest {
 
   @SelfFuzzTest
   void fuzz_ProtoBufs(
-      // com.google.protobuf.StringValue v0, // BUG: makes maxIncreaseSize negative in
-      // LibProtobufMutator.mutate
+      com.google.protobuf.StringValue v0,
       com.google.protobuf.Int32Value v1,
       com.google.protobuf.BoolValue v2,
       com.google.protobuf.UInt64Value v3,
       com.google.protobuf.FloatValue v4,
       com.google.protobuf.DoubleValue v5,
-      // com.google.protobuf.BytesValue v6, // BUG: makes maxIncreaseSize negative in
-      // LibProtobufMutator.mutate
+      com.google.protobuf.BytesValue v6,
       com.google.protobuf.Int64Value v7) {
     if (v7 != null) {
       assertThat(v7.getValue()).isAtLeast(Long.MIN_VALUE);
@@ -224,15 +222,13 @@ public class ArgumentsMutatorFuzzTest {
 
   @SelfFuzzTest
   void fuzz_ProtoBufsNotNull(
-      // @NotNull com.google.protobuf.StringValue v0, // BUG: makes maxIncreaseSize negative in
-      // LibProtobufMutator.mutate
+      @NotNull com.google.protobuf.StringValue v0,
       @NotNull com.google.protobuf.Int32Value v1,
       @NotNull com.google.protobuf.BoolValue v2,
       @NotNull com.google.protobuf.UInt64Value v3,
       @NotNull com.google.protobuf.FloatValue v4,
       @NotNull com.google.protobuf.DoubleValue v5,
-      // @NotNull com.google.protobuf.BytesValue v6, // BUG: makes maxIncreaseSize negative in
-      // LibProtobufMutator.mutate
+      @NotNull com.google.protobuf.BytesValue v6,
       @NotNull com.google.protobuf.Int64Value v7) {
     if (v7 != null) {
       assertThat(v7.getValue()).isAtLeast(Long.MIN_VALUE);
@@ -240,9 +236,8 @@ public class ArgumentsMutatorFuzzTest {
     }
   }
 
-  // BUG: makes maxIncreaseSize negative in LibProtobufMutator.mutate
-  // @SelfFuzzTest
-  // public static void fuzz_TestProtobuf(TestProtobuf o1) {}
+  @SelfFuzzTest
+  public static void fuzz_TestProtobuf(Proto2.TestProtobuf o1) {}
 
   @SelfFuzzTest
   void fuzz_MapField3(Proto3.MapField3 o1) {}

--- a/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/BUILD.bazel
+++ b/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/BUILD.bazel
@@ -10,7 +10,7 @@ java_fuzz_target_test(
     ],
     data = ["//selffuzz/src/test/resources:ArgumentsMutatorFuzzTest-corpus"],
     env = {
-        "_JAVA_OPTIONS": "-Xmx1024m",
+        "_JAVA_OPTIONS": "-Xmx2048m",
     },
     fuzzer_args = [
         # Make sure that the fuzzer can run. Longer fuzzing runs will be done in a separate GH action.

--- a/src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer/LibFuzzerMutatorFactory.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/mutator/libfuzzer/LibFuzzerMutatorFactory.java
@@ -113,6 +113,9 @@ public final class LibFuzzerMutatorFactory {
 
     @Override
     public byte[] mutate(byte[] value, PseudoRandom prng) {
+      // Enforce length constraints on the input to mutate. We do this because some mutators (e.g.
+      // protobuf mutator) don't enforce length constraints in the read methods.
+      value = enforceLength(value);
       int maxLengthIncrease = maxLength - value.length;
       byte[] mutated = LibFuzzerMutate.mutateDefault(value, maxLengthIncrease);
       return enforceLength(mutated);

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/lang/StringMutatorTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/lang/StringMutatorTest.java
@@ -227,6 +227,20 @@ class StringMutatorTest {
   }
 
   @Test
+  void testMutateWithInputLongerThanMaxLength() {
+    SerializingMutator<String> mutator =
+        (SerializingMutator<String>)
+            factory.createOrThrow(
+                new TypeHolder<@NotNull @WithUtf8Length(max = 5) String>() {}.annotatedType());
+    assertThat(mutator.toString()).isEqualTo("String");
+    String s = "foobarbazf";
+    try (MockPseudoRandom prng = mockPseudoRandom()) {
+      s = mutator.mutate(s, prng);
+    }
+    assertThat(s.length()).isAtMost(5);
+  }
+
+  @Test
   void testMaxLengthMutate() {
     SerializingMutator<String> mutator =
         (SerializingMutator<String>)


### PR DESCRIPTION
When parsing protobuf messages from libfuzzer bytes in the protobuf mutator we don't enforce length limits. This could lead to maxSizeIncrease < 0 situations if the e.g. a String read by the protobuf mutator exceeds the size limit.
To guard against similar cases we now enforce the size constraints for the byte array that is being mutated before performing the mutation.
