### PR TITLE
fix: handle null values in Arrays.equal/compare hooks

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
+++ b/src/main/java/com/code_intelligence/jazzer/runtime/TraceCmpHooks.java
@@ -744,6 +744,7 @@ public final class TraceCmpHooks {
     if (returnValue) return;
     byte[] first = (byte[]) arguments[0];
     byte[] second = (byte[]) arguments[1];
+    if (first == null || second == null) return;
     TraceDataFlowNativeCallbacks.traceMemcmp(first, second, 1, hookId);
   }
 
@@ -777,6 +778,7 @@ public final class TraceCmpHooks {
     if (returnValue == 0) return;
     byte[] first = (byte[]) arguments[0];
     byte[] second = (byte[]) arguments[1];
+    if (first == null || second == null) return;
     TraceDataFlowNativeCallbacks.traceMemcmp(first, second, returnValue, hookId);
   }
 

--- a/src/test/java/com/code_intelligence/jazzer/runtime/TraceCmpHooksTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/runtime/TraceCmpHooksTest.java
@@ -52,4 +52,13 @@ public class TraceCmpHooksTest {
     // noinspection ResultOfMethodCallIgnored
     ES.awaitTermination(5, TimeUnit.SECONDS);
   }
+
+  @Test
+  public void handlesNullValuesInArrayCompare() {
+    byte[] b1 = new byte[10];
+    byte[] b2 = null;
+    // Make sure we don't crash the JVM on null arrays.
+    TraceCmpHooks.arraysEquals(null, null, new Object[] {b1, b2}, 1, false);
+    TraceCmpHooks.arraysCompare(null, null, new Object[] {b1, b2}, 1, 1);
+  }
 }


### PR DESCRIPTION
`null` arrays would crash in the `Arrays.equal` and `Arrays.compare` hooks.
