### PR TITLE
fix: keep autofuzz from stalling in BigInteger(int, int, Random)

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/autofuzz/AccessibleObjectLookup.java
+++ b/src/main/java/com/code_intelligence/jazzer/autofuzz/AccessibleObjectLookup.java
@@ -21,11 +21,19 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 class AccessibleObjectLookup {
+  // Constructors that autofuzz should never invoke, e.g. because they can take practically forever
+  // to compute a value (https://github.com/CodeIntelligenceTesting/jazzer/issues/1055).
+  private static final Set<Constructor<?>> DENYLISTED_CONSTRUCTORS = denylistedConstructors();
+
   private static final Comparator<Class<?>> STABLE_CLASS_COMPARATOR =
       Comparator.comparing(Class::getName);
   private static final Comparator<Executable> STABLE_EXECUTABLE_COMPARATOR =
@@ -62,6 +70,7 @@ class AccessibleObjectLookup {
             Arrays.stream(type.getDeclaredConstructors()), Arrays.stream(type.getConstructors()))
         .distinct()
         .filter(this::isAccessible)
+        .filter(constructor -> !DENYLISTED_CONSTRUCTORS.contains(constructor))
         .sorted(STABLE_EXECUTABLE_COMPARATOR)
         .filter(
             constructor -> {
@@ -75,6 +84,18 @@ class AccessibleObjectLookup {
               }
             })
         .toArray(Constructor<?>[]::new);
+  }
+
+  private static Set<Constructor<?>> denylistedConstructors() {
+    try {
+      return Stream.of(
+              // Searches for a random prime with up to Integer.MAX_VALUE bits, which can stall the
+              // fuzzer indefinitely.
+              BigInteger.class.getConstructor(int.class, int.class, Random.class))
+          .collect(Collectors.toSet());
+    } catch (NoSuchMethodException e) {
+      throw new AutofuzzError("Failed to look up denylisted constructor", e);
+    }
   }
 
   Method[] getAccessibleMethods(Class<?> type) {

--- a/src/test/java/com/code_intelligence/jazzer/autofuzz/AccessibleObjectLookupTest.java
+++ b/src/test/java/com/code_intelligence/jazzer/autofuzz/AccessibleObjectLookupTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Code Intelligence GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.code_intelligence.jazzer.autofuzz;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Constructor;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Random;
+import org.junit.Test;
+
+public class AccessibleObjectLookupTest {
+  @Test
+  public void testGetAccessibleConstructors_skipsDenylistedConstructors() {
+    AccessibleObjectLookup lookup = new AccessibleObjectLookup(null);
+    Constructor<?>[] constructors = lookup.getAccessibleConstructors(BigInteger.class);
+    // BigInteger(int, int, Random) searches for a random prime, which can stall the fuzzer
+    // (https://github.com/CodeIntelligenceTesting/jazzer/issues/1055).
+    assertFalse(
+        Arrays.stream(constructors)
+            .anyMatch(
+                constructor ->
+                    Arrays.equals(
+                        constructor.getParameterTypes(),
+                        new Class<?>[] {int.class, int.class, Random.class})));
+    // Other constructors are still available.
+    assertTrue(
+        Arrays.stream(constructors)
+            .anyMatch(
+                constructor ->
+                    Arrays.equals(constructor.getParameterTypes(), new Class<?>[] {String.class})));
+  }
+}

--- a/src/test/java/com/code_intelligence/jazzer/autofuzz/BUILD.bazel
+++ b/src/test/java/com/code_intelligence/jazzer/autofuzz/BUILD.bazel
@@ -1,6 +1,19 @@
 package(default_testonly = True)
 
 java_test(
+    name = "AccessibleObjectLookupTest",
+    size = "small",
+    srcs = [
+        "AccessibleObjectLookupTest.java",
+    ],
+    test_class = "com.code_intelligence.jazzer.autofuzz.AccessibleObjectLookupTest",
+    deps = [
+        "//src/main/java/com/code_intelligence/jazzer/autofuzz",
+        "@maven//:junit_junit",
+    ],
+)
+
+java_test(
     name = "MetaTest",
     size = "small",
     srcs = [


### PR DESCRIPTION
Fixes #1055

In autofuzz mode, constructor discovery can pick `BigInteger(int, int, Random)`, which searches for a random prime with the given bit length and can take practically forever for large arguments, stalling the fuzzer.

This adds a denylist of constructors that are never considered during constructor discovery in `AccessibleObjectLookup` and puts `BigInteger(int, int, Random)` on it, as suggested in the issue. The denylist is a simple static set for now, so further problematic constructors can easily be added; making it user-configurable could be a follow-up if needed.

Includes a unit test verifying that the denylisted constructor is filtered out while other `BigInteger` constructors remain available.