### PR TITLE
Fix wrong command line usage help

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/driver/OptParser.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/OptParser.java
@@ -42,11 +42,11 @@ final class OptParser {
         String.format(
             "  java -cp jazzer.jar[%cclasspath_entries] com.code_intelligence.jazzer.Jazzer"
                 + " --target_class=<target class> [args...]",
-            File.separatorChar),
+            File.pathSeparatorChar),
         String.format(
             "  java -cp jazzer.jar[%cclasspath_entries] com.code_intelligence.jazzer.Jazzer"
                 + " --autofuzz=<method reference> [args...]",
-            File.separatorChar),
+            File.pathSeparatorChar),
         "",
         "In addition to the options listed below, Jazzer also accepts all",
         "libFuzzer options described at:",


### PR DESCRIPTION
`-cp` takes paths separated by the 'path separator' (':' or ';'), but `File.separatorChar` is '/' respectively '\\'.

For example, for me on Windows running `java -jar ./jazzer_standalone.jar --help` currently erroneously shows:
```
Usage:

  java -cp jazzer.jar[\classpath_entries] com.code_intelligence.jazzer.Jazzer --target_class=<target class> [args...]

  java -cp jazzer.jar[\classpath_entries] com.code_intelligence.jazzer.Jazzer --autofuzz=<method reference> [args...]
```

(note the `-cp jazzer.jar[\classpath_entries]`)