### PR TITLE
fix: support lists of arbitrary types

### DIFF
--- a/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ArgumentsMutatorFuzzTest.java
+++ b/selffuzz/src/test/java/com/code_intelligence/selffuzz/mutation/ArgumentsMutatorFuzzTest.java
@@ -16,6 +16,7 @@
 
 package com.code_intelligence.selffuzz.mutation;
 
+import static com.code_intelligence.selffuzz.jazzer.mutation.utils.PropertyConstraint.RECURSIVE;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.code_intelligence.jazzer.api.FuzzedDataProvider;
@@ -23,6 +24,7 @@ import com.code_intelligence.jazzer.junit.FuzzTest;
 import com.code_intelligence.jazzer.protobuf.Proto2;
 import com.code_intelligence.jazzer.protobuf.Proto3;
 import com.code_intelligence.selffuzz.jazzer.mutation.ArgumentsMutator;
+import com.code_intelligence.selffuzz.jazzer.mutation.annotation.InRange;
 import com.code_intelligence.selffuzz.jazzer.mutation.annotation.NotNull;
 import com.code_intelligence.selffuzz.jazzer.mutation.annotation.WithLength;
 import com.code_intelligence.selffuzz.jazzer.mutation.annotation.WithSize;
@@ -289,6 +291,25 @@ public class ArgumentsMutatorFuzzTest {
               arrayOfArraysOfListOfIntegers) {
     assertThat(arrayOfListOfStrings.length).isAtMost(4);
     assertThat(arrayOfArraysOfListOfIntegers.length).isAtMost(2);
+  }
+
+  @SelfFuzzTest
+  public static void fuzzListOfGenericArrays(
+      @NotNull(constraint = RECURSIVE)
+          @WithSize(min = 1, max = 1, constraint = RECURSIVE)
+          @WithLength(min = 1, max = 1, constraint = RECURSIVE)
+          @InRange(min = 2, max = 3, constraint = RECURSIVE)
+          List<List<Integer>[]> lofGenericArrays) {
+    // Make sure all annotations are respected.
+    assertThat(lofGenericArrays.size()).isEqualTo(1);
+    for (List<Integer>[] array : lofGenericArrays) {
+      assertThat(array.length).isEqualTo(1);
+      for (List<Integer> list : array) {
+        assertThat(list.size()).isEqualTo(1);
+        assertThat(list.get(0)).isAtLeast(2);
+        assertThat(list.get(0)).isAtMost(3);
+      }
+    }
   }
 
   /**

--- a/src/main/java/com/code_intelligence/jazzer/mutation/support/TypeSupport.java
+++ b/src/main/java/com/code_intelligence/jazzer/mutation/support/TypeSupport.java
@@ -488,13 +488,7 @@ public final class TypeSupport {
               if (typeArguments.size() != 1) {
                 return Optional.empty();
               } else {
-                AnnotatedType elementType = typeArguments.get(0);
-                if (!(elementType.getType() instanceof ParameterizedType)
-                    && !(elementType.getType() instanceof Class)) {
-                  return Optional.empty();
-                } else {
-                  return Optional.of(elementType);
-                }
+                return Optional.of(typeArguments.get(0));
               }
             });
   }

--- a/src/test/java/com/code_intelligence/jazzer/mutation/support/TypeSupportTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/mutation/support/TypeSupportTest.java
@@ -47,11 +47,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.ParameterizedType;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.BiPredicate;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -553,5 +555,18 @@ class TypeSupportTest {
   void testForwardAnnotations_withExcludes(
       AnnotatedType src, AnnotatedType target, Annotation[] excludes, AnnotatedType expected) {
     assertThat(forwardAnnotations(src, target, excludes)).isEqualTo(expected);
+  }
+
+  @Test
+  void testParameterTypeIfParameterizedList() {
+    AnnotatedType type = new TypeHolder<List<List<Integer>[]>>() {}.annotatedType();
+    Optional<AnnotatedType> parameterType =
+        TypeSupport.parameterTypeIfParameterized(type, List.class);
+    if (!parameterType.isPresent()
+        || !(parameterType.get().getType() instanceof GenericArrayType)) {
+      throw new AssertionError("Expected to find a GenericArrayType as parameter type.");
+    }
+    AnnotatedType expectedParameterType = new TypeHolder<List<Integer>[]>() {}.annotatedType();
+    assertThat(annotatedTypeEquals(parameterType.get(), expectedParameterType)).isTrue();
   }
 }


### PR DESCRIPTION
Previously, types like `List<List<Integer>[]>` failed because the
`parameterTypeIfParameterized` helper function incorrectly filtered out
generic array types. Removed this filtering since the mutation
framework already handles supported type matching.