### PR TITLE
Add a Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM silkeh/clang:21

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+    "name": "Jazzer Dev Container",
+    "dockerFile": "Dockerfile",
+    "features": {
+      "ghcr.io/devcontainers/features/git:1": {
+      },
+      "ghcr.io/devcontainers-community/features/bazel:1": {
+        "bazelisk_version": "v1.17.0",
+        "buildifier_version": "v6.1.2"
+      }
+    },
+    "customizations": {
+      "vscode": {
+        // Set *default* container specific settings.json values on container create.
+        "settings": {
+          "terminal.integrated.shell.linux": "/bin/bash",
+        },
+        // Add the IDs of extensions you want installed when the container is created.
+        "extensions": [
+          // Java
+          "redhat-java",
+          // Bazel
+          "bazelbuild.vscode-bazel",
+          // Documentation
+          "zhang.markdown-all-in-one",
+          "redhat.vscode-yaml",
+          "shardulm94.trailing-spaces",
+        ],
+      },
+    },
+}


### PR DESCRIPTION
Creating this pull request rather for a discussion. The attached basic image works, but it has limited value as Bazel will reinstall the C++ stack and Java anyway, and the first build is very slow,

Would there be, in principle, an interest in a Dev Container for this repo? If so, I will get it finished

## Before merge

- [x] Basic image
- [ ] Ensure tools are pre-installed and cached in the Dev Container image
- [ ] Enable in-repository build caching by default
- [ ] Add Dev Container to the documentation

