### PR TITLE
feat: add support for proto maps with enum values

### DIFF
--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/StressTest.java
@@ -59,6 +59,7 @@ import com.code_intelligence.jazzer.protobuf.Proto3.EnumField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.EnumField3.TestEnum;
 import com.code_intelligence.jazzer.protobuf.Proto3.EnumFieldRepeated3;
 import com.code_intelligence.jazzer.protobuf.Proto3.EnumFieldRepeated3.TestEnumRepeated;
+import com.code_intelligence.jazzer.protobuf.Proto3.EnumMapField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.FloatField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.IntegralField3;
 import com.code_intelligence.jazzer.protobuf.Proto3.MapField3;
@@ -1011,6 +1012,12 @@ public class StressTest {
             distinctElementsRatio(0.45),
             distinctElementsRatio(0.45)),
         arguments(
+            new TypeHolder<@NotNull EnumMapField3>() {}.annotatedType(),
+            "{Builder.Map<String, {Builder.Enum<TestEnum>} -> Message>} -> Message",
+            false,
+            distinctElementsRatio(0.45),
+            distinctElementsRatio(0.45)),
+        arguments(
             new TypeHolder<@NotNull DoubleField3>() {}.annotatedType(),
             "{Builder.Double} -> Message",
             true,
@@ -1050,7 +1057,8 @@ public class StressTest {
                 + " Builder via List<Integer>, Builder via List<Integer>, Builder via List<Long>,"
                 + " Builder via List<Long>, Builder via List<Float>, Builder via List<Double>,"
                 + " Builder via List<String>, Builder via List<Enum<Enum>>, WithoutInit(Builder via"
-                + " List<(cycle) -> Message>), Builder.Map<Integer, Integer>,"
+                + " List<(cycle) -> Message>), Builder.Map<Integer, Integer>, Builder.Map<Integer,"
+                + " Enum<Enum>>, WithoutInit(Builder.Map<Integer, (cycle) -> Message>),"
                 + " Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<{<empty>} ->"
                 + " Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> |"
                 + " Builder.Nullable<Integer>} -> Message>)} -> Message>), Builder via"
@@ -1058,9 +1066,10 @@ public class StressTest {
                 + " via List<Long>, Builder via List<Long>, Builder via List<Float>, Builder via"
                 + " List<Double>, Builder via List<String>, Builder via List<Enum<Enum>>,"
                 + " WithoutInit(Builder via List<(cycle) -> Message>), Builder.Map<Integer,"
-                + " Integer>, Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<(cycle) ->"
-                + " Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> |"
-                + " Builder.Nullable<Integer>} -> Message",
+                + " Integer>, Builder.Map<Integer, Enum<Enum>>, WithoutInit(Builder.Map<Integer,"
+                + " (cycle) -> Message>), Builder.Nullable<FixedValue(OnlyLabel)>,"
+                + " Builder.Nullable<(cycle) -> Message>, Builder.Nullable<Integer> |"
+                + " Builder.Nullable<Long> | Builder.Nullable<Integer>} -> Message",
             false,
             manyDistinctElements(),
             manyDistinctElements()),
@@ -1083,7 +1092,8 @@ public class StressTest {
                 + " Builder via List<Integer>, Builder via List<Integer>, Builder via List<Long>,"
                 + " Builder via List<Long>, Builder via List<Float>, Builder via List<Double>,"
                 + " Builder via List<String>, Builder via List<Enum<Enum>>, WithoutInit(Builder via"
-                + " List<(cycle) -> Message>), Builder.Map<Integer, Integer>,"
+                + " List<(cycle) -> Message>), Builder.Map<Integer, Integer>, Builder.Map<Integer,"
+                + " Enum<Enum>>, WithoutInit(Builder.Map<Integer, (cycle) -> Message>),"
                 + " Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<{<empty>} ->"
                 + " Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> |"
                 + " Builder.Nullable<Integer>} -> Message>)} -> Message>), Builder via"
@@ -1091,9 +1101,10 @@ public class StressTest {
                 + " via List<Long>, Builder via List<Long>, Builder via List<Float>, Builder via"
                 + " List<Double>, Builder via List<String>, Builder via List<Enum<Enum>>,"
                 + " WithoutInit(Builder via List<(cycle) -> Message>), Builder.Map<Integer,"
-                + " Integer>, Builder.Nullable<FixedValue(OnlyLabel)>, Builder.Nullable<(cycle) ->"
-                + " Message>, Builder.Nullable<Integer> | Builder.Nullable<Long> |"
-                + " Builder.Nullable<Integer>} -> Message",
+                + " Integer>, Builder.Map<Integer, Enum<Enum>>, WithoutInit(Builder.Map<Integer,"
+                + " (cycle) -> Message>), Builder.Nullable<FixedValue(OnlyLabel)>,"
+                + " Builder.Nullable<(cycle) -> Message>, Builder.Nullable<Integer> |"
+                + " Builder.Nullable<Long> | Builder.Nullable<Integer>} -> Message",
             false,
             manyDistinctElements(),
             manyDistinctElements()),

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto2.proto
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto2.proto
@@ -132,6 +132,8 @@ message TestProtobuf {
   }
 
   map<int32, int32> map_field = 25;
+  map<int32, Enum> enum_map = 26;
+  map<int32, TestSubProtobuf> message_map = 27;
 
   // Special cases
   enum EnumOneLabel {

--- a/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/mutator/proto/proto3.proto
@@ -117,6 +117,10 @@ message MessageMapField3 {
   map<string, MapField3> some_field = 1;
 }
 
+message EnumMapField3 {
+  map<string, EnumField3> some_field = 1;
+}
+
 message FloatField3 {
   float some_field = 1;
 }

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -616,6 +616,7 @@ java_fuzz_target_test(
 
 java_fuzz_target_test(
     name = "MutatorComplexProtoFuzzer",
+    timeout = "long",
     srcs = ["src/test/java/com/example/MutatorComplexProtoFuzzer.java"],
     allowed_findings = ["com.code_intelligence.jazzer.api.FuzzerSecurityIssueMedium"],
     fuzzer_args = [
@@ -624,7 +625,7 @@ java_fuzz_target_test(
         # Limit runs to catch regressions in mutator efficiency and speed up test runs.
         # Especially on Windows this test needs way more iterations than on other platforms.
         "-runs=3000000",
-        "-seed=123",
+        "-seed=1",
     ],
     target_class = "com.example.MutatorComplexProtoFuzzer",
     verify_crash_reproducer = False,


### PR DESCRIPTION
Adds mutator support for protobuf maps where the map value is a protobuf enum.

```
message TestProtobuf {
  enum Enum {
    Label1 = 0;
    Label2 = 1;
    Label3 = 2;
    Label4 = 3;
    Label5 = 4;
  }

  map<int32, Enum> map_field = 1;
}
```